### PR TITLE
[MFTF]: User chooses the number of images to display on the page

### DIFF
--- a/AdobeStockImageAdminUi/Test/Mftf/ActionGroup/AdminDataGridSelectCustomPerPageActionGroup.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/ActionGroup/AdminDataGridSelectCustomPerPageActionGroup.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="AdminDataGridSelectCustomPerPageActionGroup">
+        <arguments>
+            <argument name="perPage" type="string"/>
+        </arguments>
+        <click selector="{{AdminDataGridPaginationSection.perPageDropdown}}" stepKey="clickPerPageDropdown"/>
+        <click selector="{{AdminDataGridPaginationSection.perPageOption('Custom')}}" stepKey="selectCustomPerPage"/>
+        <waitForElementVisible selector="{{AdminDataGridPaginationSection.perPageInput}}" time="30" stepKey="waitForInputVisible"/>
+        <fillField selector="{{AdminDataGridPaginationSection.perPageInput}}" userInput="{{perPage}}" stepKey="fillCustomPerPage"/>
+        <click selector="{{AdminDataGridPaginationSection.perPageApplyInput}}" stepKey="applyCustomPerPage"/>
+        <waitForLoadingMaskToDisappear stepKey="waitForGridLoad"/>
+        <seeInField selector="{{AdminDataGridPaginationSection.perPageDropDownValue}}" userInput="{{perPage}}" stepKey="seePerPageValueInDropDown"/>
+    </actionGroup>
+</actionGroups>

--- a/AdobeStockImageAdminUi/Test/Mftf/Test/AdminUserCanSelectNumberOfImagesToDisplayTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/AdminUserCanSelectNumberOfImagesToDisplayTest.xml
@@ -7,7 +7,7 @@
 -->
 
 <tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
-    <test name="AdminUserSortsTheOrderOfImagesInTheGridTest">
+    <test name="AdminUserCanSelectNumberOfImagesToDisplayTest">
         <annotations>
             <features value="AdobeStockImagePanel"/>
             <stories value="Access Adobe Stock Image panel via the Admin"/>
@@ -38,7 +38,14 @@
         <actionGroup ref="AdminAssertAdobeStockThumbnailsNumberActionGroup" stepKey="see64imagesOnTheSecondPage">
             <argument name="thumbnailsNumber" value="64"/>
         </actionGroup>
-<!-- assert custom page size -->
+        <actionGroup ref="adminDataGridSelectPerPage" stepKey="select48rderPerPage">
+            <argument name="perPage" value="48"/>
+        </actionGroup>
+        <seeInField selector="{{AdminDataGridPaginationSection.perPageDropDownValue}}" userInput="48" stepKey="see48PerPageValueInDropDown"/>
+        <actionGroup ref="AdminAssertAdobeStockThumbnailsNumberActionGroup" stepKey="see48imagesOnTheSecondPage">
+            <argument name="thumbnailsNumber" value="48"/>
+        </actionGroup>
+        <!-- assert custom page size -->
         <actionGroup ref="AdminDataGridSelectCustomPerPageActionGroup" stepKey="selectCustomPerPage">
             <argument name="perPage" value="23"/>
         </actionGroup>

--- a/AdobeStockImageAdminUi/Test/Mftf/Test/AdminUserSortsTheOrderOfImagesInTheGridTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/AdminUserSortsTheOrderOfImagesInTheGridTest.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+    <test name="AdminUserSortsTheOrderOfImagesInTheGridTest">
+        <annotations>
+            <features value="AdobeStockImagePanel"/>
+            <stories value="Access Adobe Stock Image panel via the Admin"/>
+            <title value="Admin should be able to chooses the number of images to display on the page"/>
+            <description value="Admin should be able to chooses the number of images to display on the page"/>
+            <severity value="CRITICAL"/>
+            <group value="AdobeStockIntegration"/>
+        </annotations>
+        <before>
+            <actionGroup ref="AdminAdobeStockSetConfigActionGroup" stepKey="setCorrectModuleConfig"/>
+            <actionGroup ref="LoginAsAdmin" stepKey="loginAsAdmin"/>
+        </before>
+        <after>
+            <actionGroup ref="logout" stepKey="logout"/>
+            <actionGroup ref="AdminAdobeStockSetConfigActionGroup" stepKey="cleanModuleConfig">
+                <argument name="enabled" value="0"/>
+                <argument name="wysiwygEnabled" value="disabled"/>
+<!--                TODO: uncomment next lines where issue with sensitive config setting will be resolved. -->
+<!--                <argument name="apiKey" value=""/>-->
+<!--                <argument name="privateKey" value=""/>-->
+            </actionGroup>
+        </after>
+        <actionGroup ref="AdminAdobeStockOpenSearchModalActionGroup" stepKey="openAdobeStockPanel"/>
+        <actionGroup ref="adminDataGridSelectPerPage" stepKey="select64rderPerPage">
+            <argument name="perPage" value="64"/>
+        </actionGroup>
+        <seeInField selector="{{AdminDataGridPaginationSection.perPageDropDownValue}}" userInput="64" stepKey="seePerPageValueInDropDown"/>
+        <actionGroup ref="AdminAssertAdobeStockThumbnailsNumberActionGroup" stepKey="see64imagesOnTheSecondPage">
+            <argument name="thumbnailsNumber" value="64"/>
+        </actionGroup>
+<!-- assert custom page size -->
+        <actionGroup ref="AdminDataGridSelectCustomPerPageActionGroup" stepKey="selectCustomPerPage">
+            <argument name="perPage" value="23"/>
+        </actionGroup>
+        <seeInField selector="{{AdminDataGridPaginationSection.perPageDropDownValue}}" userInput="23" stepKey="seePerPage"/>
+        <actionGroup ref="AdminAssertAdobeStockThumbnailsNumberActionGroup" stepKey="see100imagesOnTheSecondPage">
+            <argument name="thumbnailsNumber" value="23"/>
+        </actionGroup>
+    </test>
+</tests>


### PR DESCRIPTION
### Description (*)

Implemented MFTF test to cover scenario: "User chooses the number of images to display on the page"
### Fixed Issues (if relevant)
1. magento/adobe-stock-integration#220: User chooses the number of images to display on the page

### Manual testing scenarios (*)
Run Functional tests