### PR TITLE
Adjust WebApi tests for AdobeStockAsset module

### DIFF
--- a/AdobeStockAsset/Model/Asset.php
+++ b/AdobeStockAsset/Model/Asset.php
@@ -53,15 +53,21 @@ class Asset extends AbstractExtensibleModel implements AssetInterface
     /**
      * @inheritdoc
      */
-    public function getMediaTypeId(): int
+    public function getMediaTypeId(): ?int
     {
-        return (int) $this->getData(self::MEDIA_TYPE_ID);
+        $mediaTypeId = $this->getData(self::MEDIA_TYPE_ID);
+
+        if (!$mediaTypeId) {
+            return null;
+        }
+
+        return (int) $mediaTypeId;
     }
 
     /**
      * @inheritdoc
      */
-    public function setMediaTypeId(int $mediaTypeId): void
+    public function setMediaTypeId(int $mediaTypeId = null): void
     {
         $this->setData(self::MEDIA_TYPE_ID, $mediaTypeId);
     }
@@ -117,15 +123,21 @@ class Asset extends AbstractExtensibleModel implements AssetInterface
     /**
      * @inheritdoc
      */
-    public function getPremiumLevelId(): int
+    public function getPremiumLevelId(): ?int
     {
-        return (int) $this->getData(self::PREMIUM_LEVEL_ID);
+        $premiumLevelId = $this->getData(self::PREMIUM_LEVEL_ID);
+
+        if (!$premiumLevelId) {
+            return null;
+        }
+
+        return (int) $premiumLevelId;
     }
 
     /**
      * @inheritdoc
      */
-    public function setPremiumLevelId(int $premiumLevelId): void
+    public function setPremiumLevelId(int $premiumLevelId = null): void
     {
         $this->setData(self::PREMIUM_LEVEL_ID, $premiumLevelId);
     }

--- a/AdobeStockAsset/Model/Asset.php
+++ b/AdobeStockAsset/Model/Asset.php
@@ -55,19 +55,13 @@ class Asset extends AbstractExtensibleModel implements AssetInterface
      */
     public function getMediaTypeId(): ?int
     {
-        $mediaTypeId = $this->getData(self::MEDIA_TYPE_ID);
-
-        if (!$mediaTypeId) {
-            return null;
-        }
-
-        return (int) $mediaTypeId;
+        return $this->hasData(self::MEDIA_TYPE_ID) ? (int) $this->getData(self::MEDIA_TYPE_ID) : null;
     }
 
     /**
      * @inheritdoc
      */
-    public function setMediaTypeId(int $mediaTypeId = null): void
+    public function setMediaTypeId(?int $mediaTypeId): void
     {
         $this->setData(self::MEDIA_TYPE_ID, $mediaTypeId);
     }
@@ -125,19 +119,13 @@ class Asset extends AbstractExtensibleModel implements AssetInterface
      */
     public function getPremiumLevelId(): ?int
     {
-        $premiumLevelId = $this->getData(self::PREMIUM_LEVEL_ID);
-
-        if (!$premiumLevelId) {
-            return null;
-        }
-
-        return (int) $premiumLevelId;
+        return $this->hasData(self::PREMIUM_LEVEL_ID) ? (int) $this->getData(self::PREMIUM_LEVEL_ID) : null;
     }
 
     /**
      * @inheritdoc
      */
-    public function setPremiumLevelId(int $premiumLevelId = null): void
+    public function setPremiumLevelId(?int $premiumLevelId): void
     {
         $this->setData(self::PREMIUM_LEVEL_ID, $premiumLevelId);
     }

--- a/AdobeStockAsset/Model/AssetRepository.php
+++ b/AdobeStockAsset/Model/AssetRepository.php
@@ -82,15 +82,15 @@ class AssetRepository implements AssetRepositoryInterface
     }
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
-    public function save(AssetInterface $item): void
+    public function save(AssetInterface $asset): void
     {
-        $this->resource->save($item);
+        $this->resource->save($asset);
     }
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     public function delete(AssetInterface $item): void
     {
@@ -98,7 +98,7 @@ class AssetRepository implements AssetRepositoryInterface
     }
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     public function getList(SearchCriteriaInterface $searchCriteria) : AssetSearchResultsInterface
     {
@@ -120,7 +120,7 @@ class AssetRepository implements AssetRepositoryInterface
     }
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     public function getById(int $id) : AssetInterface
     {
@@ -133,7 +133,7 @@ class AssetRepository implements AssetRepositoryInterface
     }
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     public function deleteById(int $id): void
     {

--- a/AdobeStockAsset/Model/AssetRepository.php
+++ b/AdobeStockAsset/Model/AssetRepository.php
@@ -81,7 +81,7 @@ class AssetRepository implements AssetRepositoryInterface
     }
 
     /**
-     * @inheritDoc
+     * @inheritdoc
      */
     public function save(AssetInterface $asset): void
     {
@@ -89,7 +89,7 @@ class AssetRepository implements AssetRepositoryInterface
     }
 
     /**
-     * @inheritDoc
+     * @inheritdoc
      */
     public function delete(AssetInterface $item): void
     {
@@ -97,7 +97,7 @@ class AssetRepository implements AssetRepositoryInterface
     }
 
     /**
-     * @inheritDoc
+     * @inheritdoc
      */
     public function getList(SearchCriteriaInterface $searchCriteria) : AssetSearchResultsInterface
     {
@@ -119,7 +119,7 @@ class AssetRepository implements AssetRepositoryInterface
     }
 
     /**
-     * @inheritDoc
+     * @inheritdoc
      */
     public function getById(int $id) : AssetInterface
     {
@@ -132,7 +132,7 @@ class AssetRepository implements AssetRepositoryInterface
     }
 
     /**
-     * @inheritDoc
+     * @inheritdoc
      */
     public function deleteById(int $id): void
     {

--- a/AdobeStockAsset/Model/ResourceModel/UserProfile.php
+++ b/AdobeStockAsset/Model/ResourceModel/UserProfile.php
@@ -16,7 +16,7 @@ use Magento\Framework\Model\ResourceModel\Db\AbstractDb;
 class UserProfile extends AbstractDb
 {
     /**
-     * @inheritDoc
+     * @inheritdoc
      */
     protected function _construct()
     {

--- a/AdobeStockAsset/Model/ResourceModel/UserProfile/Collection.php
+++ b/AdobeStockAsset/Model/ResourceModel/UserProfile/Collection.php
@@ -18,7 +18,7 @@ use Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection;
 class Collection extends AbstractCollection
 {
     /**
-     * @inheritDoc
+     * @inheritdoc
      */
     protected function _construct()
     {

--- a/AdobeStockAsset/Test/Api/AssetRepository/DeleteTest.php
+++ b/AdobeStockAsset/Test/Api/AssetRepository/DeleteTest.php
@@ -24,22 +24,22 @@ class DeleteTest extends WebapiAbstract
     /**
      * Service name
      */
-    const SERVICE_NAME = 'adobeStockAssetApiAssetRepositoryV1';
+    private const SERVICE_NAME = 'adobeStockAssetApiAssetRepositoryV1';
 
     /**
      * Service version
      */
-    const SERVICE_VERSION = 'V1';
+    private const SERVICE_VERSION = 'V1';
 
     /**
      * Resource path
      */
-    const RESOURCE_PATH = '/V1/adobestock/asset';
+    private const RESOURCE_PATH = '/V1/adobestock/asset';
 
     /**
      * Service operation
      */
-    const SERVICE_OPERATION = 'DeleteById';
+    private const SERVICE_OPERATION = 'DeleteById';
 
     /**
      * @var ObjectManagerInterface

--- a/AdobeStockAsset/Test/Api/AssetRepository/DeleteTest.php
+++ b/AdobeStockAsset/Test/Api/AssetRepository/DeleteTest.php
@@ -37,11 +37,6 @@ class DeleteTest extends WebapiAbstract
     const RESOURCE_PATH = '/V1/adobestock/asset';
 
     /**
-     * Service operation
-     */
-    const SERVICE_OPERATION = 'DeleteById';
-
-    /**
      * @var ObjectManagerInterface
      */
     private $objectManager;
@@ -112,12 +107,12 @@ class DeleteTest extends WebapiAbstract
         $serviceInfo = [
             'rest' => [
                 'resourcePath' => self::RESOURCE_PATH . DIRECTORY_SEPARATOR . $assetId,
-                'httpMethod'   => Request::HTTP_METHOD_DELETE,
+                'httpMethod' => Request::HTTP_METHOD_DELETE,
             ],
             'soap' => [
                 'service' => self::SERVICE_NAME,
                 'serviceVersion' => self::SERVICE_VERSION,
-                'operation' => self::SERVICE_NAME . self::SERVICE_OPERATION
+                'operation' => self::SERVICE_NAME . 'DeleteById'
             ],
         ];
 

--- a/AdobeStockAsset/Test/Api/AssetRepository/DeleteTest.php
+++ b/AdobeStockAsset/Test/Api/AssetRepository/DeleteTest.php
@@ -37,6 +37,11 @@ class DeleteTest extends WebapiAbstract
     const RESOURCE_PATH = '/V1/adobestock/asset';
 
     /**
+     * Service operation
+     */
+    const SERVICE_OPERATION = 'DeleteById';
+
+    /**
      * @var ObjectManagerInterface
      */
     private $objectManager;
@@ -107,12 +112,12 @@ class DeleteTest extends WebapiAbstract
         $serviceInfo = [
             'rest' => [
                 'resourcePath' => self::RESOURCE_PATH . DIRECTORY_SEPARATOR . $assetId,
-                'httpMethod' => Request::HTTP_METHOD_DELETE,
+                'httpMethod'   => Request::HTTP_METHOD_DELETE,
             ],
             'soap' => [
                 'service' => self::SERVICE_NAME,
                 'serviceVersion' => self::SERVICE_VERSION,
-                'operation' => self::SERVICE_NAME . 'DeleteById'
+                'operation' => self::SERVICE_NAME . self::SERVICE_OPERATION
             ],
         ];
 

--- a/AdobeStockAsset/Test/Api/AssetRepository/GetByIdTest.php
+++ b/AdobeStockAsset/Test/Api/AssetRepository/GetByIdTest.php
@@ -38,11 +38,6 @@ class GetByIdTest extends WebapiAbstract
     const SERVICE_NAME = 'adobeStockAssetApiAssetRepositoryV1';
 
     /**
-     * Service operation
-     */
-    const SERVICE_OPERATION = 'GetById';
-
-    /**
      * @var ObjectManagerInterface
      */
     private $objectManager;
@@ -80,7 +75,7 @@ class GetByIdTest extends WebapiAbstract
             'soap' => [
                 'service' => self::SERVICE_NAME,
                 'serviceVersion' => self::SERVICE_VERSION,
-                'operation' => self::SERVICE_NAME . self::SERVICE_OPERATION
+                'operation' => self::SERVICE_NAME . 'GetById'
             ],
         ];
 
@@ -126,7 +121,7 @@ class GetByIdTest extends WebapiAbstract
             'soap' => [
                 'service' => self::SERVICE_NAME,
                 'serviceVersion' => self::SERVICE_VERSION,
-                'operation' => self::SERVICE_NAME . self::SERVICE_OPERATION,
+                'operation' => self::SERVICE_NAME . 'GetById',
             ],
         ];
 

--- a/AdobeStockAsset/Test/Api/AssetRepository/GetByIdTest.php
+++ b/AdobeStockAsset/Test/Api/AssetRepository/GetByIdTest.php
@@ -74,7 +74,7 @@ class GetByIdTest extends WebapiAbstract
         $notExistedAssetId = -1;
         $serviceInfo = [
             'rest' => [
-                'resourcePath' => self::RESOURCE_PATH . '/' . $notExistedAssetId,
+                'resourcePath' => self::RESOURCE_PATH . DIRECTORY_SEPARATOR . $notExistedAssetId,
                 'httpMethod' => Request::HTTP_METHOD_GET,
             ],
             'soap' => [
@@ -90,7 +90,7 @@ class GetByIdTest extends WebapiAbstract
             if (TESTS_WEB_API_ADAPTER === self::ADAPTER_REST) {
                 $this->_webApiCall($serviceInfo);
             } else {
-                $this->_webApiCall($serviceInfo, ['id' => $notExistedAssetId]);
+                $this->_webApiCall($serviceInfo, [AssetInterface::ID => $notExistedAssetId]);
             }
             $this->fail('Expected throwing exception');
         } catch (\Exception $e) {
@@ -133,7 +133,7 @@ class GetByIdTest extends WebapiAbstract
         if (TESTS_WEB_API_ADAPTER === self::ADAPTER_REST) {
             $assetResultData = $this->_webApiCall($serviceInfo);
         } else {
-            $assetResultData = $this->_webApiCall($serviceInfo, ['id' => $assetId]);
+            $assetResultData = $this->_webApiCall($serviceInfo, [AssetInterface::ID => $assetId]);
         }
 
         self::assertEquals($assetId, $assetResultData[AssetInterface::ID]);

--- a/AdobeStockAsset/Test/Api/AssetRepository/GetByIdTest.php
+++ b/AdobeStockAsset/Test/Api/AssetRepository/GetByIdTest.php
@@ -38,6 +38,11 @@ class GetByIdTest extends WebapiAbstract
     const SERVICE_NAME = 'adobeStockAssetApiAssetRepositoryV1';
 
     /**
+     * Service operation
+     */
+    const SERVICE_OPERATION = 'GetById';
+
+    /**
      * @var ObjectManagerInterface
      */
     private $objectManager;
@@ -75,7 +80,7 @@ class GetByIdTest extends WebapiAbstract
             'soap' => [
                 'service' => self::SERVICE_NAME,
                 'serviceVersion' => self::SERVICE_VERSION,
-                'operation' => self::SERVICE_NAME . 'GetById'
+                'operation' => self::SERVICE_NAME . self::SERVICE_OPERATION
             ],
         ];
 
@@ -121,7 +126,7 @@ class GetByIdTest extends WebapiAbstract
             'soap' => [
                 'service' => self::SERVICE_NAME,
                 'serviceVersion' => self::SERVICE_VERSION,
-                'operation' => self::SERVICE_NAME . 'GetById',
+                'operation' => self::SERVICE_NAME . self::SERVICE_OPERATION,
             ],
         ];
 

--- a/AdobeStockAsset/Test/Api/AssetRepository/SaveTest.php
+++ b/AdobeStockAsset/Test/Api/AssetRepository/SaveTest.php
@@ -96,7 +96,6 @@ class SaveTest extends WebapiAbstract
                         AssetInterface::HEIGHT => '800',
                         AssetInterface::PREVIEW_WIDTH => '500',
                         AssetInterface::PREVIEW_HEIGHT => '400',
-                        AssetInterface::URL => uniqid('url'),
                         AssetInterface::PREVIEW_URL => uniqid('preview-url'),
                         AssetInterface::DETAILS_URL => uniqid('details-url'),
                     ]

--- a/AdobeStockAsset/Test/Api/AssetRepository/SaveTest.php
+++ b/AdobeStockAsset/Test/Api/AssetRepository/SaveTest.php
@@ -37,11 +37,6 @@ class SaveTest extends WebapiAbstract
     const RESOURCE_PATH = '/V1/adobestock/asset';
 
     /**
-     * Service operation
-     */
-    const SERVICE_OPERATION = 'Save';
-
-    /**
      * @var ObjectManagerInterface
      */
     private $objectManager;
@@ -148,7 +143,7 @@ class SaveTest extends WebapiAbstract
             'soap' => [
                 'service' => self::SERVICE_NAME,
                 'serviceVersion' => self::SERVICE_VERSION,
-                'operation' => self::SERVICE_NAME . self::SERVICE_OPERATION,
+                'operation' => self::SERVICE_NAME . 'Save',
             ],
         ];
         $requestData = ['asset' => $data];

--- a/AdobeStockAsset/Test/Api/AssetRepository/SaveTest.php
+++ b/AdobeStockAsset/Test/Api/AssetRepository/SaveTest.php
@@ -24,22 +24,22 @@ class SaveTest extends WebapiAbstract
     /**
      * Service name
      */
-    const SERVICE_NAME = 'adobeStockAssetApiAssetRepositoryV1';
+    private const SERVICE_NAME = 'adobeStockAssetApiAssetRepositoryV1';
 
     /**
      * Service version
      */
-    const SERVICE_VERSION = 'V1';
+    private const SERVICE_VERSION = 'V1';
 
     /**
      * Resource path
      */
-    const RESOURCE_PATH = '/V1/adobestock/asset';
+    private const RESOURCE_PATH = '/V1/adobestock/asset';
 
     /**
      * Service operation
      */
-    const SERVICE_OPERATION = 'Save';
+    private const SERVICE_OPERATION = 'Save';
 
     /**
      * @var ObjectManagerInterface

--- a/AdobeStockAsset/Test/Api/AssetRepository/SaveTest.php
+++ b/AdobeStockAsset/Test/Api/AssetRepository/SaveTest.php
@@ -21,9 +21,25 @@ use Magento\TestFramework\TestCase\WebapiAbstract;
  */
 class SaveTest extends WebapiAbstract
 {
-    const SERVICE_NAME = 'adobeStockAssetRepositoryV1';
+    /**
+     * Service name
+     */
+    const SERVICE_NAME = 'adobeStockAssetApiAssetRepositoryV1';
+
+    /**
+     * Service version
+     */
     const SERVICE_VERSION = 'V1';
+
+    /**
+     * Resource path
+     */
     const RESOURCE_PATH = '/V1/adobestock/asset';
+
+    /**
+     * Service operation
+     */
+    const SERVICE_OPERATION = 'Save';
 
     /**
      * @var ObjectManagerInterface
@@ -55,8 +71,14 @@ class SaveTest extends WebapiAbstract
         $this->saveAsset($data);
         /** @var Asset $asset */
         $asset = $this->getSavedAsset($data[AssetInterface::ADOBE_ID]);
+        $uniqueData = [
+            AssetInterface::ADOBE_ID => $data[AssetInterface::ADOBE_ID],
+            AssetInterface::PATH => $data[AssetInterface::PATH],
+            AssetInterface::PREVIEW_URL => $data[AssetInterface::PREVIEW_URL],
+            AssetInterface::DETAILS_URL => $data[AssetInterface::DETAILS_URL]
+        ];
 
-        $this->assertArraySubset($data, $asset->getData());
+        $this->assertArraySubset($uniqueData, $asset->getData());
     }
 
     /**
@@ -64,6 +86,24 @@ class SaveTest extends WebapiAbstract
      */
     public function assetDataProvider()
     {
+        if (TESTS_WEB_API_ADAPTER === self::ADAPTER_REST) {
+            return [
+                [
+                    [
+                        AssetInterface::ADOBE_ID => (string) mt_rand(9999, 99999),
+                        AssetInterface::PATH => uniqid() . '/file-path.png',
+                        AssetInterface::WIDTH => '1000',
+                        AssetInterface::HEIGHT => '800',
+                        AssetInterface::PREVIEW_WIDTH => '500',
+                        AssetInterface::PREVIEW_HEIGHT => '400',
+                        AssetInterface::URL => uniqid('url'),
+                        AssetInterface::PREVIEW_URL => uniqid('preview-url'),
+                        AssetInterface::DETAILS_URL => uniqid('details-url'),
+                    ]
+                ]
+            ];
+        }
+
         return [
             [
                 [
@@ -73,8 +113,22 @@ class SaveTest extends WebapiAbstract
                     AssetInterface::HEIGHT => '800',
                     AssetInterface::PREVIEW_WIDTH => '500',
                     AssetInterface::PREVIEW_HEIGHT => '400',
+                    AssetInterface::MEDIA_TYPE_ID => null,
+                    AssetInterface::KEYWORDS => [],
+                    AssetInterface::PREMIUM_LEVEL_ID => null,
+                    AssetInterface::STOCK_ID => 1,
+                    AssetInterface::TITLE => 'Title',
+                    AssetInterface::URL => uniqid('preview-url'),
+                    AssetInterface::COUNTRY_NAME => '',
+                    AssetInterface::VECTOR_TYPE => '',
+                    AssetInterface::CONTENT_TYPE => '',
+                    AssetInterface::CREATION_DATE => '',
+                    AssetInterface::CREATED_AT => '',
+                    AssetInterface::UPDATED_AT => '',
                     AssetInterface::PREVIEW_URL => uniqid('preview-url'),
                     AssetInterface::DETAILS_URL => uniqid('details-url'),
+                    AssetInterface::IS_LICENSED => 1,
+                    'licensed' => 1,
                 ]
             ]
         ];
@@ -95,13 +149,12 @@ class SaveTest extends WebapiAbstract
             'soap' => [
                 'service' => self::SERVICE_NAME,
                 'serviceVersion' => self::SERVICE_VERSION,
-                'operation' => self::SERVICE_NAME . 'save',
+                'operation' => self::SERVICE_NAME . self::SERVICE_OPERATION,
             ],
         ];
+        $requestData = ['asset' => $data];
 
-        $requestData = ['item' => $data];
-
-        return $this->_webApiCall($serviceInfo, $requestData, null);
+        return $this->_webApiCall($serviceInfo, $requestData);
     }
 
     /**

--- a/AdobeStockAsset/Test/Api/AssetRepository/SaveTest.php
+++ b/AdobeStockAsset/Test/Api/AssetRepository/SaveTest.php
@@ -37,6 +37,11 @@ class SaveTest extends WebapiAbstract
     const RESOURCE_PATH = '/V1/adobestock/asset';
 
     /**
+     * Service operation
+     */
+    const SERVICE_OPERATION = 'Save';
+
+    /**
      * @var ObjectManagerInterface
      */
     private $objectManager;
@@ -143,7 +148,7 @@ class SaveTest extends WebapiAbstract
             'soap' => [
                 'service' => self::SERVICE_NAME,
                 'serviceVersion' => self::SERVICE_VERSION,
-                'operation' => self::SERVICE_NAME . 'Save',
+                'operation' => self::SERVICE_NAME . self::SERVICE_OPERATION,
             ],
         ];
         $requestData = ['asset' => $data];

--- a/AdobeStockAssetApi/Api/AssetRepositoryInterface.php
+++ b/AdobeStockAssetApi/Api/AssetRepositoryInterface.php
@@ -21,11 +21,11 @@ interface AssetRepositoryInterface
     /**
      * Save asset
      *
-     * @param \Magento\AdobeStockAssetApi\Api\Data\AssetInterface $item
+     * @param \Magento\AdobeStockAssetApi\Api\Data\AssetInterface $asset
      * @return void
      * @throws \Magento\Framework\Exception\AlreadyExistsException
      */
-    public function save(AssetInterface $item): void;
+    public function save(AssetInterface $asset): void;
 
     /**
      * Delete item

--- a/AdobeStockAssetApi/Api/Data/AssetInterface.php
+++ b/AdobeStockAssetApi/Api/Data/AssetInterface.php
@@ -134,7 +134,7 @@ interface AssetInterface extends \Magento\Framework\Api\ExtensibleDataInterface
      * @param int|null $mediaTypeId
      * @return void
      */
-    public function setMediaTypeId(int $mediaTypeId = null): void;
+    public function setMediaTypeId(?int $mediaTypeId): void;
 
     /**
      * Get category
@@ -194,7 +194,7 @@ interface AssetInterface extends \Magento\Framework\Api\ExtensibleDataInterface
      * @param int|null $premiumLevelId
      * @return void
      */
-    public function setPremiumLevelId(int $premiumLevelId = null): void;
+    public function setPremiumLevelId(?int $premiumLevelId): void;
 
     /**
      * Get adobe id

--- a/AdobeStockAssetApi/Api/Data/AssetInterface.php
+++ b/AdobeStockAssetApi/Api/Data/AssetInterface.php
@@ -124,17 +124,17 @@ interface AssetInterface extends \Magento\Framework\Api\ExtensibleDataInterface
     /**
      * Get media type id
      *
-     * @return int
+     * @return int|null
      */
-    public function getMediaTypeId(): int;
+    public function getMediaTypeId(): ?int;
 
     /**
      * Set media type id
      *
-     * @param int $mediaTypeId
+     * @param int|null $mediaTypeId
      * @return void
      */
-    public function setMediaTypeId(int $mediaTypeId): void;
+    public function setMediaTypeId(int $mediaTypeId = null): void;
 
     /**
      * Get category
@@ -184,17 +184,17 @@ interface AssetInterface extends \Magento\Framework\Api\ExtensibleDataInterface
     /**
      * Get premium level id
      *
-     * @return int
+     * @return int|null
      */
-    public function getPremiumLevelId(): int;
+    public function getPremiumLevelId(): ?int;
 
     /**
      * Set premium level id
      *
-     * @param int $premiumLevelId
+     * @param int|null $premiumLevelId
      * @return void
      */
-    public function setPremiumLevelId(int $premiumLevelId): void;
+    public function setPremiumLevelId(int $premiumLevelId = null): void;
 
     /**
      * Get adobe id

--- a/AdobeStockClient/Model/Client.php
+++ b/AdobeStockClient/Model/Client.php
@@ -231,7 +231,7 @@ class Client implements ClientInterface
     }
 
     /**
-     * @inheritDoc
+     * @inheritdoc
      */
     public function getToken(string $code): OAuth\TokenResponse
     {

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/sorting.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/sorting.js
@@ -23,7 +23,7 @@ define([
         },
 
         /**
-         * @inheritDoc
+         * @inheritdoc
          */
         initObservable: function () {
             this.preparedOptions();


### PR DESCRIPTION
### Description (*)
This PR adjust Web API tests for  AdobeStockAsset module.
Also, it fixes the issues with running Web API tests with SOAP.
The new test `testDeleteWithException` was added.

### Manual testing scenarios (*)
1. Run Web API tests with REST and SOAP configs