### PR TITLE
FIX: undefined field name in the recursive document to asset convert

### DIFF
--- a/AdobeStockAsset/Model/DocumentToAsset.php
+++ b/AdobeStockAsset/Model/DocumentToAsset.php
@@ -96,7 +96,8 @@ class DocumentToAsset
                 }
                 return $items;
             } else {
-                $entity->setData($assetField, $data[$documentField]);
+                $filedValue = isset($data[$documentField]) ? $data[$documentField] : null;
+                $entity->setData($assetField, $filedValue);
             }
             unset($data[$documentField]);
         }


### PR DESCRIPTION
### Description
It is possible that some data such as `category` can be not provided for some assets. This leads to an error in the document to asset convert action.
Due to the fact that this looks like a normal behaviour (for example, a category can not be assigned to the current image), I decided to provide next solution: if a required field doesn't have any value - provide null.

### Fixed Issues (if relevant)
[Fixed issue: #295](https://github.com/magento/adobe-stock-integration/issues/295)

### Manual testing scenarios
According to the issue description