### PR TITLE
Fix phpdoc and add return types to AssetInterface

### DIFF
--- a/AdobeStockAsset/Model/Asset.php
+++ b/AdobeStockAsset/Model/Asset.php
@@ -30,9 +30,9 @@ class Asset extends AbstractExtensibleObject implements AssetInterface
     /**
      * @inheritdoc
      */
-    public function setId($value)
+    public function setId($value): void
     {
-        return $this->setData(self::ID, $value);
+        $this->setData(self::ID, $value);
     }
 
     /**
@@ -46,7 +46,7 @@ class Asset extends AbstractExtensibleObject implements AssetInterface
     /**
      * @inheritdoc
      */
-    public function setMediaTypeId(int $mediaTypeId)
+    public function setMediaTypeId(int $mediaTypeId): void
     {
         $this->setData(self::MEDIA_TYPE_ID, $mediaTypeId);
     }
@@ -62,7 +62,7 @@ class Asset extends AbstractExtensibleObject implements AssetInterface
     /**
      * @inheritdoc
      */
-    public function setCategory(CategoryInterface $categoryId)
+    public function setCategory(CategoryInterface $categoryId): void
     {
         $this->setData(self::CATEGORY, $categoryId);
     }
@@ -78,7 +78,7 @@ class Asset extends AbstractExtensibleObject implements AssetInterface
     /**
      * @inheritdoc
      */
-    public function setCreator(CreatorInterface $creator)
+    public function setCreator(CreatorInterface $creator): void
     {
         $this->setData(self::CREATOR, $creator);
     }
@@ -94,7 +94,7 @@ class Asset extends AbstractExtensibleObject implements AssetInterface
     /**
      * @inheritdoc
      */
-    public function setKeywords(array $keywords)
+    public function setKeywords(array $keywords): void
     {
         $this->setData(self::KEYWORDS, $keywords);
     }
@@ -110,7 +110,7 @@ class Asset extends AbstractExtensibleObject implements AssetInterface
     /**
      * @inheritdoc
      */
-    public function setPremiumLevelId(int $premiumLevelId)
+    public function setPremiumLevelId(int $premiumLevelId): void
     {
         $this->setData(self::PREMIUM_LEVEL_ID, $premiumLevelId);
     }
@@ -126,7 +126,7 @@ class Asset extends AbstractExtensibleObject implements AssetInterface
     /**
      * @inheritdoc
      */
-    public function setPath(string $path)
+    public function setPath(string $path): void
     {
         $this->setData(self::PATH, $path);
     }
@@ -142,7 +142,7 @@ class Asset extends AbstractExtensibleObject implements AssetInterface
     /**
      * @inheritdoc
      */
-    public function setAdobeId(int $adobeId)
+    public function setAdobeId(int $adobeId): void
     {
         $this->setData(self::ADOBE_ID, $adobeId);
     }
@@ -158,7 +158,7 @@ class Asset extends AbstractExtensibleObject implements AssetInterface
     /**
      * @inheritdoc
      */
-    public function setStockId(int $stockId)
+    public function setStockId(int $stockId): void
     {
         $this->setData(self::STOCK_ID, $stockId);
     }
@@ -174,7 +174,7 @@ class Asset extends AbstractExtensibleObject implements AssetInterface
     /**
      * @inheritdoc
      */
-    public function setIsLicensed(int $isLicensed)
+    public function setIsLicensed(int $isLicensed): void
     {
         $this->setData(self::IS_LICENSED, $isLicensed);
     }
@@ -190,7 +190,7 @@ class Asset extends AbstractExtensibleObject implements AssetInterface
     /**
      * @inheritdoc
      */
-    public function setTitle(string $title)
+    public function setTitle(string $title): void
     {
         $this->setData(self::TITLE, $title);
     }
@@ -206,7 +206,7 @@ class Asset extends AbstractExtensibleObject implements AssetInterface
     /**
      * @inheritdoc
      */
-    public function setPreviewUrl(string $previewUrl)
+    public function setPreviewUrl(string $previewUrl): void
     {
         $this->setData(self::PREVIEW_UR, $previewUrl);
     }
@@ -222,7 +222,7 @@ class Asset extends AbstractExtensibleObject implements AssetInterface
     /**
      * @inheritdoc
      */
-    public function setPreviewWidth(int $previewWidth)
+    public function setPreviewWidth(int $previewWidth): void
     {
         $this->setData(self::PREVIEW_WIDTH, $previewWidth);
     }
@@ -238,7 +238,7 @@ class Asset extends AbstractExtensibleObject implements AssetInterface
     /**
      * @inheritdoc
      */
-    public function setPreviewHeight(int $previewHeight)
+    public function setPreviewHeight(int $previewHeight): void
     {
         $this->setData(self::PREVIEW_HEIGHT, $previewHeight);
     }
@@ -254,7 +254,7 @@ class Asset extends AbstractExtensibleObject implements AssetInterface
     /**
      * @inheritdoc
      */
-    public function setUrl(string $url)
+    public function setUrl(string $url): void
     {
         $this->setData(self::URL, $url);
     }
@@ -270,7 +270,7 @@ class Asset extends AbstractExtensibleObject implements AssetInterface
     /**
      * @inheritdoc
      */
-    public function setWidth(int $width)
+    public function setWidth(int $width): void
     {
         $this->setData(self::WIDTH, $width);
     }
@@ -286,7 +286,7 @@ class Asset extends AbstractExtensibleObject implements AssetInterface
     /**
      * @inheritdoc
      */
-    public function setHeight(int $height)
+    public function setHeight(int $height): void
     {
         $this->setData(self::HEIGHT, $height);
     }
@@ -302,7 +302,7 @@ class Asset extends AbstractExtensibleObject implements AssetInterface
     /**
      * @inheritdoc
      */
-    public function setCountryName(string $countryName)
+    public function setCountryName(string $countryName): void
     {
         $this->setData(self::COUNTRY_NAME, $countryName);
     }
@@ -318,7 +318,7 @@ class Asset extends AbstractExtensibleObject implements AssetInterface
     /**
      * @inheritdoc
      */
-    public function setDetailsUrl(string $detailsUrl)
+    public function setDetailsUrl(string $detailsUrl): void
     {
         $this->setData(self::DETAILS_URL, $detailsUrl);
     }
@@ -334,7 +334,7 @@ class Asset extends AbstractExtensibleObject implements AssetInterface
     /**
      * @inheritdoc
      */
-    public function setVectorType(string $vectorType)
+    public function setVectorType(string $vectorType): void
     {
         $this->setData(self::VECTOR_TYPE, $vectorType);
     }
@@ -350,7 +350,7 @@ class Asset extends AbstractExtensibleObject implements AssetInterface
     /**
      * @inheritdoc
      */
-    public function setContentType(string $contentType)
+    public function setContentType(string $contentType): void
     {
         $this->setData(self::CONTENT_TYPE, $contentType);
     }
@@ -366,7 +366,7 @@ class Asset extends AbstractExtensibleObject implements AssetInterface
     /**
      * @inheritdoc
      */
-    public function setCreationDate(string $creationDate)
+    public function setCreationDate(string $creationDate): void
     {
         $this->setData(self::CREATION_DATE, $creationDate);
     }
@@ -382,7 +382,7 @@ class Asset extends AbstractExtensibleObject implements AssetInterface
     /**
      * @inheritdoc
      */
-    public function setCreatedAt(string $createdAt)
+    public function setCreatedAt(string $createdAt): void
     {
         $this->setData(self::CREATED_AT, $createdAt);
     }
@@ -398,7 +398,7 @@ class Asset extends AbstractExtensibleObject implements AssetInterface
     /**
      * @inheritdoc
      */
-    public function setUpdatedAt(string $updatedAt)
+    public function setUpdatedAt(string $updatedAt): void
     {
         $this->setData(self::UPDATED_AT, $updatedAt);
     }
@@ -414,8 +414,8 @@ class Asset extends AbstractExtensibleObject implements AssetInterface
     /**
      * @inheritdoc
      */
-    public function setExtensionAttributes(AssetExtensionInterface $extensionAttributes)
+    public function setExtensionAttributes(AssetExtensionInterface $extensionAttributes): void
     {
-        return $this->_setExtensionAttributes($extensionAttributes);
+        $this->_setExtensionAttributes($extensionAttributes);
     }
 }

--- a/AdobeStockAssetApi/Api/Data/AssetInterface.php
+++ b/AdobeStockAssetApi/Api/Data/AssetInterface.php
@@ -57,9 +57,9 @@ interface AssetInterface extends \Magento\Framework\Api\ExtensibleDataInterface
      * Set ID
      *
      * @param int $value
-     * @return $this
+     * @return void
      */
-    public function setId($value);
+    public function setId($value): void;
 
     /**
      * Get Path
@@ -72,9 +72,9 @@ interface AssetInterface extends \Magento\Framework\Api\ExtensibleDataInterface
      * Set Path
      *
      * @param string $value
-     * @return $this
+     * @return void
      */
-    public function setPath(string $value);
+    public function setPath(string $value): void;
 
     /**
      * Get URL
@@ -87,17 +87,17 @@ interface AssetInterface extends \Magento\Framework\Api\ExtensibleDataInterface
      * Set URL
      *
      * @param string $url
-     * @return $this
+     * @return void
      */
-    public function setUrl(string $url);
+    public function setUrl(string $url): void;
 
     /**
      * Set full licensed asset's height
      *
      * @param int $value
-     * @return $this
+     * @return void
      */
-    public function setHeight(int $value);
+    public function setHeight(int $value): void;
 
     /**
      * Retrieve full licensed asset's height
@@ -110,9 +110,9 @@ interface AssetInterface extends \Magento\Framework\Api\ExtensibleDataInterface
      * Set full licensed asset's width
      *
      * @param int $value
-     * @return $this
+     * @return void
      */
-    public function setWidth(int $value);
+    public function setWidth(int $value): void;
 
     /**
      * Retrieve full licensed asset's width
@@ -134,7 +134,7 @@ interface AssetInterface extends \Magento\Framework\Api\ExtensibleDataInterface
      * @param int $mediaTypeId
      * @return void
      */
-    public function setMediaTypeId(int $mediaTypeId);
+    public function setMediaTypeId(int $mediaTypeId): void;
 
     /**
      * Get category
@@ -147,9 +147,9 @@ interface AssetInterface extends \Magento\Framework\Api\ExtensibleDataInterface
      * Set category
      *
      * @param CategoryInterface $categoryId
-     * @return $this
+     * @return void
      */
-    public function setCategory(CategoryInterface $categoryId);
+    public function setCategory(CategoryInterface $categoryId): void;
 
     /**
      * Return the creator
@@ -162,9 +162,9 @@ interface AssetInterface extends \Magento\Framework\Api\ExtensibleDataInterface
      * Set the creator id
      *
      * @param CreatorInterface $creatorId
-     * @return $this
+     * @return void
      */
-    public function setCreator(CreatorInterface $creatorId);
+    public function setCreator(CreatorInterface $creatorId): void;
 
     /**
      * Get keywords
@@ -177,9 +177,9 @@ interface AssetInterface extends \Magento\Framework\Api\ExtensibleDataInterface
      * Set keywords
      *
      * @param KeywordInterface[] $keywords
-     * @return $this
+     * @return void
      */
-    public function setKeywords(array $keywords);
+    public function setKeywords(array $keywords): void;
 
     /**
      * Get premium level id
@@ -192,9 +192,9 @@ interface AssetInterface extends \Magento\Framework\Api\ExtensibleDataInterface
      * Set premium level id
      *
      * @param int $premiumLevelId
-     * @return $this
+     * @return void
      */
-    public function setPremiumLevelId(int $premiumLevelId);
+    public function setPremiumLevelId(int $premiumLevelId): void;
 
     /**
      * Get adobe id
@@ -207,9 +207,9 @@ interface AssetInterface extends \Magento\Framework\Api\ExtensibleDataInterface
      * Set adobe id
      *
      * @param int $adobeId
-     * @return $this
+     * @return void
      */
-    public function setAdobeId(int $adobeId);
+    public function setAdobeId(int $adobeId): void;
 
     /**
      * Get the stock id
@@ -222,9 +222,9 @@ interface AssetInterface extends \Magento\Framework\Api\ExtensibleDataInterface
      * Set stock id
      *
      * @param int $stockId
-     * @return $this
+     * @return void
      */
-    public function setStockId(int $stockId);
+    public function setStockId(int $stockId): void;
 
     /**
      * Is licensed
@@ -237,9 +237,9 @@ interface AssetInterface extends \Magento\Framework\Api\ExtensibleDataInterface
      * Set is licensed
      *
      * @param int $isLicensed
-     * @return $this
+     * @return void
      */
-    public function setIsLicensed(int $isLicensed);
+    public function setIsLicensed(int $isLicensed): void;
 
     /**
      * Get title
@@ -252,9 +252,9 @@ interface AssetInterface extends \Magento\Framework\Api\ExtensibleDataInterface
      * Set title
      *
      * @param string $title
-     * @return $this
+     * @return void
      */
-    public function setTitle(string $title);
+    public function setTitle(string $title): void;
 
     /**
      * Get preview url
@@ -267,9 +267,9 @@ interface AssetInterface extends \Magento\Framework\Api\ExtensibleDataInterface
      * Set preview url
      *
      * @param string $previewUrl
-     * @return $this
+     * @return void
      */
-    public function setPreviewUrl(string $previewUrl);
+    public function setPreviewUrl(string $previewUrl): void;
 
     /**
      * Get preview width
@@ -282,9 +282,9 @@ interface AssetInterface extends \Magento\Framework\Api\ExtensibleDataInterface
      * Set preview width
      *
      * @param int $previewWidth
-     * @return $this
+     * @return void
      */
-    public function setPreviewWidth(int $previewWidth);
+    public function setPreviewWidth(int $previewWidth): void;
 
     /**
      * Get the preview height
@@ -297,9 +297,9 @@ interface AssetInterface extends \Magento\Framework\Api\ExtensibleDataInterface
      * Set preview height
      *
      * @param int $previewHeight
-     * @return $this
+     * @return void
      */
-    public function setPreviewHeight(int $previewHeight);
+    public function setPreviewHeight(int $previewHeight): void;
 
     /**
      * Get country name
@@ -312,9 +312,9 @@ interface AssetInterface extends \Magento\Framework\Api\ExtensibleDataInterface
      * Set country name
      *
      * @param string $countryName
-     * @return $this
+     * @return void
      */
-    public function setCountryName(string $countryName);
+    public function setCountryName(string $countryName): void;
 
     /**
      * Get details url
@@ -327,9 +327,9 @@ interface AssetInterface extends \Magento\Framework\Api\ExtensibleDataInterface
      * Set details url
      *
      * @param string $detailsUrl
-     * @return $this
+     * @return void
      */
-    public function setDetailsUrl(string $detailsUrl);
+    public function setDetailsUrl(string $detailsUrl): void;
 
     /**
      * Get vector types
@@ -342,9 +342,9 @@ interface AssetInterface extends \Magento\Framework\Api\ExtensibleDataInterface
      * Set vector types
      *
      * @param string $vectorType
-     * @return $this
+     * @return void
      */
-    public function setVectorType(string $vectorType);
+    public function setVectorType(string $vectorType): void;
 
     /**
      * Get content type
@@ -357,9 +357,9 @@ interface AssetInterface extends \Magento\Framework\Api\ExtensibleDataInterface
      * Set content type
      *
      * @param string $contentType
-     * @return $this
+     * @return void
      */
-    public function setContentType(string $contentType);
+    public function setContentType(string $contentType): void;
 
     /**
      * Get creation date
@@ -372,9 +372,9 @@ interface AssetInterface extends \Magento\Framework\Api\ExtensibleDataInterface
      * Set creation date
      *
      * @param string $creationDate
-     * @return $this
+     * @return void
      */
-    public function setCreationDate(string $creationDate);
+    public function setCreationDate(string $creationDate): void;
 
     /**
      * Get created at
@@ -387,9 +387,9 @@ interface AssetInterface extends \Magento\Framework\Api\ExtensibleDataInterface
      * Set created at
      *
      * @param string $createdAt
-     * @return $this
+     * @return void
      */
-    public function setCreatedAt(string $createdAt);
+    public function setCreatedAt(string $createdAt): void;
 
     /**
      * Get updated at
@@ -402,9 +402,9 @@ interface AssetInterface extends \Magento\Framework\Api\ExtensibleDataInterface
      * Return updated at
      *
      * @param string $updatedAt
-     * @return $this
+     * @return void
      */
-    public function setUpdatedAt(string $updatedAt);
+    public function setUpdatedAt(string $updatedAt): void;
 
     /**
      * Retrieve existing extension attributes object or create a new one.
@@ -417,7 +417,7 @@ interface AssetInterface extends \Magento\Framework\Api\ExtensibleDataInterface
      * Set an extension attributes object.
      *
      * @param \Magento\AdobeStockAssetApi\Api\Data\AssetExtensionInterface $extensionAttributes
-     * @return $this
+     * @return void
      */
-    public function setExtensionAttributes(AssetExtensionInterface $extensionAttributes);
+    public function setExtensionAttributes(AssetExtensionInterface $extensionAttributes): void;
 }


### PR DESCRIPTION
### Description (*)
- Improve `Magento\AdobeStockAssetApi\Api\Data\AssetInterface`:
  - Fix incorrect PhpDoc: set methods return void instead of $this
  - Add void return type to methods with appropriate phpdoc
  - change setId and setExtensionAttributes method signatures to return void instead of self as it should be by design.
- Change `Magento\AdobeStockAsset\Model\Asset` to fit it's interface