### PR TITLE
Localize the image search by keywords for admin

### DIFF
--- a/AdobeStockAsset/Model/Client.php
+++ b/AdobeStockAsset/Model/Client.php
@@ -11,7 +11,6 @@ use AdobeStock\Api\Models\SearchParameters;
 use AdobeStock\Api\Request\SearchFiles as SearchFilesRequest;
 use Magento\AdobeStockAssetApi\Api\ClientInterface;
 use Magento\AdobeStockAssetApi\Api\Data\ConfigInterface;
-use Magento\Framework\Locale\ResolverInterface;
 
 /**
  * DataProvider for cms ui.
@@ -24,20 +23,12 @@ class Client implements ClientInterface
     private $config;
 
     /**
-     * @var ResolverInterface
-     */
-    private $localeResolver;
-
-    /**
      * Client constructor.
      * @param ConfigInterface $config
      */
-    public function __construct(
-        ConfigInterface $config,
-        ResolverInterface $localeResolver
-    ) {
+    public function __construct(ConfigInterface $config)
+    {
         $this->config = $config;
-        $this->localeResolver = $localeResolver;
     }
 
     /**
@@ -54,6 +45,7 @@ class Client implements ClientInterface
         $searchParams->setWords($words);
         $searchParams->setLimit($request->getData('size'));
         $searchParams->setOffset($request->getData('offset'));
+        $locale = $request->getData('locale');
 
         $resultsColumns = Constants::getResultColumns();
         $resultColumnArray = [];
@@ -63,7 +55,7 @@ class Client implements ClientInterface
 
         $request = new SearchFilesRequest();
 
-        $request->setLocale($this->locale());
+        $request->setLocale($locale);
         $request->setSearchParams($searchParams);
         $request->setResultColumns($resultColumnArray);
 
@@ -99,10 +91,5 @@ class Client implements ClientInterface
             $this->config->getProductName(),
             $this->config->getTargetEnvironment()
         );
-    }
-
-    private function locale(): string
-    {
-        return $this->localeResolver->getLocale();
     }
 }

--- a/AdobeStockAsset/Model/Client.php
+++ b/AdobeStockAsset/Model/Client.php
@@ -11,6 +11,7 @@ use AdobeStock\Api\Models\SearchParameters;
 use AdobeStock\Api\Request\SearchFiles as SearchFilesRequest;
 use Magento\AdobeStockAssetApi\Api\ClientInterface;
 use Magento\AdobeStockAssetApi\Api\Data\ConfigInterface;
+use Magento\Framework\Locale\ResolverInterface;
 
 /**
  * DataProvider for cms ui.
@@ -23,12 +24,20 @@ class Client implements ClientInterface
     private $config;
 
     /**
+     * @var ResolverInterface
+     */
+    private $localeResolver;
+
+    /**
      * Client constructor.
      * @param ConfigInterface $config
      */
-    public function __construct(ConfigInterface $config)
-    {
+    public function __construct(
+        ConfigInterface $config,
+        ResolverInterface $localeResolver
+    ) {
         $this->config = $config;
+        $this->localeResolver = $localeResolver;
     }
 
     /**
@@ -54,8 +63,7 @@ class Client implements ClientInterface
 
         $request = new SearchFilesRequest();
 
-        // TODO: Use backend locale for requests
-        $request->setLocale('En_US');
+        $request->setLocale($this->locale());
         $request->setSearchParams($searchParams);
         $request->setResultColumns($resultColumnArray);
 
@@ -91,5 +99,10 @@ class Client implements ClientInterface
             $this->config->getProductName(),
             $this->config->getTargetEnvironment()
         );
+    }
+
+    private function locale(): string
+    {
+        return $this->localeResolver->getLocale();
     }
 }

--- a/AdobeStockAsset/Model/Request/Builder.php
+++ b/AdobeStockAsset/Model/Request/Builder.php
@@ -90,6 +90,14 @@ class Builder implements RequestBuilderInterface
     /**
      * @inheritdoc
      */
+    public function setLocale(string $locale): void
+    {
+        $this->data['locale'] = $locale;
+    }
+
+    /**
+     * @inheritdoc
+     */
     public function bind(string $name, $value): void
     {
         $this->data['placeholder'][$name] = $value;

--- a/AdobeStockAsset/Model/Request/Builder/Binder.php
+++ b/AdobeStockAsset/Model/Request/Builder/Binder.php
@@ -20,6 +20,7 @@ class Binder
             'offset' => (int) $requestData['offset'] ?? (int) $requestConfig['from'],
             'filters' => $this->buildFilters($requestData['placeholder'] ?? [] , $requestConfig['filters']),
             'resultColumns' => $requestData['resultColumns'] ?? $requestConfig['resultColumns'],
+            'locale' => (string) $requestData['locale'] ?? (string) $requestConfig['locale'],
         ];
     }
 

--- a/AdobeStockAssetApi/Api/RequestBuilderInterface.php
+++ b/AdobeStockAssetApi/Api/RequestBuilderInterface.php
@@ -45,6 +45,14 @@ interface RequestBuilderInterface
     public function setSort(array $sort) : void;
 
     /**
+     * Set locale
+     *
+     * @param string $locale
+     * @return void
+     */
+    public function setLocale(string $locale) : void;
+
+    /**
      * Bind value to placeholder
      *
      * @param string $name

--- a/AdobeStockImage/Model/GetImageList.php
+++ b/AdobeStockImage/Model/GetImageList.php
@@ -12,6 +12,7 @@ use Magento\AdobeStockImageApi\Api\Data\ImageInterfaceFactory;
 use Magento\Ui\DataProvider\SearchResultFactory;
 use Magento\AdobeStockAssetApi\Api\ClientInterface;
 use Magento\AdobeStockAssetApi\Api\RequestBuilderInterface;
+use Magento\Framework\Locale\ResolverInterface;
 
 /**
  * Class GetImageList
@@ -39,6 +40,11 @@ class GetImageList implements GetImageListInterface
     private $requestBuilder;
 
     /**
+     * @var ResolverInterface
+     */
+    private $localeResolver;
+
+    /**
      * GetImageList constructor.
      * @param ClientInterface $client
      * @param ImageInterfaceFactory $imageFactory
@@ -49,12 +55,14 @@ class GetImageList implements GetImageListInterface
         ClientInterface $client,
         ImageInterfaceFactory $imageFactory,
         SearchResultFactory $searchResultFactory,
-        RequestBuilderInterface $requestBuilder
+        RequestBuilderInterface $requestBuilder,
+        ResolverInterface $localeResolver
     ) {
         $this->imageFactory = $imageFactory;
         $this->searchResultFactory = $searchResultFactory;
         $this->client = $client;
         $this->requestBuilder = $requestBuilder;
+        $this->localeResolver = $localeResolver;
     }
 
     /**
@@ -66,6 +74,7 @@ class GetImageList implements GetImageListInterface
         $this->requestBuilder->setName('adobe_stock_image_search');
         $this->requestBuilder->setSize($searchCriteria->getPageSize());
         $this->requestBuilder->setOffset($searchCriteria->getCurrentPage());
+        $this->requestBuilder->setLocale($this->localeResolver->getLocale());
         $this->applyFilters($searchCriteria);
         $request = $this->requestBuilder->create();
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Add Magento admin locale to search API requests so admin user can see localized results.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/adobe-stock-integration#7 Admin user can search images by keywords

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Change locale configuration for 'Default config': Stores > Configuration > General > Locale options > Locale
2. Search stock images by keywords in admin (UI Component)