### PR TITLE
117: redirect admin user to the login page when the session is expired

### DIFF
--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/masonry.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/masonry.js
@@ -3,10 +3,11 @@
  * See COPYING.txt for license details.
  */
 define([
+    'mage/url',
     'Magento_Ui/js/grid/listing',
     'jquery',
     'ko'
-], function (Element, $, ko) {
+], function (url, Element, $, ko) {
     'use strict';
 
     return Element.extend({
@@ -77,6 +78,11 @@ define([
          * @return {Object}
          */
         initComponent: function (rows) {
+
+            if (typeof rows === 'undefined') {
+                window.location.replace(url.build('*/*'));
+            }
+
             if (!rows.length) {
                 this.totalHeight = 0;
                 this.setContainerHeight();


### PR DESCRIPTION
### Description
According do the [reported issue 117](https://github.com/magento/adobe-stock-integration/issues/117) when the session has expired an admin user should be redirected to the login page. As an implementation, I choose next: if rows (data which data provider returns to the UI component) is a type of undefined, we redirect to the request page. If the session is expired an admin user will be redirected to the login page.

### Fixed Issues (if relevant)
[magento/adobe-stock-integration#117: If Admin's session expired Magento should kick out User to Login page](https://github.com/magento/adobe-stock-integration/issues/117)

### Manual testing scenarios
1. Log in to the Magento admin
1. Choose any page (or start new page creation process) from the list (Content -> Elements -> Pages)
1. Go to the Content tab and press on the insert image button
1. At the appeared press choose source icon
1. At the source selected pop up "Select Images" press  "Search Adobe Stock"
1. Then you have to wait until the current session becomes expired or delete the cookies in the browser inspector to be not logged in for Magento
1. Try to search for an image.

Acceptance criteria: with the session being an expired the search for an image should redirect to the login page.