### PR TITLE
#144 : Set correct filters order on the grid

### DIFF
--- a/AdobeStockImageAdminUi/view/adminhtml/ui_component/adobe_stock_images_listing.xml
+++ b/AdobeStockImageAdminUi/view/adminhtml/ui_component/adobe_stock_images_listing.xml
@@ -45,44 +45,20 @@
             </settings>
         </paging>
         <filters name="listing_filters">
+            <filterSelect name="content_type_filter" provider="${ $.parentName }">
+                <settings>
+                    <caption translate="true">All</caption>
+                    <options class="Magento\AdobeStockImageAdminUi\Ui\Component\Listing\Columns\ContentType\Options"/>
+                    <label translate="true">Subcategory</label>
+                    <dataScope>content_type_filter</dataScope>
+                </settings>
+            </filterSelect>
             <filterSelect name="orientation_filter" provider="${ $.parentName }">
                 <settings>
                     <caption translate="true">All</caption>
                     <options class="Magento\AdobeStockImageAdminUi\Ui\Component\Listing\Columns\Orientation\Options"/>
                     <label translate="true">Orientation</label>
                     <dataScope>orientation_filter</dataScope>
-                </settings>
-            </filterSelect>
-            <filterSelect name="premium_price_filter" provider="${ $.parentName }">
-                <settings>
-                    <caption translate="true">All</caption>
-                    <options class="Magento\AdobeStockImageAdminUi\Ui\Component\Listing\Columns\PremiumPrice\Options"/>
-                    <label translate="true">Price</label>
-                    <dataScope>premium_price_filter</dataScope>
-                </settings>
-            </filterSelect>
-            <filterSelect name="offensive_filter" provider="${ $.parentName }">
-                <settings>
-                    <caption translate="true">Only safe</caption>
-                    <options class="Magento\AdobeStockImageAdminUi\Ui\Component\Listing\Columns\Offensive\Options"/>
-                    <label translate="true">Offensive</label>
-                    <dataScope>offensive_filter</dataScope>
-                </settings>
-            </filterSelect>
-            <filterSelect name="isolated_filter" provider="${ $.parentName }">
-                <settings>
-                    <caption translate="true">No</caption>
-                    <options class="Magento\AdobeStockImageAdminUi\Ui\Component\Listing\Columns\Isolated\Options"/>
-                    <label translate="true">Isolated images only</label>
-                    <dataScope>isolated_filter</dataScope>
-                </settings>
-            </filterSelect>
-            <filterSelect name="content_type_filter" provider="${ $.parentName }">
-                <settings>
-                    <caption translate="true">All</caption>
-                    <options class="Magento\AdobeStockImageAdminUi\Ui\Component\Listing\Columns\ContentType\Options"/>
-                    <label translate="true">Content Type</label>
-                    <dataScope>content_type_filter</dataScope>
                 </settings>
             </filterSelect>
             <filterInput name="colors_filter" class="\Magento\AdobeStockImageAdminUi\Ui\Component\Listing\Filter\Color"  template="Magento_AdobeStockImageAdminUi/grid/filter/color" provider="${ $.parentName }">
@@ -99,6 +75,30 @@
                     <label translate="true">Color</label>
                 </settings>
             </filterInput>
+            <filterSelect name="premium_price_filter" provider="${ $.parentName }">
+                <settings>
+                    <caption translate="true">All</caption>
+                    <options class="Magento\AdobeStockImageAdminUi\Ui\Component\Listing\Columns\PremiumPrice\Options"/>
+                    <label translate="true">Price</label>
+                    <dataScope>premium_price_filter</dataScope>
+                </settings>
+            </filterSelect>
+            <filterSelect name="offensive_filter" provider="${ $.parentName }">
+                <settings>
+                    <caption translate="true">Only safe</caption>
+                    <options class="Magento\AdobeStockImageAdminUi\Ui\Component\Listing\Columns\Offensive\Options"/>
+                    <label translate="true">Safe search</label>
+                    <dataScope>offensive_filter</dataScope>
+                </settings>
+            </filterSelect>
+            <filterSelect name="isolated_filter" provider="${ $.parentName }">
+                <settings>
+                    <caption translate="true">No</caption>
+                    <options class="Magento\AdobeStockImageAdminUi\Ui\Component\Listing\Columns\Isolated\Options"/>
+                    <label translate="true">Isolated Assets</label>
+                    <dataScope>isolated_filter</dataScope>
+                </settings>
+            </filterSelect>
         </filters>
     </listingToolbar>
     <columns name="adobe_stock_images_columns" template="Magento_AdobeStockImageAdminUi/grid/listing">

--- a/AdobeStockImageAdminUi/view/adminhtml/ui_component/adobe_stock_images_listing.xml
+++ b/AdobeStockImageAdminUi/view/adminhtml/ui_component/adobe_stock_images_listing.xml
@@ -45,7 +45,7 @@
             </settings>
         </paging>
         <filters name="listing_filters">
-            <filterSelect name="content_type_filter" provider="${ $.parentName }">
+            <filterSelect name="content_type_filter" provider="${ $.parentName }" sortOrder="10">
                 <settings>
                     <caption translate="true">All</caption>
                     <options class="Magento\AdobeStockImageAdminUi\Ui\Component\Listing\Columns\ContentType\Options"/>
@@ -53,7 +53,7 @@
                     <dataScope>content_type_filter</dataScope>
                 </settings>
             </filterSelect>
-            <filterSelect name="orientation_filter" provider="${ $.parentName }">
+            <filterSelect name="orientation_filter" provider="${ $.parentName }" sortOrder="20">
                 <settings>
                     <caption translate="true">All</caption>
                     <options class="Magento\AdobeStockImageAdminUi\Ui\Component\Listing\Columns\Orientation\Options"/>
@@ -61,7 +61,7 @@
                     <dataScope>orientation_filter</dataScope>
                 </settings>
             </filterSelect>
-            <filterInput name="colors_filter" class="\Magento\AdobeStockImageAdminUi\Ui\Component\Listing\Filter\Color"  template="Magento_AdobeStockImageAdminUi/grid/filter/color" provider="${ $.parentName }">
+            <filterInput name="colors_filter" class="\Magento\AdobeStockImageAdminUi\Ui\Component\Listing\Filter\Color"  template="Magento_AdobeStockImageAdminUi/grid/filter/color" provider="${ $.parentName }" sortOrder="30">
                 <argument name="data" xsi:type="array">
                     <item name="config" xsi:type="array">
                         <item name="label" xsi:type="string" translate="true">Color</item>
@@ -75,7 +75,7 @@
                     <label translate="true">Color</label>
                 </settings>
             </filterInput>
-            <filterSelect name="premium_price_filter" provider="${ $.parentName }">
+            <filterSelect name="premium_price_filter" provider="${ $.parentName }" sortOrder="40">
                 <settings>
                     <caption translate="true">All</caption>
                     <options class="Magento\AdobeStockImageAdminUi\Ui\Component\Listing\Columns\PremiumPrice\Options"/>
@@ -83,7 +83,7 @@
                     <dataScope>premium_price_filter</dataScope>
                 </settings>
             </filterSelect>
-            <filterSelect name="offensive_filter" provider="${ $.parentName }">
+            <filterSelect name="offensive_filter" provider="${ $.parentName }" sortOrder="50">
                 <settings>
                     <caption translate="true">Only safe</caption>
                     <options class="Magento\AdobeStockImageAdminUi\Ui\Component\Listing\Columns\Offensive\Options"/>
@@ -91,7 +91,7 @@
                     <dataScope>offensive_filter</dataScope>
                 </settings>
             </filterSelect>
-            <filterSelect name="isolated_filter" provider="${ $.parentName }">
+            <filterSelect name="isolated_filter" provider="${ $.parentName }" sortOrder="60">
                 <settings>
                     <caption translate="true">No</caption>
                     <options class="Magento\AdobeStockImageAdminUi\Ui\Component\Listing\Columns\Isolated\Options"/>


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/adobe-stock-integration#144 : Set correct filters order on the grid
2. ...

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
Correct Filter order:
1. Subcategory filter
2. Orientation filter
3. Color filter
4. Price filter
5. Safe search filter
6. Isolated Assets filter

![image](https://user-images.githubusercontent.com/39480008/60385049-b8f5b280-9aa2-11e9-8c3d-0fa96f48a848.png)
