### PR TITLE
#101 : Change Api Key field type to password on the configuration page

### DIFF
--- a/AdobeStockAsset/etc/adminhtml/system.xml
+++ b/AdobeStockAsset/etc/adminhtml/system.xml
@@ -15,7 +15,7 @@
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <config_path>adobe_stock/integration/enabled</config_path>
                 </field>
-                <field id="api_key" translate="label" type="text" sortOrder="20" showInDefault="1" showInWebsite="0" showInStore="0">
+                <field id="api_key" translate="label" type="password" sortOrder="20" showInDefault="1" showInWebsite="0" showInStore="0">
                     <label>Api Key</label>
                     <comment><![CDATA[Configure an Adobe Stock account on the <a href="https://console.adobe.io/" target="_blank">Adobe.io</a> site to retrieve an API key.]]></comment>
                     <config_path>adobe_stock/integration/api_key</config_path>


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/adobe-stock-integration#101: Change Api Key field type to password on the configuration page

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Navigate to Configuration -> Advanced -> System -> Adobe Stock Integration
2. User not able to see the API key