### PR TITLE
Implement "price" search filter

### DIFF
--- a/AdobeStockImage/etc/adobe_stock_requests.xml
+++ b/AdobeStockImage/etc/adobe_stock_requests.xml
@@ -15,7 +15,7 @@
             <filter name="isolated_filter" field="isolated"/>
             <filter name="orientation_filter" field="orientation"/>
             <filter name="colors_filter" field="colors"/>
-            <filter name="premium_filter" field="premium"/>
+            <filter name="premium_price_filter" field="premium"/>
         </filters>
         <resultColumns>
             <column name="nb_results" field="NB_RESULTS"/>

--- a/AdobeStockImageAdminUi/Ui/Component/Listing/Columns/PremiumPrice/Options.php
+++ b/AdobeStockImageAdminUi/Ui/Component/Listing/Columns/PremiumPrice/Options.php
@@ -19,15 +19,15 @@ class Options implements \Magento\Framework\Data\OptionSourceInterface
     {
         return [
             [
-                'label' => 'All',
+                'label' => __('All'),
                 'value' => 'ALL'
             ],
             [
-                'label' => 'Standard',
+                'label' => __('Standard'),
                 'value' => 'FALSE'
             ],
             [
-                'label' => 'Premium',
+                'label' => __('Premium'),
                 'value' => 'TRUE'
             ]
         ];

--- a/AdobeStockImageAdminUi/Ui/Component/Listing/Columns/PremiumPrice/Options.php
+++ b/AdobeStockImageAdminUi/Ui/Component/Listing/Columns/PremiumPrice/Options.php
@@ -3,7 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-namespace Magento\AdobeStockImageAdminUi\Ui\Component\Listing\Columns\Price;
+namespace Magento\AdobeStockImageAdminUi\Ui\Component\Listing\Columns\PremiumPrice;
 
 /**
  * Pricing filter options provider

--- a/AdobeStockImageAdminUi/Ui/Component/Listing/Columns/Price/Options.php
+++ b/AdobeStockImageAdminUi/Ui/Component/Listing/Columns/Price/Options.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\AdobeStockImageAdminUi\Ui\Component\Listing\Columns\Price;
+
+/**
+ * Pricing filter options provider
+ */
+class Options implements \Magento\Framework\Data\OptionSourceInterface
+{
+    /**
+     * Get options
+     *
+     * @return array
+     */
+    public function toOptionArray()
+    {
+        return [
+            [
+                'label' => 'All',
+                'value' => 'ALL'
+            ],
+            [
+                'label' => 'Standard',
+                'value' => 'FALSE'
+            ],
+            [
+                'label' => 'Premium',
+                'value' => 'TRUE'
+            ]
+        ];
+    }
+}

--- a/AdobeStockImageAdminUi/view/adminhtml/ui_component/adobe_stock_images_listing.xml
+++ b/AdobeStockImageAdminUi/view/adminhtml/ui_component/adobe_stock_images_listing.xml
@@ -53,11 +53,11 @@
                     <dataScope>orientation_filter</dataScope>
                 </settings>
             </filterSelect>
-            <filterSelect name="premium_filter" provider="${ $.parentName }">
+            <filterSelect name="premium_price_filter" provider="${ $.parentName }">
                 <settings>
-                    <options class="Magento\AdobeStockImageAdminUi\Ui\Component\Listing\Columns\Price\Options"/>
+                    <options class="Magento\AdobeStockImageAdminUi\Ui\Component\Listing\Columns\PremiumPrice\Options"/>
                     <label translate="true">Price</label>
-                    <dataScope>premium_filter</dataScope>
+                    <dataScope>premium_price_filter</dataScope>
                 </settings>
             </filterSelect>
         </filters>

--- a/AdobeStockImageAdminUi/view/adminhtml/ui_component/adobe_stock_images_listing.xml
+++ b/AdobeStockImageAdminUi/view/adminhtml/ui_component/adobe_stock_images_listing.xml
@@ -53,6 +53,13 @@
                     <dataScope>orientation_filter</dataScope>
                 </settings>
             </filterSelect>
+            <filterSelect name="premium_filter" provider="${ $.parentName }">
+                <settings>
+                    <options class="Magento\AdobeStockImageAdminUi\Ui\Component\Listing\Columns\Price\Options"/>
+                    <label translate="true">Price</label>
+                    <dataScope>premium_filter</dataScope>
+                </settings>
+            </filterSelect>
         </filters>
     </listingToolbar>
     <columns name="adobe_stock_images_columns" template="Magento_AdobeStockImageAdminUi/grid/listing">

--- a/AdobeStockImageAdminUi/view/adminhtml/ui_component/adobe_stock_images_listing.xml
+++ b/AdobeStockImageAdminUi/view/adminhtml/ui_component/adobe_stock_images_listing.xml
@@ -55,6 +55,7 @@
             </filterSelect>
             <filterSelect name="premium_price_filter" provider="${ $.parentName }">
                 <settings>
+                    <caption translate="true">Select...</caption>
                     <options class="Magento\AdobeStockImageAdminUi\Ui\Component\Listing\Columns\PremiumPrice\Options"/>
                     <label translate="true">Price</label>
                     <dataScope>premium_price_filter</dataScope>


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
With these changes, a Merchant will be able to filter stock images by their premium level and narrow search result to images that better fit my needs

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/adobe-stock-integration#19: Implement search filter for the price attribute
2. magento/adobe-stock-integration#34: [Story #11] User filters images by price

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Search premium stock images selecting 'premium' price filter in the in admin (UI Component)