### PR TITLE
#91 Option 48 is missing in the images count per page drop down

### DIFF
--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/images-grid-sizes.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/images-grid-sizes.js
@@ -19,6 +19,10 @@ define([
                 value: 32,
                 label: 32
             },
+            '48': {
+                value: 48,
+                label: 48
+            },
             '64': {
                 value: 64,
                 label: 64


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/adobe-stock-integration#91: Option 48 is missing in the images count per page drop down

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Navigate to Content > Elements > Pages
2. Click Add New Page button
3. Fill Title with "Test CMS Page"
4. Expand the "Content" section
5. Fill Content Heading with "Test Content Heading"
6. Click "Insert Image..." button
7. Click "Search Adobe Stock" button
8. You can choose option 48 in the "per page" dropdown