### PR TITLE
ASI-128: Client error: Api Key is invalid if User is allowed to click on by client and is not allowed by server

### DIFF
--- a/AdobeStockClient/Model/Client.php
+++ b/AdobeStockClient/Model/Client.php
@@ -274,6 +274,6 @@ class Client implements ClientInterface
     private function processException(Phrase $message, Exception $exception)
     {
         $this->logger->critical($message->render());
-        throw new IntegrationException($message, $exception);
+        throw new IntegrationException($message, $exception, $exception->getCode());
     }
 }

--- a/AdobeStockImage/Model/GetImageList.php
+++ b/AdobeStockImage/Model/GetImageList.php
@@ -83,7 +83,7 @@ class GetImageList implements GetImageListInterface
             );
         } catch (\Exception $exception) {
             $message = __('Get image list action failed.');
-            throw new LocalizedException($message, $exception);
+            throw new LocalizedException($message, $exception, $exception->getCode());
         }
     }
 }

--- a/AdobeStockImageAdminUi/Model/Listing/DataProvider.php
+++ b/AdobeStockImageAdminUi/Model/Listing/DataProvider.php
@@ -99,7 +99,7 @@ class DataProvider extends \Magento\Framework\View\Element\UiComponent\DataProvi
             $message = __('Error with message: %1', $e->getMessage());
             if ($e->getCode() === 403) {
                 $message = __(
-                    'You have problem with API key, please check it on <a href="%url'
+                    'Please ensure the Adobe Stock API key is specified correctly on the <a href="%url'
                     . '#system_adobe_stock_integration-link"'
                     . '>Adobe Stock Integration configuration</a> page.',
                     ['url' => $this->urlBuilder->getUrl('adminhtml/system_config/edit/section/system')]

--- a/AdobeStockImageAdminUi/Model/Listing/DataProvider.php
+++ b/AdobeStockImageAdminUi/Model/Listing/DataProvider.php
@@ -13,7 +13,9 @@ use Magento\Framework\Api\Search\ReportingInterface;
 use Magento\Framework\Api\Search\SearchCriteriaBuilder;
 use Magento\Framework\App\RequestInterface;
 use Magento\AdobeStockImageApi\Api\GetImageListInterface;
+use Magento\Framework\Exception\LocalizedException;
 use Magento\Ui\DataProvider\SearchResultFactory;
+use \Magento\Framework\UrlInterface;
 
 /**
  * DataProvider of customer addresses for customer address grid.
@@ -31,6 +33,11 @@ class DataProvider extends \Magento\Framework\View\Element\UiComponent\DataProvi
     private $searchResultFactory;
 
     /**
+     * @var UrlInterface
+     */
+    private $urlBuilder;
+
+    /**
      * DataProvider constructor.
      * @param string $name
      * @param string $primaryFieldName
@@ -41,6 +48,7 @@ class DataProvider extends \Magento\Framework\View\Element\UiComponent\DataProvi
      * @param FilterBuilder $filterBuilder
      * @param GetImageListInterface $getImageList
      * @param SearchResultFactory $searchResultFactory
+     * @param UrlInterface $urlBuilder
      * @param array $meta
      * @param array $data
      */
@@ -54,6 +62,7 @@ class DataProvider extends \Magento\Framework\View\Element\UiComponent\DataProvi
         FilterBuilder $filterBuilder,
         GetImageListInterface $getImageList,
         SearchResultFactory $searchResultFactory,
+        UrlInterface $urlBuilder,
         array $meta = [],
         array $data = []
     ) {
@@ -70,6 +79,7 @@ class DataProvider extends \Magento\Framework\View\Element\UiComponent\DataProvi
         );
         $this->getImageList = $getImageList;
         $this->searchResultFactory = $searchResultFactory;
+        $this->urlBuilder = $urlBuilder;
     }
 
     /**
@@ -77,12 +87,25 @@ class DataProvider extends \Magento\Framework\View\Element\UiComponent\DataProvi
      */
     public function getSearchResult()
     {
-        $result = $this->getImageList->execute($this->getSearchCriteria());
-        return $this->searchResultFactory->create(
-            $result->getItems(),
-            $result->getTotalCount(),
-            $this->getSearchCriteria(),
-            'id'
-        );
+        try {
+            $result = $this->getImageList->execute($this->getSearchCriteria());
+            return $this->searchResultFactory->create(
+                $result->getItems(),
+                $result->getTotalCount(),
+                $this->getSearchCriteria(),
+                'id'
+            );
+        } catch (\Exception $e) {
+            $message = __('Error with message: %1', $e->getMessage());
+            if ($e->getCode() === 403) {
+                $message = __(
+                    'You have problem with API key, please check it on <a href="%url'
+                    . '#system_adobe_stock_integration-link"'
+                    . '>Adobe Stock Integration configuration</a> page.',
+                    ['url' => $this->urlBuilder->getUrl('adminhtml/system_config/edit/section/system')]
+                );
+            }
+            throw new LocalizedException($message, $e, $e->getCode());
+        }
     }
 }


### PR DESCRIPTION
### Description (*)
Change error message and add URL to API key page configuration.

### Fixed Issues (if relevant)
1. magento/adobe-stock-integration#128: Client error: Api Key is invalid if User is allowed to click on by client and is not allowed by server