### PR TITLE
Fix the issue with not specified namespace in API methods docs

### DIFF
--- a/AdobeStockAssetApi/Api/AssetRepositoryInterface.php
+++ b/AdobeStockAssetApi/Api/AssetRepositoryInterface.php
@@ -11,11 +11,9 @@ namespace Magento\AdobeStockAssetApi\Api;
 use Magento\AdobeStockAssetApi\Api\Data\AssetInterface;
 use Magento\AdobeStockAssetApi\Api\Data\AssetSearchResultsInterface;
 use Magento\Framework\Api\SearchCriteriaInterface;
-use Magento\Framework\Exception\NoSuchEntityException;
 
 /**
  * Interface AssetRepositoryInterface
- * @package Magento\AdobeStockImage\Api
  * @api
  */
 interface AssetRepositoryInterface
@@ -23,7 +21,7 @@ interface AssetRepositoryInterface
     /**
      * Save asset
      *
-     * @param AssetInterface $item
+     * @param \Magento\AdobeStockAssetApi\Api\Data\AssetInterface $item
      * @return void
      * @throws \Magento\Framework\Exception\AlreadyExistsException
      */
@@ -41,8 +39,8 @@ interface AssetRepositoryInterface
     /**
      * Get a list of assets
      *
-     * @param SearchCriteriaInterface $searchCriteria
-     * @return AssetSearchResultsInterface
+     * @param \Magento\Framework\Api\SearchCriteriaInterface $searchCriteria
+     * @return \Magento\AdobeStockAssetApi\Api\Data\AssetSearchResultsInterface
      */
     public function getList(SearchCriteriaInterface $searchCriteria) : AssetSearchResultsInterface;
 
@@ -50,8 +48,8 @@ interface AssetRepositoryInterface
      * Get asset by id
      *
      * @param int $id
-     * @return AssetInterface
-     * @throws NoSuchEntityException
+     * @return \Magento\AdobeStockAssetApi\Api\Data\AssetInterface
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
      */
     public function getById(int $id) : AssetInterface;
 

--- a/AdobeStockAssetApi/Api/Data/AssetInterface.php
+++ b/AdobeStockAssetApi/Api/Data/AssetInterface.php
@@ -139,14 +139,14 @@ interface AssetInterface extends \Magento\Framework\Api\ExtensibleDataInterface
     /**
      * Get category
      *
-     * @return CategoryInterface|null
+     * @return \Magento\AdobeStockAssetApi\Api\Data\CategoryInterface|null
      */
     public function getCategory(): ?CategoryInterface;
 
     /**
      * Set category
      *
-     * @param CategoryInterface $categoryId
+     * @param \Magento\AdobeStockAssetApi\Api\Data\CategoryInterface $categoryId
      * @return void
      */
     public function setCategory(CategoryInterface $categoryId): void;
@@ -154,14 +154,14 @@ interface AssetInterface extends \Magento\Framework\Api\ExtensibleDataInterface
     /**
      * Return the creator
      *
-     * @return CreatorInterface|null
+     * @return \Magento\AdobeStockAssetApi\Api\Data\CreatorInterface|null
      */
     public function getCreator(): ?CreatorInterface;
 
     /**
      * Set the creator id
      *
-     * @param CreatorInterface $creatorId
+     * @param \Magento\AdobeStockAssetApi\Api\Data\CreatorInterface $creatorId
      * @return void
      */
     public function setCreator(CreatorInterface $creatorId): void;
@@ -169,14 +169,14 @@ interface AssetInterface extends \Magento\Framework\Api\ExtensibleDataInterface
     /**
      * Get keywords
      *
-     * @return KeywordInterface[]
+     * @return \Magento\AdobeStockAssetApi\Api\Data\KeywordInterface[]
      */
     public function getKeywords(): array;
 
     /**
      * Set keywords
      *
-     * @param KeywordInterface[] $keywords
+     * @param \Magento\AdobeStockAssetApi\Api\Data\KeywordInterface[] $keywords
      * @return void
      */
     public function setKeywords(array $keywords): void;

--- a/AdobeStockImageApi/Api/GetImageListInterface.php
+++ b/AdobeStockImageApi/Api/GetImageListInterface.php
@@ -10,7 +10,6 @@ namespace Magento\AdobeStockImageApi\Api;
 
 use Magento\AdobeStockAssetApi\Api\Data\AssetSearchResultsInterface;
 use Magento\Framework\Api\SearchCriteriaInterface;
-use Magento\Framework\Exception\LocalizedException;
 
 /**
  * Interface
@@ -22,9 +21,9 @@ interface GetImageListInterface
     /**
      * Search for images based on search criteria
      *
-     * @param SearchCriteriaInterface $searchCriteria
-     * @return AssetSearchResultsInterface
-     * @throws LocalizedException
+     * @param \Magento\Framework\Api\SearchCriteriaInterface $searchCriteria
+     * @return \Magento\AdobeStockAssetApi\Api\Data\AssetSearchResultsInterface
+     * @throws \Magento\Framework\Exception\LocalizedException
      */
     public function execute(SearchCriteriaInterface $searchCriteria): AssetSearchResultsInterface;
 }


### PR DESCRIPTION
The fully qualified namespace must be used or the web API throws an exception.

### Description (*)
The error occurs when using the Soap API.
![image](https://user-images.githubusercontent.com/31502344/61620656-f3093d00-ac79-11e9-9f12-5377aeedbfcc.png)

```
Report ID: webapi-5d357d08ce9e7; Message: The "AssetSearchResultsInterface" class doesn't exist and the namespace must be specified. Verify and try again.
```

### Manual testing scenarios (*)

1. Go to http://{magento url}/soap/default?wsdl=1&services=customerAccountManagementV1 

