### PR TITLE
Fixed the issue with saving asset model

### DIFF
--- a/AdobeStockAsset/Model/Asset.php
+++ b/AdobeStockAsset/Model/Asset.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace Magento\AdobeStockAsset\Model;
 
+use Magento\AdobeStockAsset\Model\ResourceModel\Asset as AssetResourceModel;
 use Magento\AdobeStockAssetApi\Api\Data\AssetExtensionInterface;
 use Magento\AdobeStockAssetApi\Api\Data\AssetInterface;
 use Magento\AdobeStockAssetApi\Api\Data\CategoryInterface;
@@ -22,9 +23,23 @@ class Asset extends AbstractExtensibleModel implements AssetInterface
     /**
      * @inheritdoc
      */
-    public function getId(): int
+    protected function _construct()
     {
-        return (int) $this->getData(self::ID);
+        $this->_init(AssetResourceModel::class);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getId(): ?int
+    {
+        $id = $this->getData(self::ID);
+
+        if (!$id) {
+            return null;
+        }
+
+        return (int) $id;
     }
 
     /**


### PR DESCRIPTION

### Description 
The asset model has two problems which lead to incorrect behavior during the asset model saving.
The first one about not initialized resource model which leads to the fatal error: `Fatal error: Uncaught Magento\Framework\Exception\LocalizedException: The resource isn't set. in lib/internal/Magento/Framework/Model/AbstractModel.php:484`.

The second one about `getId()` method which returns int value and it leads to the issue with not saving a new asset. 
The `getId()` should return the `null` value in case if it is a new asset.
The `isObjectNotNew` comparing:
https://github.com/magento/magento2/blob/5911255e94d7e918f94e95caa3fde63174d7ed67/lib/internal/Magento/Framework/Model/ResourceModel/Db/AbstractDb.php#L769-L772

### Manual testing scenarios 

1. Try to save the new asset entity via `Magento\AdobeStockAsset\Model\ResourceModel\Asset` resource model or via `Magento\AdobeStockAssetApi\Api\AssetRepositoryInterface`.