### PR TITLE
Cleanup

### DIFF
--- a/AdobeStockClient/Model/SearchParametersProvider/Sorting.php
+++ b/AdobeStockClient/Model/SearchParametersProvider/Sorting.php
@@ -29,7 +29,7 @@ class Sorting implements SearchParameterProviderInterface
     {
         $resultsOrders = Constants::getSearchParamsOrders();
         foreach ($searchCriteria->getSortOrders() as $sortOrder) {
-            if (false !== ($sortOrderField = array_search($sortOrder->getField(), $resultsOrders, null))) {
+            if (false !== ($sortOrderField = array_search($sortOrder->getField(), $resultsOrders, false))) {
                 $searchParams->setOrder($sortOrderField);
             }
         }

--- a/AdobeStockClient/Model/SearchParametersProvider/Sorting.php
+++ b/AdobeStockClient/Model/SearchParametersProvider/Sorting.php
@@ -29,7 +29,7 @@ class Sorting implements SearchParameterProviderInterface
     {
         $resultsOrders = Constants::getSearchParamsOrders();
         foreach ($searchCriteria->getSortOrders() as $sortOrder) {
-            if (false !== ($sortOrderField = array_search($sortOrder->getField(), $resultsOrders, false))) {
+            if (false !== ($sortOrderField = array_search($sortOrder->getField(), $resultsOrders))) {
                 $searchParams->setOrder($sortOrderField);
             }
         }


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
My previous PR #292 breaks one of the tests 🤦‍♂  because the 3rd parameter has to be boolean
![Screenshot 2019-08-05 at 23 40 33](https://user-images.githubusercontent.com/1080386/62499541-03bdc500-b7db-11e9-84c5-cfbb5ea06b97.png)

I have re-checked the [php docs](https://www.php.net/manual/en/function.array-search.php) and I am now passing `false` (default value if no value is passed) and that fix the issue
![Screenshot 2019-08-05 at 23 47 40](https://user-images.githubusercontent.com/1080386/62499739-a70eda00-b7db-11e9-949e-31bb5ba4a110.png)