### PR TITLE
Fix phpdoc and add return types to AssetRepositoryInterface and KeywordInterface

### DIFF
--- a/AdobeStockAsset/Model/AssetRepository.php
+++ b/AdobeStockAsset/Model/AssetRepository.php
@@ -8,7 +8,6 @@ declare(strict_types=1);
 
 namespace Magento\AdobeStockAsset\Model;
 
-use Exception;
 use Magento\AdobeStockAsset\Model\ResourceModel\Asset as ResourceModel;
 use Magento\AdobeStockAsset\Model\ResourceModel\Asset\Collection as AssetCollection;
 use Magento\AdobeStockAsset\Model\ResourceModel\Asset\CollectionFactory as AssetCollectionFactory;
@@ -20,7 +19,6 @@ use Magento\Framework\Api\ExtensionAttribute\JoinProcessorInterface;
 use Magento\Framework\Api\SearchCriteria\CollectionProcessorInterface;
 use Magento\Framework\Api\SearchCriteriaBuilderFactory;
 use Magento\Framework\Api\SearchCriteriaInterface;
-use Magento\Framework\Exception\AlreadyExistsException;
 use Magento\Framework\Exception\NoSuchEntityException;
 
 /**
@@ -84,32 +82,23 @@ class AssetRepository implements AssetRepositoryInterface
     }
 
     /**
-     * Save asset
-     *
-     * @param AssetInterface $item
-     * @throws AlreadyExistsException
+     * @inheritdoc
      */
-    public function save(AssetInterface $item)
+    public function save(AssetInterface $item): void
     {
         $this->resource->save($item);
     }
 
     /**
-     * Delete item
-     *
-     * @param AssetInterface $item
-     * @throws Exception
+     * @inheritdoc
      */
-    public function delete(AssetInterface $item)
+    public function delete(AssetInterface $item): void
     {
         $this->resource->delete($item);
     }
 
     /**
-     * Get a list of assets
-     *
-     * @param SearchCriteriaInterface $searchCriteria
-     * @return AssetSearchResultsInterface
+     * @inheritdoc
      */
     public function getList(SearchCriteriaInterface $searchCriteria) : AssetSearchResultsInterface
     {
@@ -131,11 +120,7 @@ class AssetRepository implements AssetRepositoryInterface
     }
 
     /**
-     * Get asset by id
-     *
-     * @param int $id
-     * @return AssetInterface
-     * @throws NoSuchEntityException
+     * @inheritdoc
      */
     public function getById(int $id) : AssetInterface
     {
@@ -148,14 +133,9 @@ class AssetRepository implements AssetRepositoryInterface
     }
 
     /**
-     * Delete asset
-     *
-     * @param int $id
-     * @return bool|void
-     * @throws NoSuchEntityException
-     * @throws Exception
+     * @inheritdoc
      */
-    public function deleteById(int $id)
+    public function deleteById(int $id): void
     {
         $this->delete($this->getById($id));
     }

--- a/AdobeStockAsset/Model/Keyword.php
+++ b/AdobeStockAsset/Model/Keyword.php
@@ -36,7 +36,7 @@ class Keyword extends AbstractExtensibleModel implements KeywordInterface
     /**
      * @inheritdoc
      */
-    public function setKeyword(string $keyword)
+    public function setKeyword(string $keyword): void
     {
         $this->setData(self::KEYWORD, $keyword);
     }

--- a/AdobeStockAssetApi/Api/AssetRepositoryInterface.php
+++ b/AdobeStockAssetApi/Api/AssetRepositoryInterface.php
@@ -24,17 +24,19 @@ interface AssetRepositoryInterface
      * Save asset
      *
      * @param AssetInterface $item
+     * @return void
      * @throws \Magento\Framework\Exception\AlreadyExistsException
      */
-    public function save(AssetInterface $item);
+    public function save(AssetInterface $item): void;
 
     /**
      * Delete item
      *
      * @param AssetInterface $item
+     * @return void
      * @throws \Exception
      */
-    public function delete(AssetInterface $item);
+    public function delete(AssetInterface $item): void;
 
     /**
      * Get a list of assets
@@ -57,8 +59,8 @@ interface AssetRepositoryInterface
      * Delete asset
      *
      * @param int $id
-     * @return bool|void
-     * @throws NoSuchEntityException
+     * @return void
+     * @throws \Exception
      */
-    public function deleteById(int $id);
+    public function deleteById(int $id): void;
 }

--- a/AdobeStockAssetApi/Api/Data/KeywordInterface.php
+++ b/AdobeStockAssetApi/Api/Data/KeywordInterface.php
@@ -28,7 +28,7 @@ interface KeywordInterface
      * Set the id
      *
      * @param int $value
-     * @return void
+     * @return $this
      */
     public function setId($value);
 
@@ -43,6 +43,7 @@ interface KeywordInterface
      * Set the keyword
      *
      * @param string $keyword
+     * @return void
      */
-    public function setKeyword(string $keyword);
+    public function setKeyword(string $keyword): void;
 }


### PR DESCRIPTION
### Description (*)
- Improve `Magento\AdobeStockAssetApi\Api\Data\KeywordInterface`:
  - Fix incorrect PhpDoc: `deleteById` had incorrect return type and exception type
  - Add void return type to methods with appropriate phpdoc
- Change `Magento\AdobeStockAsset\Model\Keyword` to fit it's interface
- Improve `Magento\AdobeStockAssetApi\Api\AssetRepositoryInterface`:
  - Add void return type to methods with appropriate phpdoc
- Change `Magento\AdobeStockAsset\Model\AssetRepository` to fit it's interface