### PR TITLE
ASI 154: Writing unit tests for module AdobeStockImage

### DIFF
--- a/AdobeStockImage/Test/Unit/Model/GetImageListTest.php
+++ b/AdobeStockImage/Test/Unit/Model/GetImageListTest.php
@@ -1,0 +1,216 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\AdobeStockImage\Test\Unit\Model;
+
+use Magento\AdobeStockAsset\Model\Asset;
+use Magento\AdobeStockAssetApi\Api\Data\AssetInterfaceFactory;
+use Magento\AdobeStockAssetApi\Api\Data\AssetSearchResultsInterface;
+use Magento\AdobeStockAssetApi\Api\Data\AssetSearchResultsInterfaceFactory;
+use Magento\AdobeStockClientApi\Api\ClientInterface;
+use Magento\AdobeStockImage\Model\GetImageList;
+use Magento\Framework\Api\AttributeInterface;
+use Magento\Framework\Api\Search\DocumentFactory;
+use Magento\Framework\Api\Search\SearchResultInterface;
+use Magento\Framework\Api\SearchCriteriaInterface;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Get image list test.
+ */
+class GetImageListTest extends TestCase
+{
+    /**
+     * @var ObjectManager
+     */
+    private $objectManager;
+
+    /**
+     * @var GetImageList|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $getImageList;
+
+    /**
+     * @var ClientInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $clientMock;
+
+    /**
+     * @var AssetInterfaceFactory|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $assetFactoryMock;
+
+    /**
+     * @var AssetSearchResultsInterfaceFactory|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $assetSearchResultsInterfaceFactoryMock;
+
+    /**
+     * Prepare test objects.
+     */
+    public function setUp()
+    {
+        $this->objectManager = new ObjectManager($this);
+        $this->clientMock = $this->getMockBuilder(ClientInterface::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['search'])
+            ->getMockForAbstractClass();
+        /** @var AssetInterfaceFactory|\PHPUnit_Framework_MockObject_MockObject $assetFactoryMock */
+        $this->assetFactoryMock = $this->getMockBuilder(AssetInterfaceFactory::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['create'])
+            ->getMockForAbstractClass();
+        $this->assetSearchResultsInterfaceFactoryMock = $this->getMockBuilder(AssetSearchResultsInterfaceFactory::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['create'])
+            ->getMock();
+        $this->getImageList = $this->objectManager->getObject(
+            GetImageList::class,
+            [
+                'client' => $this->clientMock,
+                'assetFactory' => $this->assetFactoryMock,
+                'searchResultFactory' => $this->assetSearchResultsInterfaceFactoryMock
+            ]
+        );
+    }
+
+    /**
+     * Test with founded items.
+     */
+    public function testExecuteWithItems()
+    {
+        $this->assetFactoryMock->expects($this->once())
+            ->method('create')
+            ->willReturn($this->objectManager->getObject(Asset::class));
+        /** @var SearchCriteriaInterface $searchCriteriaMock */
+        $searchCriteriaMock = $this->getMockBuilder(SearchCriteriaInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $searchResultMock = $this->getMockBuilder(SearchResultInterface::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getItems', 'getTotalCount'])
+            ->getMockForAbstractClass();
+        $searchResultMock->expects($this->once())
+            ->method('getItems')
+            ->willReturn($this->getResultItems());
+        $searchResultMock->expects($this->once())
+            ->method('getTotalCount')
+            ->willReturn(1);
+        $this->clientMock->expects($this->once())
+            ->method('search')
+            ->with($searchCriteriaMock)
+            ->willReturn($searchResultMock);
+        $assetSearchResultsInterface = $this->getMockBuilder(AssetSearchResultsInterface::class)
+            ->disableOriginalConstructor()
+            ->getMockForAbstractClass();
+        /** @var Asset $assetItem */
+        $assetItem = $this->objectManager->getObject(Asset::class);
+        $assetItem->setId(1);
+        $assetItem->setUrl('http://example.com');
+        $assetItem->setWidth(200);
+        $assetItem->setHeight(100);
+        $params = [
+            'data' => [
+                'items' => [$assetItem],
+                'total_count' => 1
+            ]
+        ];
+        $this->assetSearchResultsInterfaceFactoryMock->expects($this->once())
+            ->method('create')
+            ->with($params)
+            ->willReturn($assetSearchResultsInterface);
+        $imageListResult = $this->getImageList->execute($searchCriteriaMock);
+        $this->assertInstanceOf(AssetSearchResultsInterface::class, $imageListResult);
+    }
+
+    /**
+     * Test with didn't founded items.
+     */
+    public function testExecuteWithoutItems()
+    {
+        $this->assetFactoryMock->expects($this->any())
+            ->method('create')
+            ->willReturn($this->objectManager->getObject(Asset::class));
+        /** @var SearchCriteriaInterface $searchCriteriaMock */
+        $searchCriteriaMock = $this->getMockBuilder(SearchCriteriaInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $searchResultMock = $this->getMockBuilder(SearchResultInterface::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getItems', 'getTotalCount'])
+            ->getMockForAbstractClass();
+        $searchResultMock->expects($this->once())
+            ->method('getItems')
+            ->willReturn([]);
+        $searchResultMock->expects($this->once())
+            ->method('getTotalCount')
+            ->willReturn(0);
+        $this->clientMock->expects($this->once())
+            ->method('search')
+            ->with($searchCriteriaMock)
+            ->willReturn($searchResultMock);
+        $assetSearchResultsInterface = $this->getMockBuilder(AssetSearchResultsInterface::class)
+            ->disableOriginalConstructor()
+            ->getMockForAbstractClass();
+        $params = [
+            'data' => [
+                'items' => [],
+                'total_count' => 0
+            ]
+        ];
+        $this->assetSearchResultsInterfaceFactoryMock->expects($this->once())
+            ->method('create')
+            ->with($params)
+            ->willReturn($assetSearchResultsInterface);
+        $imageListResult = $this->getImageList->execute($searchCriteriaMock);
+        $this->assertInstanceOf(AssetSearchResultsInterface::class, $imageListResult);
+    }
+
+    /**
+     * Return result items.
+     *
+     * @return array
+     */
+    private function getResultItems(): array
+    {
+        $itemMock = $this->getMockBuilder(DocumentFactory::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getId', 'getCustomAttribute'])
+            ->getMock();
+        $itemMock->expects($this->once())
+            ->method('getId')
+            ->willReturn(1);
+        $urlAttributeMock = $this->getMockBuilder(AttributeInterface::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getValue'])
+            ->getMockForAbstractClass();
+        $urlAttributeMock->expects($this->once())
+            ->method('getValue')
+            ->willReturn('http://example.com');
+        $heightAttributeMock = $this->getMockBuilder(AttributeInterface::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getValue'])
+            ->getMockForAbstractClass();
+        $heightAttributeMock->expects($this->once())
+            ->method('getValue')
+            ->willReturn(100);
+        $widthAttributeMock = $this->getMockBuilder(AttributeInterface::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getValue'])
+            ->getMockForAbstractClass();
+        $widthAttributeMock->expects($this->once())
+            ->method('getValue')
+            ->willReturn(200);
+        $itemMock->expects($this->exactly(3))
+            ->method('getCustomAttribute')
+            ->withConsecutive(['url'], ['height'], ['width'])
+            ->willReturnOnConsecutiveCalls($urlAttributeMock, $heightAttributeMock, $widthAttributeMock);
+
+        return [$itemMock];
+    }
+}

--- a/AdobeStockImage/Test/Unit/Plugin/Product/Gallery/ProcessorTest.php
+++ b/AdobeStockImage/Test/Unit/Plugin/Product/Gallery/ProcessorTest.php
@@ -1,0 +1,217 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\AdobeStockImage\Test\Unit\Plugin\Product\Gallery;
+
+use Magento\AdobeStockAssetApi\Api\AssetRepositoryInterface;
+use Magento\AdobeStockAssetApi\Api\Data\AssetInterface;
+use Magento\AdobeStockAssetApi\Api\Data\AssetSearchResultsInterface;
+use Magento\AdobeStockImage\Plugin\Product\Gallery\Processor;
+use Magento\Catalog\Model\Product;
+use Magento\Catalog\Model\Product\Gallery\Processor as ProcessorSubject;
+use Magento\Framework\Api\Filter;
+use Magento\Framework\Api\FilterBuilder;
+use Magento\Framework\Api\SearchCriteria;
+use Magento\Framework\Api\SearchCriteriaBuilder;
+use Magento\Framework\Api\SearchCriteriaBuilderFactory;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test process after remove image.
+ */
+class ProcessorTest extends TestCase
+{
+    /**
+     * @var ObjectManager
+     */
+    private $objectManager;
+
+    /**
+     * @var SearchCriteriaBuilderFactory|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $searchCriteriaBuilderFactoryMock;
+
+    /**
+     * @var FilterBuilder|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $filterBuilderMock;
+
+    /**
+     * @var AssetRepositoryInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $assetRepositoryInterfaceMock;
+
+    /**
+     * @var Processor
+     */
+    private $processor;
+
+    /**
+     * Prepare test objects.
+     */
+    public function setUp()
+    {
+        $this->objectManager = new ObjectManager($this);
+        $this->searchCriteriaBuilderFactoryMock = $this->getMockBuilder(SearchCriteriaBuilderFactory::class)
+            ->setMethods(['create'])
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->filterBuilderMock = $this->getMockBuilder(FilterBuilder::class)
+            ->setMethods(['setValue', 'setConditionType', 'setField', 'create'])
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->assetRepositoryInterfaceMock = $this->getMockBuilder(AssetRepositoryInterface::class)
+            ->setMethods(['getList', 'delete'])
+            ->disableOriginalConstructor()
+            ->getMockForAbstractClass();
+        $this->processor = $this->objectManager->getObject(
+            Processor::class,
+            [
+                'assetRepository' => $this->assetRepositoryInterfaceMock,
+                'filterBuilder' => $this->filterBuilderMock,
+                'searchCriteriaBuilderFactory' => $this->searchCriteriaBuilderFactoryMock
+            ]
+        );
+    }
+
+    /**
+     * Test delete Adobe's stock asset after image was deleted
+     * with image file path.
+     */
+    public function testAfterRemoveImageWithFile()
+    {
+        /** @var ProcessorSubject $subject */
+        $subject = $this->objectManager->getObject(ProcessorSubject::class);
+        /** @var ProcessorSubject $result */
+        $result = $this->objectManager->getObject(ProcessorSubject::class);
+        /** @var Product $product */
+        $product = $this->objectManager->getObject(Product::class);
+        $file = 'some_file_path';
+        $this->filterBuilderMock->expects($this->once())
+            ->method('setField')
+            ->with('path')
+            ->willReturn($this->filterBuilderMock);
+        $this->filterBuilderMock->expects($this->once())
+            ->method('setConditionType')
+            ->with('eq')
+            ->willReturn($this->filterBuilderMock);
+        $this->filterBuilderMock->expects($this->once())
+            ->method('setValue')
+            ->with($file)
+            ->willReturn($this->filterBuilderMock);
+        $filterMock = $this->getMockBuilder(Filter::class)
+            ->disableOriginalConstructor()
+            ->getMockForAbstractClass();
+        $this->filterBuilderMock->expects($this->once())
+            ->method('create')
+            ->willReturn($filterMock);
+        $searchCriteriaBuilderMock = $this->getMockBuilder(SearchCriteriaBuilder::class)
+            ->setMethods(['addFilters', 'create'])
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->searchCriteriaBuilderFactoryMock->expects($this->once())
+            ->method('create')
+            ->willReturn($searchCriteriaBuilderMock);
+        $searchCriteriaBuilderMock->expects($this->once())
+            ->method('addFilters')
+            ->with([$filterMock]);
+        $searchCriteriaMock = $this->getMockBuilder(SearchCriteria::class)
+            ->disableOriginalConstructor()
+            ->getMockForAbstractClass();
+        $searchCriteriaBuilderMock->expects($this->once())
+            ->method('create')
+            ->willReturn($searchCriteriaMock);
+        $assertSearchResultMock = $this->getMockBuilder(AssetSearchResultsInterface::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getItems'])
+            ->getMockForAbstractClass();
+        $this->assetRepositoryInterfaceMock->expects($this->once())
+            ->method('getList')
+            ->with($searchCriteriaMock)
+            ->willReturn($assertSearchResultMock);
+        $assetMock = $this->getMockBuilder(AssetInterface::class)
+            ->disableOriginalConstructor()
+            ->getMockForAbstractClass();
+        $assertSearchResultMock->expects($this->once())
+            ->method('getItems')
+            ->willReturn([$assetMock]);
+        $this->assetRepositoryInterfaceMock->expects($this->once())
+            ->method('delete')
+            ->with($assetMock);
+        $methodResult = $this->processor->afterRemoveImage($subject, $result, $product, $file);
+        $this->assertInstanceOf(ProcessorSubject::class, $methodResult);
+    }
+
+    /**
+     * Test delete Adobe's stock asset after image was deleted
+     * without image file path.
+     */
+    public function testAfterRemoveImageWithoutFile()
+    {
+        /** @var ProcessorSubject $subject */
+        $subject = $this->objectManager->getObject(ProcessorSubject::class);
+        /** @var ProcessorSubject $result */
+        $result = $this->objectManager->getObject(ProcessorSubject::class);
+        /** @var Product $product */
+        $product = $this->objectManager->getObject(Product::class);
+        $file = null;
+        $this->filterBuilderMock->expects($this->never())
+            ->method('setField')
+            ->with('path')
+            ->willReturn($this->filterBuilderMock);
+        $this->filterBuilderMock->expects($this->never())
+            ->method('setConditionType')
+            ->with('eq')
+            ->willReturn($this->filterBuilderMock);
+        $this->filterBuilderMock->expects($this->never())
+            ->method('setValue')
+            ->with($file)
+            ->willReturn($this->filterBuilderMock);
+        $filterMock = $this->getMockBuilder(Filter::class)
+            ->disableOriginalConstructor()
+            ->getMockForAbstractClass();
+        $this->filterBuilderMock->expects($this->never())
+            ->method('create')
+            ->willReturn($filterMock);
+        $searchCriteriaBuilderMock = $this->getMockBuilder(SearchCriteriaBuilder::class)
+            ->setMethods(['addFilters', 'create'])
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->searchCriteriaBuilderFactoryMock->expects($this->never())
+            ->method('create')
+            ->willReturn($searchCriteriaBuilderMock);
+        $searchCriteriaBuilderMock->expects($this->never())
+            ->method('addFilters')
+            ->with([$filterMock]);
+        $searchCriteriaMock = $this->getMockBuilder(SearchCriteria::class)
+            ->disableOriginalConstructor()
+            ->getMockForAbstractClass();
+        $searchCriteriaBuilderMock->expects($this->never())
+            ->method('create')
+            ->willReturn($searchCriteriaMock);
+        $assertSearchResultMock = $this->getMockBuilder(AssetSearchResultsInterface::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getItems'])
+            ->getMockForAbstractClass();
+        $this->assetRepositoryInterfaceMock->expects($this->never())
+            ->method('getList')
+            ->with($searchCriteriaMock)
+            ->willReturn($assertSearchResultMock);
+        $assetMock = $this->getMockBuilder(AssetInterface::class)
+            ->disableOriginalConstructor()
+            ->getMockForAbstractClass();
+        $assertSearchResultMock->expects($this->never())
+            ->method('getItems')
+            ->willReturn([$assetMock]);
+        $this->assetRepositoryInterfaceMock->expects($this->never())
+            ->method('delete')
+            ->with($assetMock);
+        $methodResult = $this->processor->afterRemoveImage($subject, $result, $product, $file);
+        $this->assertInstanceOf(ProcessorSubject::class, $methodResult);
+    }
+}


### PR DESCRIPTION
### Description (*)
Unit test added for module AdobeStockImage.

### Fixed Issues (if relevant)
1. magento/adobe-stock-integration#154: Writing unit tests for module AdobeStockImage.

### Manual testing scenarios (*)
1. Run next unit tests:
- \Magento\AdobeStockImage\Test\Unit\Model\GetImageListTest
- \Magento\AdobeStockImage\Test\Unit\Plugin\Product\Gallery\ProcessorTest