### PR TITLE
magento/adobe-stock-integration#102: implemented urlencode for filters

### DIFF
--- a/AdobeStockImage/Model/GetImageList.php
+++ b/AdobeStockImage/Model/GetImageList.php
@@ -87,7 +87,7 @@ class GetImageList implements GetImageListInterface
     {
         foreach ($searchCriteria->getFilterGroups() as $filterGroup) {
             foreach ($filterGroup->getFilters() as $filter) {
-                $this->requestBuilder->bind($filter->getField(), $filter->getValue());
+                $this->requestBuilder->bind($filter->getField(), urlencode($filter->getValue()));
             }
         }
     }


### PR DESCRIPTION
### Description (*)
Added "urlencode" method to filters

### Fixed Issues (if relevant)
1. magento/adobe-stock-integration#102: 400 (Bad Request) when search term is %0F

### Manual testing scenarios (*)
1. Navigate to Content > Elements > Pages
2. Click Add New Page button
3. Fill Title with "Test CMS Page"
4. Expand the "Content" section
5. Fill Content Heading with "Test Content Heading"
6. Click "Insert Image..." button
7. Click "Search Adobe Stock" button
8. Type %0F in the search input
9. Submit search