### PR TITLE
Added WebAPI test for AssetRepository::getById

### DIFF
--- a/AdobeStockAsset/Test/Api/AssetRepository/GetByIdTest.php
+++ b/AdobeStockAsset/Test/Api/AssetRepository/GetByIdTest.php
@@ -1,0 +1,166 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Magento\AdobeStockAsset\Test\Api\AssetRepository;
+
+use Magento\AdobeStockAsset\Model\ResourceModel\Asset\Collection;
+use Magento\AdobeStockAsset\Model\ResourceModel\Asset\CollectionFactory;
+use Magento\AdobeStockAssetApi\Api\Data\AssetInterface;
+use Magento\Framework\ObjectManagerInterface;
+use Magento\Framework\Webapi\Exception;
+use Magento\Framework\Webapi\Rest\Request;
+use Magento\TestFramework\Helper\Bootstrap;
+use Magento\TestFramework\TestCase\WebapiAbstract;
+
+/**
+ * Class GetByIdTest
+ */
+class GetByIdTest extends WebapiAbstract
+{
+    /**
+     * Resource path
+     */
+    const RESOURCE_PATH = '/V1/adobestock/asset';
+
+    /**
+     * Service version
+     */
+    const SERVICE_VERSION = 'V1';
+
+    /**
+     * Service name
+     */
+    const SERVICE_NAME = 'adobeStockAssetApiAssetRepositoryV1';
+
+    /**
+     * Service operation
+     */
+    const SERVICE_OPERATION = 'GetById';
+
+    /**
+     * @var ObjectManagerInterface
+     */
+    private $objectManager;
+
+    /**
+     * @var Collection
+     */
+    private $assetCollectionFactory;
+
+    /**
+     * Set up
+     *
+     * @return void
+     */
+    public function setUp()
+    {
+        $this->objectManager = Bootstrap::getObjectManager();
+        $this->assetCollectionFactory = $this->objectManager->get(CollectionFactory::class);
+    }
+
+    /**
+     * Test get asset by id API with NoSuchEntityException
+     *
+     * @return void
+     * @throws \Exception
+     */
+    public function testGetNoSuchEntityException()
+    {
+        $notExistedAssetId = -1;
+        $serviceInfo = [
+            'rest' => [
+                'resourcePath' => self::RESOURCE_PATH . '/' . $notExistedAssetId,
+                'httpMethod' => Request::HTTP_METHOD_GET,
+            ],
+            'soap' => [
+                'service' => self::SERVICE_NAME,
+                'serviceVersion' => self::SERVICE_VERSION,
+                'operation' => self::SERVICE_NAME . self::SERVICE_OPERATION
+            ],
+        ];
+
+        $expectedMessage = 'Object with id "%1" does not exist.';
+
+        try {
+            if (TESTS_WEB_API_ADAPTER === self::ADAPTER_REST) {
+                $this->_webApiCall($serviceInfo);
+            } else {
+                $this->_webApiCall($serviceInfo, ['id' => $notExistedAssetId]);
+            }
+            $this->fail('Expected throwing exception');
+        } catch (\Exception $e) {
+            if (TESTS_WEB_API_ADAPTER === self::ADAPTER_REST) {
+                $errorData = $this->processRestExceptionResult($e);
+                self::assertEquals($expectedMessage, $errorData['message']);
+                self::assertEquals($notExistedAssetId, $errorData['parameters'][0]);
+                self::assertEquals(Exception::HTTP_NOT_FOUND, $e->getCode());
+            } elseif (TESTS_WEB_API_ADAPTER === self::ADAPTER_SOAP) {
+                $this->assertInstanceOf('SoapFault', $e);
+                $this->checkSoapFault($e, $expectedMessage, 'env:Sender', [1 => $notExistedAssetId]);
+            } else {
+                throw $e;
+            }
+        }
+    }
+
+    /**
+     * Test get by ID
+     *
+     * @magentoApiDataFixture assetFixtureProvider
+     *
+     * @return void
+     */
+    public function testGetAssetById()
+    {
+        $assetId = $this->getAssetId();
+        $serviceInfo = [
+            'rest' => [
+                'resourcePath' => self::RESOURCE_PATH . '/' . $assetId,
+                'httpMethod' => Request::HTTP_METHOD_GET,
+            ],
+            'soap' => [
+                'service' => self::SERVICE_NAME,
+                'serviceVersion' => self::SERVICE_VERSION,
+                'operation' => self::SERVICE_NAME . self::SERVICE_OPERATION,
+            ],
+        ];
+
+        if (TESTS_WEB_API_ADAPTER === self::ADAPTER_REST) {
+            $assetResultData = $this->_webApiCall($serviceInfo);
+        } else {
+            $assetResultData = $this->_webApiCall($serviceInfo, ['id' => $assetId]);
+        }
+
+        self::assertEquals($assetId, $assetResultData[AssetInterface::ID]);
+    }
+
+    /**
+     * Get asset id
+     *
+     * @return int
+     */
+    private function getAssetId(): int
+    {
+        /** @var Collection $collection */
+        $collection = $this->assetCollectionFactory->create();
+        /** @var AssetInterface $asset */
+        $asset = $collection->getLastItem();
+
+        return (int) $asset->getId();
+    }
+
+    /**
+     * Asset fixture provider
+     *
+     * @return void
+     */
+    public static function assetFixtureProvider()
+    {
+        require __DIR__ . '/../../_files/asset.php';
+    }
+}

--- a/AdobeStockAsset/Test/_files/asset.php
+++ b/AdobeStockAsset/Test/_files/asset.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+use Magento\AdobeStockAssetApi\Api\AssetRepositoryInterface;
+use Magento\AdobeStockAssetApi\Api\Data\AssetInterface;
+use Magento\AdobeStockAssetApi\Api\Data\AssetInterfaceFactory;
+use Magento\TestFramework\Helper\Bootstrap;
+
+$objectManager = Bootstrap::getObjectManager();
+/** @var AssetRepositoryInterface $assetRepository */
+$assetRepository = $objectManager->get(AssetRepositoryInterface::class);
+/** @var AssetInterfaceFactory $assetFactory */
+$assetFactory = $objectManager->get(AssetInterfaceFactory::class);
+/** @var AssetInterface $asset */
+$asset = $assetFactory->create();
+
+$asset->setAdobeId(1);
+$asset->setIsLicensed(1);
+$asset->setPreviewWidth(1);
+$asset->setPreviewHeight(1);
+$asset->setWidth(1);
+$asset->setHeight(1);
+
+$assetRepository->save($asset);

--- a/AdobeStockAsset/etc/acl.xml
+++ b/AdobeStockAsset/etc/acl.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Acl/etc/acl.xsd">
+    <acl>
+        <resources>
+            <resource id="Magento_Backend::admin">
+                <resource id="Magento_Backend::system">
+                    <resource id="Magento_AdobeStockAsset::adobe_stock_asset" title="Adobe Stock" translate="title" sortOrder="5">
+                        <resource id="Magento_AdobeStockAsset::actions" title="Actions" translate="title">
+                            <resource id="Magento_AdobeStockAsset::actions_get" title="Get" translate="title" />
+                        </resource>
+                    </resource>
+                </resource>
+            </resource>
+        </resources>
+    </acl>
+</config>

--- a/AdobeStockAsset/etc/webapi.xml
+++ b/AdobeStockAsset/etc/webapi.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<routes xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Webapi:etc/webapi.xsd">
+    <route url="/V1/adobestock/asset/:id" method="GET">
+        <service class="Magento\AdobeStockAssetApi\Api\AssetRepositoryInterface" method="getById"/>
+        <resources>
+            <resource ref="Magento_AdobeStockAsset::actions_get"/>
+        </resources>
+    </route>
+</routes>


### PR DESCRIPTION
### Description 
The WebAPI endpoint for `\Magento\AdobeStockAsset\Model\AssetRepository::getById` is declared and covered by WebAPI test.
*Notice* This PR is blocked by https://github.com/magento/adobe-stock-integration/pull/240 and https://github.com/magento/adobe-stock-integration/pull/241.

### Fixed Issues 

1. https://github.com/magento/adobe-stock-integration/issues/176: WebAPI for AssetRepository::getById

### Manual testing scenarios 

1. `vendor/bin/phpunit --configuration=./dev/tests/api-functional/phpunit_rest.xml ./app/code/Magento/AdobeStockAsset/Test/Api/AssetRepository/GetByIdTest.php`