### PR TITLE
#232 : Color filter UI is broken

### DIFF
--- a/AdobeStockImageAdminUi/view/adminhtml/web/css/source/_module.less
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/css/source/_module.less
@@ -76,7 +76,7 @@
     }
     .admin__form-field {
         .colorpicker-input {
-            min-width: 18.83rem;
+            min-width: 70%;
         }
     }
 }


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/adobe-stock-integration#232: Color filter UI is broken

### Manual testing scenarios (*)
Expected Result:- 

![image](https://user-images.githubusercontent.com/39480008/61394222-4a0cbc00-a8e0-11e9-9fff-7c98a10644c8.png)
