### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,37 @@
+---
+name: Bug report
+about: Technical issue with the Adobe Stock Integration core components
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+<!---
+Please review our guidelines before adding a new issue: https://github.com/magento/magento2/wiki/Issue-reporting-guidelines
+Fields marked with (*) are required. Please don't remove the template.
+-->
+
+### Preconditions (*)
+<!---
+Provide the exact Magento version (example: 2.2.5) and any important information on the environment where bug is reproducible.
+-->
+1.
+2.
+
+### Steps to reproduce (*)
+<!---
+Important: Provide a set of clear steps to reproduce this bug. We can not provide support without clear instructions on how to reproduce.
+-->
+1.
+2.
+
+### Expected result (*)
+<!--- Tell us what do you expect to happen. -->
+1. [Screenshots, logs or description]
+2.
+
+### Actual result (*)
+<!--- Tell us what happened instead. Include error messages and issues. -->
+1. [Screenshots, logs or description]
+2.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

Hi guys 👋 
Reviewing the repo I noticed we have some items missing in the [community profile](https://github.com/magento/adobe-stock-integration/community) comparing to the [recommended community standards.](https://opensource.guide/)

<img width="1041" alt="Screenshot 2019-06-22 at 11 21 22" src="https://user-images.githubusercontent.com/1080386/59962652-4bfd7e00-94e0-11e9-9915-3ce5a9f21b33.png">

Not sure how important or how many of this items are needed (if not all) but if it isn't we can just close these PR.