### PR TITLE
magento/adobe-stock-integration:#93 -  Specify correct ACL resources …

### DIFF
--- a/AdobeStockAsset/etc/adminhtml/system.xml
+++ b/AdobeStockAsset/etc/adminhtml/system.xml
@@ -7,7 +7,10 @@
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_file.xsd">
     <system>
-        <section id="system">
+        <section id="adobe_stock_integration" translate="label" type="text" sortOrder="1100" showInDefault="1" showInWebsite="1" showInStore="0">
+            <label>Adobe Stock Integration</label>
+            <tab>advanced</tab>
+            <resource>Magento_AdobeStockAsset::config</resource>
             <group id="adobe_stock_integration" translate="label" type="text" sortOrder="1100" showInDefault="1" showInWebsite="0" showInStore="0">
                 <label>Adobe Stock Integration</label>
                 <field id="enabled" translate="label" type="select" sortOrder="10" showInDefault="1" showInWebsite="0" showInStore="0">

--- a/AdobeStockImageAdminUi/Model/Block/Wysiwyg/Images/Content/Plugin/AddSearchButton.php
+++ b/AdobeStockImageAdminUi/Model/Block/Wysiwyg/Images/Content/Plugin/AddSearchButton.php
@@ -10,12 +10,20 @@ namespace Magento\AdobeStockImageAdminUi\Model\Block\Wysiwyg\Images\Content\Plug
 use Magento\AdobeStockAsset\Model\Config;
 use Magento\Backend\Block\Widget\Container;
 use Magento\Framework\View\LayoutInterface;
+use Magento\Framework\AuthorizationInterface;
 
 /**
  * Plugin for media gallery block adding button to the toolbar.
  */
 class AddSearchButton
 {
+    private const ACL_SAVE_PREVIEW_IMAGES = 'Magento_AdobeStockImageAdminUi::save_preview_images';
+
+    /**
+     * @var AuthorizationInterface
+     */
+    private $authorization;
+
     /**
      * @var Config
      */
@@ -24,23 +32,25 @@ class AddSearchButton
     /**
      * AddSearchButton constructor.
      * @param Config $config
+     * @param AuthorizationInterface $authorization
      */
-    public function __construct(Config $config)
+    public function __construct(Config $config, AuthorizationInterface $authorization)
     {
         $this->config = $config;
+        $this->authorization = $authorization;
     }
 
     /**
      * Add Adobe Stock Search button to the toolbar
      *
      * @param Container $subject
-     * @return null
+     * @param LayoutInterface $layout
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function beforeSetLayout(Container $subject, LayoutInterface $layout)
+    public function beforeSetLayout(Container $subject, LayoutInterface $layout): void
     {
-        if ($this->config->isEnabled()) {
+        if ($this->authorization->isAllowed(self::ACL_SAVE_PREVIEW_IMAGES) && $this->config->isEnabled()) {
             $subject->addButton(
                 'search_adobe_stock',
                 [

--- a/AdobeStockImageAdminUi/etc/acl.xml
+++ b/AdobeStockImageAdminUi/etc/acl.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Acl/etc/acl.xsd">
+    <acl>
+        <resources>
+            <resource id="Magento_Backend::admin">
+                <resource id="Magento_Backend::content">
+                    <resource id="Magento_Backend::content_elements">
+                        <resource id="Magento_Cms::media_gallery">
+                            <resource id="Magento_AdobeStockImageAdminUi::media_gallery" title="Adobe Stock" translate="title" sortOrder="70">
+                                <resource id="Magento_AdobeStockImageAdminUi::save_preview_images" title="Save Preview Image" translate="title" sortOrder="30" />
+                                <resource id="Magento_AdobeStockImageAdminUi::license_images" disabled="true" title="License images" translate="title" sortOrder="50" />
+                            </resource>
+                        </resource>
+                    </resource>
+                </resource>
+            </resource>
+        </resources>
+    </acl>
+</config>

--- a/AdobeStockImageAdminUi/view/adminhtml/layout/cms_wysiwyg_images_index.xml
+++ b/AdobeStockImageAdminUi/view/adminhtml/layout/cms_wysiwyg_images_index.xml
@@ -7,8 +7,8 @@
 -->
 <layout xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/layout_generic.xsd">
     <referenceContainer name="root">
-        <block class="Magento\Backend\Block\Template" template="Magento_AdobeStockImageAdminUi::panel.phtml" name="stock.panel">
-            <uiComponent name="adobe_stock_images_listing"/>
+        <block class="Magento\Backend\Block\Template" template="Magento_AdobeStockImageAdminUi::panel.phtml" name="stock.panel" aclResource="Magento_AdobeStockImageAdminUi::save_preview_images">
+            <uiComponent name="adobe_stock_images_listing" />
         </block>
     </referenceContainer>
 </layout>

--- a/AdobeStockImageAdminUi/view/adminhtml/ui_component/adobe_stock_images_listing.xml
+++ b/AdobeStockImageAdminUi/view/adminhtml/ui_component/adobe_stock_images_listing.xml
@@ -24,7 +24,7 @@
             </storageConfig>
             <updateUrl path="mui/index/render"/>
         </settings>
-        <aclResource>Magento_AdobeStockImageAdminUi::search</aclResource>
+        <aclResource>Magento_AdobeStockImageAdminUi::save_preview_images</aclResource>
         <dataProvider class="Magento\AdobeStockImageAdminUi\Model\Listing\DataProvider" name="adobe_stock_images_listing_data_source">
             <settings>
                 <requestFieldName>id</requestFieldName>


### PR DESCRIPTION
### Description (#93 )
- Specify correct ACL resources for UI component and backend resources

### Documentation
Story: [User controls access to Adobe Stock images from Admin Panel in ACL](https://github.com/magento/adobe-stock-integration/issues/42)

### QA notes
1. User opens Resources tree and sees Adobe Stock Config node under Settings - Configuration - System Section.
2. User includes this resource into the role. That will allow admin user with this role to set up an integration with Adobe stock
3. User sees Adobe Stock node under Content - Elements - Media Gallery. This node has 2 child nodes:
  * Save preview images
  * License images

4. User includes Save preview images resource into the role. This will allow admin user with the role assigned only search for stock images and same their previews into Media Gallery. License image is not accessible.
5. If user doesn't select any of the 2 options, user with the role won't see the access to Adobe Stock from Media Gallery
6. If user selects the parent node Adobe Stock, both child nodes get selected.