### PR TITLE
HOTFIX: remove second time imported search criteria interface

### DIFF
--- a/AdobeStockClient/Model/Client.php
+++ b/AdobeStockClient/Model/Client.php
@@ -25,7 +25,6 @@ use Magento\Framework\Api\Search\DocumentInterface;
 use Magento\Framework\Api\SearchCriteriaInterface;
 use Magento\Framework\Api\Search\SearchResultInterface;
 use Magento\Framework\Api\Search\SearchResultFactory;
-use Magento\Framework\Api\SearchCriteriaInterface;
 use Magento\Framework\Exception\AuthorizationException;
 use Magento\Framework\Exception\IntegrationException;
 use Magento\Framework\HTTP\Client\CurlFactory;


### PR DESCRIPTION
### Description 
The `Magento\AdobeStockClient\Model\Client` has 2 times connected `Magento\Framework\Api\SearchCriteriaInterface`. [Check here](https://github.com/magento/adobe-stock-integration/blob/develop/AdobeStockClient/Model/Client.php#L25) and [check here](https://github.com/magento/adobe-stock-integration/blob/develop/AdobeStockClient/Model/Client.php#L28)

This leads to
>Fatal error:  Cannot use Magento\Framework\Api\SearchCriteriaInterface as SearchCriteriaInterface because the name is already in use in ext/magento/stock-integration/AdobeStockClient/Model/Client.php on line 28

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios 
Run di compile process.