### PR TITLE
#11 Add additional foreign key constraints

### DIFF
--- a/AdobeStockAsset/etc/db_schema.xml
+++ b/AdobeStockAsset/etc/db_schema.xml
@@ -75,7 +75,7 @@
             <column name="id"/>
         </constraint>
         <constraint xsi:type="foreign" referenceId="ADO_STO_ASS_MED_TYP_ID" table="adobe_stock_asset" column="media_type_id" referenceTable="adobe_stock_media_type" referenceColumn="id" onDelete="SET NULL"/>
-        <constraint xsi:type="foreign" referenceId="ADO_STO_ASS_CAT_ID" table="adobe_stock_asset" column="category_id" referenceTable="adobe_stock_category" referenceColumn="id"  onDelete="SET NULL"/>
+        <constraint xsi:type="foreign" referenceId="ADO_STO_ASS_CAT_ID" table="adobe_stock_asset" column="category_id" referenceTable="adobe_stock_category" referenceColumn="id" onDelete="SET NULL"/>
         <constraint xsi:type="foreign" referenceId="ADO_STO_ASS_CRE_ID" table="adobe_stock_asset" column="creator_id" referenceTable="adobe_stock_creator" referenceColumn="id" onDelete="SET NULL"/>
         <constraint xsi:type="foreign" referenceId="ADO_STO_ASS_PRE_LEV_ID" table="adobe_stock_asset" column="premium_level_id" referenceTable="adobe_stock_premium_level" referenceColumn="id" onDelete="SET NULL"/>
     </table>
@@ -94,6 +94,8 @@
             <column name="keyword_id"/>
             <column name="asset_id"/>
         </constraint>
+        <constraint xsi:type="foreign" referenceId="ADO_STO_ASS_KEY_ID" table="adobe_stock_asset_keyword" column="keyword_id" referenceTable="adobe_stock_keyword" referenceColumn="asset_id" onDelete="CASCADE"/>
+        <constraint xsi:type="foreign" referenceId="ADO_STO_ASS_ASS_ID" table="adobe_stock_asset_keyword" column="asset_id" referenceTable="adobe_stock_asset" referenceColumn="id" onDelete="CASCADE"/>
     </table>
     <table name="adobe_stock_keyword" resource="default" engine="innodb" comment="Adobe Stock Keyword">
         <column xsi:type="int" name="asset_id" padding="10" unsigned="true" nullable="false" identity="true" comment="Stock ID"/>

--- a/AdobeStockAsset/etc/db_schema_whitelist.json
+++ b/AdobeStockAsset/etc/db_schema_whitelist.json
@@ -97,7 +97,9 @@
             "asset_id": true
         },
         "constraint": {
-            "PRIMARY": true
+            "PRIMARY": true,
+            "ADO_STO_ASS_KEY_ID": true,
+            "ADOBE_STOCK_ASSET_KEYWORD_ASSET_ID_ADOBE_STOCK_ASSET_ID": true
         }
     },
     "adobe_stock_keyword": {


### PR DESCRIPTION
#11 
Hi @sivaschenko here are the two additional foreign keys constraints missing in the [previous PR](https://github.com/magento/adobe-stock-integration/pull/50)

Please let me know if everything is ok

BTW: I just noticed there is another `db_schema.xml` file creating these tables
https://github.com/magento/adobe-stock-integration/blob/develop/AdobeStockImage/etc/db_schema.xml
Which one is going to be used?