### PR TITLE
[MFTF]: User navigates to next previous image from the currently viewed

### DIFF
--- a/AdobeStockImageAdminUi/Test/Mftf/Section/AdobeStockSection.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Section/AdobeStockSection.xml
@@ -19,5 +19,8 @@
         <element name="gridSpinner" type="text" selector="//div[contains(@id, 'adobe-stock-images-search-modal')]//div[@class='spinner']"/>
         <element name="modalError" type="text" selector="//aside[contains(@class, 'modal-popup')]//div[@class='modal-content']//div[text()='Something went wrong.']"/>
         <element name="countGridImages" type="text" selector="//div[@class='masonry-image-grid']/div[contains(.,data-repeat-index)]"/>
+        <element name="savePreview" type="block" selector="//button[@class='action-secondary']/span[contains(.,'Save Preview')]"/>
+        <element name="imagePreview" type="block" selector="//div[@class='masonry-image-preview']//img"/>
+        <element name="imagePreviewNavigation" type="block" selector="//div[@class='masonry-image-preview']//div[@class='action-buttons']/button[@class='action-{{type}}']" parameterized="true"/>
     </section>
 </sections>

--- a/AdobeStockImageAdminUi/Test/Mftf/Test/AdminUserNavigatesBetweenImagesOnThePreviewTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/AdminUserNavigatesBetweenImagesOnThePreviewTest.xml
@@ -8,7 +8,7 @@
 
 <tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
-    <test name="UserNavigatesToNextPreviousImageFromTheCurrentlyViewedTest">
+    <test name="AdminUserNavigatesBetweenImagesOnThePreviewTest">
         <annotations>
             <stories value="User navigates to next previous image"/>
             <title value="Admin should be able to navigates to next previous image from the currently viewed"/>

--- a/AdobeStockImageAdminUi/Test/Mftf/Test/UserNavigatesToNextPreviousImageFromTheCurrentlyViewedTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/UserNavigatesToNextPreviousImageFromTheCurrentlyViewedTest.xml
@@ -24,9 +24,9 @@
             <actionGroup ref="AdminAdobeStockSetConfigActionGroup" stepKey="cleanModuleConfig">
                 <argument name="enabled" value="0"/>
                 <argument name="wysiwygEnabled" value="disabled"/>
-                <!--                TODO: uncomment next lines where issue with sensitive config setting will be resolved. -->
-                <!--                <argument name="apiKey" value=""/>-->
-                <!--                <argument name="privateKey" value=""/>-->
+<!--                TODO: uncomment next lines where issue with sensitive config setting will be resolved. -->
+<!--                <argument name="apiKey" value=""/>-->
+<!--                <argument name="privateKey" value=""/>-->
             </actionGroup>
             <amOnPage url="admin/admin/auth/logout/" stepKey="amOnLogoutPage"/>
         </after>

--- a/AdobeStockImageAdminUi/Test/Mftf/Test/UserNavigatesToNextPreviousImageFromTheCurrentlyViewedTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/UserNavigatesToNextPreviousImageFromTheCurrentlyViewedTest.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+    <test name="UserNavigatesToNextPreviousImageFromTheCurrentlyViewedTest">
+        <annotations>
+            <stories value="User navigates to next previous image"/>
+            <title value="Admin should be able to navigates to next previous image from the currently viewed"/>
+            <description value="Admin should be able to navigates to next previous image from the currently viewed"/>
+            <severity value="CRITICAL"/>
+            <group value="AdobeStockIntegration"/>
+        </annotations>
+        <before>
+            <actionGroup ref="AdminAdobeStockSetConfigActionGroup" stepKey="setCorrectModuleConfig"/>
+            <actionGroup ref="LoginActionGroup" stepKey="LoginAsAdmin"/>
+        </before>
+        <after>
+            <actionGroup ref="AdminAdobeStockSetConfigActionGroup" stepKey="cleanModuleConfig">
+                <argument name="enabled" value="0"/>
+                <argument name="wysiwygEnabled" value="disabled"/>
+                <!--                TODO: uncomment next lines where issue with sensitive config setting will be resolved. -->
+                <!--                <argument name="apiKey" value=""/>-->
+                <!--                <argument name="privateKey" value=""/>-->
+            </actionGroup>
+            <amOnPage url="admin/admin/auth/logout/" stepKey="amOnLogoutPage"/>
+        </after>
+        <actionGroup ref="AdminAdobeStockOpenSearchModalActionGroup" stepKey="openSearchModal"/>
+        <click selector="{{AdobeStockSection.imagesThumbnails}}" stepKey="clickOnThumbnail"/>
+        <grabAttributeFrom selector="{{AdobeStockSection.imagePreview}}" userInput="src" stepKey="getCurrentImageUrl"/>
+        <click selector="{{AdobeStockSection.imagePreviewNavigation('next')}}" stepKey="NavigateToNextImage"/>
+        <!-- Assert that User switched to the next image "-->
+        <dontSeeElement selector="{{AdobeStockSection.imageSrc($getCurrentImageUrl)}}"
+                        stepKey="checkImageNotSameAfterWeSwitchToNextImage"/>
+        <grabAttributeFrom selector="{{AdobeStockSection.imagePreview}}" userInput="src"
+                           stepKey="getImageUrlAfterSwitchedToNextImage"/>
+        <!-- Assert that User switched to the previous image "-->
+        <click selector="{{AdobeStockSection.imagePreviewNavigation('previous')}}" stepKey="NavigateToPreviousImage"/>
+        <dontSeeElement selector="{{AdobeStockSection.imageSrc($getImageUrlAfterSwitchedToNextImage)}}"
+                        stepKey="checkImageNotSameAfterWeSwitchToPreviousImage"/>
+        <!-- Assert that User can close preview "-->
+        <click selector="{{AdobeStockSection.imagePreviewNavigation('close')}}" stepKey="closeImagePopup"/>
+        <dontSeeElement selector="{{AdobeStockSection.imagePreview}}"
+                        stepKey="checkThatImagePreviewClosed"/>
+    </test>
+</tests>


### PR DESCRIPTION

### Description (*)
Implement MFTF test to cover scenario: "User navigates to next previous image from the currently viewed"

### Fixed Issues (if relevant)

1. magento/adobe-stock-integration#196:  User navigates to next previous image from the currently viewed

### Manual testing scenarios (*)
Run Functional Tests