### PR TITLE
Refactor: clean up the product image delete plugin and small fix for listing xml

### DIFF
--- a/AdobeStockAsset/Model/AssetRepository.php
+++ b/AdobeStockAsset/Model/AssetRepository.php
@@ -17,7 +17,6 @@ use Magento\AdobeStockAssetApi\Api\Data\AssetSearchResultsInterface;
 use Magento\AdobeStockAssetApi\Api\Data\AssetSearchResultsInterfaceFactory;
 use Magento\Framework\Api\ExtensionAttribute\JoinProcessorInterface;
 use Magento\Framework\Api\SearchCriteria\CollectionProcessorInterface;
-use Magento\Framework\Api\SearchCriteriaBuilderFactory;
 use Magento\Framework\Api\SearchCriteriaInterface;
 use Magento\Framework\Exception\NoSuchEntityException;
 

--- a/AdobeStockAsset/Model/Config.php
+++ b/AdobeStockAsset/Model/Config.php
@@ -15,6 +15,9 @@ use Magento\Framework\App\Config\ScopeConfigInterface;
  */
 class Config
 {
+    /**
+     * Path to enable/disable adobe stock integration in the system settings.
+     */
     private const XML_PATH_ENABLED = 'adobe_stock/integration/enabled';
 
     /**
@@ -39,6 +42,6 @@ class Config
      */
     public function isEnabled(): bool
     {
-        return (bool)$this->scopeConfig->getValue(self::XML_PATH_ENABLED);
+        return (bool)$this->scopeConfig->isSetFlag(self::XML_PATH_ENABLED);
     }
 }

--- a/AdobeStockAsset/Model/Config.php
+++ b/AdobeStockAsset/Model/Config.php
@@ -42,6 +42,6 @@ class Config
      */
     public function isEnabled(): bool
     {
-        return (bool)$this->scopeConfig->isSetFlag(self::XML_PATH_ENABLED);
+        return $this->scopeConfig->isSetFlag(self::XML_PATH_ENABLED);
     }
 }

--- a/AdobeStockAssetApi/Api/Data/AssetSearchResultsInterface.php
+++ b/AdobeStockAssetApi/Api/Data/AssetSearchResultsInterface.php
@@ -7,7 +7,7 @@
 namespace Magento\AdobeStockAssetApi\Api\Data;
 
 /**
- * Interface AssetRepositoryInterface
+ * Interface AssetSearchResultsInterface
  * @api
  */
 interface AssetSearchResultsInterface extends \Magento\Framework\Api\SearchResultsInterface

--- a/AdobeStockImage/Test/Unit/Plugin/Product/Gallery/ProcessorTest.php
+++ b/AdobeStockImage/Test/Unit/Plugin/Product/Gallery/ProcessorTest.php
@@ -4,7 +4,14 @@
  * See COPYING.txt for license details.
  */
 
+declare(strict_types=1);
+
 namespace Magento\AdobeStockImage\Test\Unit\Plugin\Product\Gallery;
+
+use Magento\Framework\Api\SearchCriteriaBuilderFactory;
+use Magento\AdobeStockAssetApi\Api\AssetRepositoryInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
 
 /**
  * Test for the Gallery Processor Plugin (ensures that metadata is remove from the database when image is deleted)
@@ -21,15 +28,11 @@ class ProcessorTest extends \PHPUnit\Framework\TestCase
      */
     private $assetRepositoryMock;
 
-    /**
-     * @var \PHPUnit\Framework\MockObject\MockObject
-     */
-    private $filterBuilderMock;
+    /** @var \Magento\Framework\Api\SearchCriteriaBuilder|\PHPUnit_Framework_MockObject_MockObject */
+    protected $searchCriteriaBuilderMock;
 
-    /**
-     * @var \PHPUnit\Framework\MockObject\MockObject
-     */
-    private $searchCriteriaBuilderMock;
+    /** @var  LoggerInterface|\PHPUnit_Framework_MockObject_MockObject */
+    private $loggerMock;
 
     /**
      * @inheritdoc
@@ -37,18 +40,29 @@ class ProcessorTest extends \PHPUnit\Framework\TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->assetRepositoryMock = $this->createMock(\Magento\AdobeStockAssetApi\Api\AssetRepositoryInterface::class);
-        $this->filterBuilderMock = $this->createMock(\Magento\Framework\Api\FilterBuilder::class);
-        $this->searchCriteriaBuilderMock = $this->createMock(
-            \Magento\Framework\Api\SearchCriteriaBuilderFactory::class
+        $this->assetRepositoryMock = $this->createMock(
+            AssetRepositoryInterface::class
         );
+        $this->searchCriteriaBuilderMock = $this->createMock(
+            SearchCriteriaBuilderFactory::class
+        );
+        $this->loggerMock = $this->getMockBuilder(LoggerInterface::class)
+            ->setMethods(['critical'])
+            ->disableOriginalConstructor()
+            ->getMockForAbstractClass();
+
         $this->model = new \Magento\AdobeStockImage\Plugin\Product\Gallery\Processor(
             $this->assetRepositoryMock,
-            $this->filterBuilderMock,
-            $this->searchCriteriaBuilderMock
+            $this->searchCriteriaBuilderMock,
+            $this->loggerMock
         );
     }
 
+    /**
+     * Test afterRemoveImage if file path is null.
+     *
+     * @throws \ReflectionException
+     */
     public function testAfterRemoveImageIfPathIsNull()
     {
         $resultMock = $this->createMock(\Magento\Catalog\Model\Product\Gallery\Processor::class);
@@ -62,38 +76,17 @@ class ProcessorTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($result, $resultMock);
     }
 
-    public function testAfterRemoveImage()
+    /**
+     * Test successful afterRemoveImage method.
+     *
+     * @throws \ReflectionException
+     */
+    public function testSuccessfulAfterRemoveImage()
     {
         $filePath = 'file/path';
+        $this->setupSuccessAssetSearchAndDelete();
         $resultMock = $this->createMock(\Magento\Catalog\Model\Product\Gallery\Processor::class);
         $productMock = $this->createMock(\Magento\Catalog\Model\Product::class);
-
-        $filterMock = $this->createMock(\Magento\Framework\Api\Filter::class);
-        $this->filterBuilderMock->method('setField')->with('path')->willReturnSelf();
-        $this->filterBuilderMock->method('setConditionType')->with('eq')->willReturnSelf();
-        $this->filterBuilderMock->method('setValue')->with($filePath)->willReturnSelf();
-        $this->filterBuilderMock->method('create')->willReturn($filterMock);
-
-        $searchCriteriaBuilder = $this->createMock(\Magento\Framework\Api\SearchCriteriaBuilder::class);
-        $this->searchCriteriaBuilderMock->expects($this->once())->method('create')->willReturn($searchCriteriaBuilder);
-        $searchCriteriaBuilder->expects($this->once())->method('addFilters')->with([$filterMock])->willReturnSelf();
-
-        $searchCriteriaMock = $this->createMock(\Magento\Framework\Api\SearchCriteria::class);
-        $searchCriteriaBuilder->expects($this->once())->method('create')->willReturn($searchCriteriaMock);
-
-        $assetMock = $this->createMock(\Magento\AdobeStockAssetApi\Api\Data\AssetInterface::class);
-        $searchResultMock = $this->createMock(\Magento\AdobeStockAssetApi\Api\Data\AssetSearchResultsInterface::class);
-        $searchResultMock->expects($this->once())->method('getItems')->willReturn([$assetMock]);
-
-        $this->assetRepositoryMock->expects($this->once())
-            ->method('getList')
-            ->with($searchCriteriaMock)
-            ->willReturn($searchResultMock);
-
-        $this->assetRepositoryMock->expects($this->once())
-            ->method('delete')
-            ->with($assetMock);
-
         $result = $this->model->afterRemoveImage(
             $this->createMock(\Magento\Catalog\Model\Product\Gallery\Processor::class),
             $resultMock,
@@ -102,5 +95,84 @@ class ProcessorTest extends \PHPUnit\Framework\TestCase
         );
 
         $this->assertEquals($result, $resultMock);
+    }
+
+    /**
+     * Test failed getList AssertRepository scenario.
+     *
+     * @throws \ReflectionException
+     */
+    public function testFailedAfterRemoveImage()
+    {
+        $filePath = 'file/path';
+        $this->setupFailedAssetSearchAndDelete();
+        $resultMock = $this->createMock(\Magento\Catalog\Model\Product\Gallery\Processor::class);
+        $productMock = $this->createMock(\Magento\Catalog\Model\Product::class);
+        $result = $this->model->afterRemoveImage(
+            $this->createMock(\Magento\Catalog\Model\Product\Gallery\Processor::class),
+            $resultMock,
+            $productMock,
+            $filePath
+        );
+
+        $this->assertEquals($result, $resultMock);
+    }
+
+    /**
+     * Setup the successful asset search and delete mock.
+     *
+     * @throws \ReflectionException
+     */
+    private function setupSuccessAssetSearchAndDelete(): void
+    {
+        $searchCriteriaMock = $this->getSearchCriteriaMock();
+        $assetMock = $this->createMock(\Magento\AdobeStockAssetApi\Api\Data\AssetInterface::class);
+        $searchResultMock = $this->createMock(\Magento\AdobeStockAssetApi\Api\Data\AssetSearchResultsInterface::class);
+        $searchResultMock->expects($this->once())->method('getItems')->willReturn([$assetMock]);
+        $this->assetRepositoryMock->expects($this->once())
+            ->method('getList')
+            ->with($searchCriteriaMock)
+            ->willReturn($searchResultMock);
+
+        $this->assetRepositoryMock->expects($this->once())
+            ->method('delete')
+            ->with($assetMock);
+    }
+
+    /**
+     * Setup the failed asset search and delete mock.
+     *
+     * @throws \ReflectionException
+     */
+    private function setupFailedAssetSearchAndDelete(): void
+    {
+        $searchCriteriaMock = $this->getSearchCriteriaMock();
+        $this->assetRepositoryMock->expects($this->once())
+            ->method('getList')
+            ->with($searchCriteriaMock)
+            ->willThrowException(new \Exception('Test error text'));
+    }
+
+    /**
+     * Get search criteria mock object.
+     *
+     * @return \PHPUnit\Framework\MockObject\MockObject
+     * @throws \ReflectionException
+     */
+    private function getSearchCriteriaMock()
+    {
+        $filePath = 'file/path';
+        $searchCriteriaBuilder = $this->createMock(\Magento\Framework\Api\SearchCriteriaBuilder::class);
+        $this->searchCriteriaBuilderMock->expects($this->once())->method('create')->willReturn($searchCriteriaBuilder);
+
+        $searchCriteriaBuilder->expects($this->once())
+            ->method('addFilter')
+            ->with('path', $filePath)
+            ->willReturnSelf();
+
+        $searchCriteriaMock = $this->createMock(\Magento\Framework\Api\SearchCriteria::class);
+        $searchCriteriaBuilder->expects($this->once())->method('create')->willReturn($searchCriteriaMock);
+
+        return $searchCriteriaMock;
     }
 }

--- a/AdobeStockImageAdminUi/view/adminhtml/ui_component/adobe_stock_images_listing.xml
+++ b/AdobeStockImageAdminUi/view/adminhtml/ui_component/adobe_stock_images_listing.xml
@@ -70,7 +70,7 @@
                     <dataScope>content_type_filter</dataScope>
                 </settings>
             </filterSelect>
-            <filterSelect name="orientation_filter" provider="${ $.parentName }">
+            <filterSelect name="orientation_filter" provider="${ $.parentName }" sortOrder="20">
                 <settings>
                     <caption translate="true">All</caption>
                     <options class="Magento\AdobeStockImageAdminUi\Ui\Component\Listing\Columns\Orientation\Options"/>


### PR DESCRIPTION
### Description
The main goal of this PR is to refactor the `AdobeStockImage\Plugin\Product\Gallery\Processor` with the next changes:

* Change visibility scope from protected to private for properties
* Use only search criteria builder factory with the `addFilter` instead of injecting filter builder and use `addFilters` (we have the only one - path :) )
* Log an exception if any appeared during the plugin method run
* Adjust Unit Tests according to the refactored changes
* Set a sort order 
* Remove unused connection of a class at `AssetRepository`

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios (*)
N/A