### PR TITLE
magento/adobe-stock-integration#5: Introduce pagination for image lis…

### DIFF
--- a/AdobeStockAsset/Model/Client.php
+++ b/AdobeStockAsset/Model/Client.php
@@ -62,7 +62,7 @@ class Client implements ClientInterface
     {
         $searchParams = new SearchParameters();
         $searchParams->setLimit($request->getSize());
-        $searchParams->setOffset($request->getOffset());
+        $searchParams->setOffset($request->getOffset() * $request->getSize());
         $this->setUpFilters($request->getFilters(), $searchParams);
 
         $resultsColumns = Constants::getResultColumns();

--- a/AdobeStockImageAdminUi/view/adminhtml/ui_component/adobe_stock_images_listing.xml
+++ b/AdobeStockImageAdminUi/view/adminhtml/ui_component/adobe_stock_images_listing.xml
@@ -36,7 +36,13 @@
             <sticky>true</sticky>
         </settings>
         <filterSearch name="words"/>
-        <paging name="listing_paging"/>
+        <paging name="listing_paging">
+            <settings>
+                <sizesConfig>
+                    <component>Magento_AdobeStockImageAdminUi/js/components/images-grid-sizes</component>
+                </sizesConfig>
+            </settings>
+        </paging>
     </listingToolbar>
     <columns name="adobe_stock_images_columns" template="Magento_AdobeStockImageAdminUi/grid/listing">
         <column name="url" class="Magento\AdobeStockImageAdminUi\Ui\Component\Listing\Columns\Image" component="Magento_Ui/js/grid/columns/thumbnail">

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/images-grid-sizes.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/images-grid-sizes.js
@@ -1,0 +1,39 @@
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+define([
+    'Magento_Ui/js/grid/paging/sizes'
+], function (Sizes) {
+    'use strict';
+
+    return Sizes.extend({
+        defaults: {
+            value: 32,
+            minSize: 1,
+            maxSize: 64
+        },
+
+        sizes: {
+            '32': {
+                value: 32,
+                label: 32
+            },
+            '64': {
+                value: 64,
+                label: 64
+            }
+        },
+
+        /**
+         * @override
+         */
+        initialize: function () {
+            this._super();
+            this.options = this.sizes;
+            this.updateArray();
+
+            return this;
+        }
+    });
+});


### PR DESCRIPTION
…ting UI component

<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/adobe-stock-integration#5: Introduce pagination for image listing

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Navigate to Adobe Stock images tab. 
2. User is able to choose the number of images listed per page
3. User has an ability to navigate to different pages 