### PR TITLE
#244 Removed scope label for Test Connection button

### DIFF
--- a/AdobeStockAsset/Model/Block/Adminhtml/System/Config/TestConnection.php
+++ b/AdobeStockAsset/Model/Block/Adminhtml/System/Config/TestConnection.php
@@ -22,6 +22,18 @@ class TestConnection extends Field
     protected $_template = 'Magento_AdobeStockAsset::system/config/testconnection.phtml';
 
     /**
+     * Remove element scope and render form element as HTML
+     *
+     * @param AbstractElement $element
+     * @return string
+     */
+    public function render(AbstractElement $element)
+    {
+        $element->setData('scope', null);
+        return parent::render($element);
+    }
+
+    /**
      * Get the button and scripts contents
      *
      * @param AbstractElement $element


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
The scope label has been removed for the "Test Connection" button.
![image](https://user-images.githubusercontent.com/31502344/61694870-0fb97980-ad3b-11e9-88cb-ad45c1a14e53.png)


### Fixed Issues 
1. https://github.com/magento/adobe-stock-integration/issues/244: Remove the "[global]" label next to "Test Connection" button

### Manual testing scenarios (*)
1. Go to Store > Configuration > Advanced > System > Adobe Stock Integration
2. Check scope label for the "Test Connection" button