### PR TITLE
Destination path utilization and selecting uploaded image in media gallery

### DIFF
--- a/AdobeStockImage/Controller/Adminhtml/Preview/Download.php
+++ b/AdobeStockImage/Controller/Adminhtml/Preview/Download.php
@@ -79,7 +79,7 @@ class Download extends Action
             $responseCode = self::HTTP_OK;
             $responseContent = [
                 'success' => true,
-                'message' => __('You have sucscessfully downloaded the image.'),
+                'message' => __('You have successfully downloaded the image.'),
             ];
         } catch (NotFoundException $exception) {
             $responseCode = self::HTTP_BAD_REQUEST;

--- a/AdobeStockImage/Controller/Adminhtml/Preview/Download.php
+++ b/AdobeStockImage/Controller/Adminhtml/Preview/Download.php
@@ -79,13 +79,13 @@ class Download extends Action
             $responseCode = self::HTTP_OK;
             $responseContent = [
                 'success' => true,
-                'message' => __('You have successfully downloaded the image.'),
+                'message' => __('You have sucscessfully downloaded the image.'),
             ];
         } catch (NotFoundException $exception) {
             $responseCode = self::HTTP_BAD_REQUEST;
             $responseContent = [
                 'success' => false,
-                'error_message' => __('Image not found. Could not be saved.'),
+                'message' => __('Image not found. Could not be saved.'),
             ];
         } catch (\Exception $exception) {
             $responseCode = self::HTTP_INTERNAL_ERROR;
@@ -93,7 +93,7 @@ class Download extends Action
             $this->logger->critical($logMessage);
             $responseContent = [
                 'success' => false,
-                'error_message' => __('An error occurred while image download. Contact support.'),
+                'message' => __('An error occurred while image download. Contact support.'),
             ];
         }
 

--- a/AdobeStockImage/Model/Storage.php
+++ b/AdobeStockImage/Model/Storage.php
@@ -78,6 +78,9 @@ class Storage
      */
     public function save(string $imageUrl, string $destinationDirectoryPath = '') : string
     {
+        if (!empty($destinationDirectoryPath)) {
+            $destinationDirectoryPath = rtrim($destinationDirectoryPath, '/') . '/';
+        }
         $destinationPath = $destinationDirectoryPath . $this->getFileName($imageUrl);
 
         $bytes = false;

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/image-preview.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/image-preview.js
@@ -15,6 +15,8 @@ define([
 
     return Column.extend({
         defaults: {
+            mediaGallerySelector: '.media-gallery-modal:has(#search_adobe_stock)',
+            adobeStockModalSelector: '#adobe-stock-images-search-modal',
             modules: {
                 thumbnailComponent: '${ $.parentName }.thumbnail_url'
             },
@@ -246,12 +248,10 @@ define([
          * @param record
          */
         save: function (record) {
-            var mediaBrowser = $('.media-gallery-modal:has(#search_adobe_stock)').data('mageMediabrowser');
-            $('#' + record.id).text('');
-            console.log(record.id)
+            var mediaBrowser = $(this.mediaGallerySelector).data('mageMediabrowser');
             $.ajax(
                 {
-                   type: "POST",
+                   type: 'POST',
                    url: this.downloadImagePreviewUrl,
                    dataType: 'json',
                    data: {
@@ -261,11 +261,12 @@ define([
                    success: function (response) {
                        messages.add('success', response.message);
                        messages.scheduleCleanup(3);
-                       $("#adobe-stock-images-search-modal").trigger('closeModal');
+                       $(this.adobeStockModalSelector).trigger('closeModal');
                        mediaBrowser.reload(true);
                    },
                    error: function (response) {
                        messages.add('error', response.responseJSON.error_message);
+                       messages.scheduleCleanup(3);
                    }
                }
            );

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/image-preview.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/image-preview.js
@@ -7,11 +7,10 @@ define([
     'jquery',
     'knockout',
     'Magento_Ui/js/grid/columns/column',
-    'Magento_Ui/js/lib/spinner',
     'Magento_AdobeStockImageAdminUi/js/action/authorization',
     'Magento_AdobeStockImageAdminUi/js/model/messages',
     'mage/translate'
-], function (_, $, ko, Column, loader, authorizationAction, messages) {
+], function (_, $, ko, Column, authorizationAction, messages) {
     'use strict';
 
     return Column.extend({

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/image-preview.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/image-preview.js
@@ -7,10 +7,11 @@ define([
     'jquery',
     'knockout',
     'Magento_Ui/js/grid/columns/column',
+    'Magento_Ui/js/lib/spinner',
     'Magento_AdobeStockImageAdminUi/js/action/authorization',
     'Magento_AdobeStockImageAdminUi/js/model/messages',
     'mage/translate'
-], function (_, $, ko, Column, authorizationAction, messages) {
+], function (_, $, ko, Column, loader, authorizationAction, messages) {
     'use strict';
 
     return Column.extend({
@@ -249,25 +250,27 @@ define([
          */
         save: function (record) {
             var mediaBrowser = $(this.mediaGallerySelector).data('mageMediabrowser');
+            $(this.adobeStockModalSelector).trigger('processStart');
             $.ajax(
                 {
-                   type: 'POST',
-                   url: this.downloadImagePreviewUrl,
-                   dataType: 'json',
-                   data: {
+                    type: 'POST',
+                    url: this.downloadImagePreviewUrl,
+                    dataType: 'json',
+                    data: {
                        'media_id': record.id,
                        'destination_path': mediaBrowser.activeNode.path || ''
-                   },
-                   success: function (response) {
-                       messages.add('success', response.message);
-                       messages.scheduleCleanup(3);
-                       $(this.adobeStockModalSelector).trigger('closeModal');
-                       mediaBrowser.reload(true);
-                   },
-                   error: function (response) {
-                       messages.add('error', response.responseJSON.error_message);
-                       messages.scheduleCleanup(3);
-                   }
+                    },
+                    context: this,
+                    success: function () {
+                        $(this.adobeStockModalSelector).trigger('processStop');
+                        $(this.adobeStockModalSelector).trigger('closeModal');
+                        mediaBrowser.reload(true);
+                    },
+                    error: function (response) {
+                        $(this.adobeStockModalSelector).trigger('processStop');
+                        messages.add('error', response.responseJSON.message);
+                        messages.scheduleCleanup(3);
+                    }
                }
            );
         },

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/image-preview.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/image-preview.js
@@ -246,44 +246,29 @@ define([
          * @param record
          */
         save: function (record) {
-            //@TODO add a logic for getting the target path
-            var destinationPath = '';
-            var postData = {
-                'media_id': record.id,
-                'destination_path': destinationPath
-            };
+            var mediaBrowser = $('.media-gallery-modal:has(#search_adobe_stock)').data('mageMediabrowser');
             $('#' + record.id).text('');
-            $.ajax({
-                       type: "POST",
-                       url: this.downloadImagePreviewUrl,
-                       dataType: 'json',
-                       data: postData,
-                       success: function (response) {
-                           var successMessage = '<div class="messages"><div class="message message-success success">' +
-                                                response.message +
-                                                '<div data-ui-id="messages-message-success"></div></div></div>';
-                           $('#' + record.id).append(successMessage);
-
-                           // update modal with an image url
-                           var image_url = record.preview_url;
-                           var targetEl = $('.media-gallery-modal:has(#search_adobe_stock)')
-                           .data('mageMediabrowser')
-                           .getTargetElement();
-                           targetEl.val(image_url).trigger('change');
-                           // close insert image panel
-                           window.MediabrowserUtility.closeDialog();
-                           targetEl.focus();
-                           $(targetEl).change();
-                           // close adobe panel
-                           $("#adobe-stock-images-search-modal").trigger('closeModal');
-                       },
-                       error: function (response) {
-                           var errorMessage = '<div class="messages"><div class="message message-error error">' +
-                                              response.responseJSON.error_message +
-                                              '<div data-ui-id="messages-message-error"></div></div></div>';
-                           $('#' + record.id).append(errorMessage);
-                       }
-                   });
+            console.log(record.id)
+            $.ajax(
+                {
+                   type: "POST",
+                   url: this.downloadImagePreviewUrl,
+                   dataType: 'json',
+                   data: {
+                       'media_id': record.id,
+                       'destination_path': mediaBrowser.activeNode.path || ''
+                   },
+                   success: function (response) {
+                       messages.add('success', response.message);
+                       messages.scheduleCleanup(3);
+                       $("#adobe-stock-images-search-modal").trigger('closeModal');
+                       mediaBrowser.reload(true);
+                   },
+                   error: function (response) {
+                       messages.add('error', response.responseJSON.error_message);
+                   }
+               }
+           );
         },
 
         /**

--- a/AdobeStockImageAdminUi/view/adminhtml/web/template/grid/column/image-preview.html
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/template/grid/column/image-preview.html
@@ -25,9 +25,13 @@
             </div>
             <ul class="messages" if="$col.getMessages().length > 0">
                 <!-- ko foreach: $col.getMessages() -->
-                <li attr="class: code">
-                    <span data-bind="html: message"></span>
-                </li>
+                <div class="messages">
+                    <div attr="class: 'message message-'+code">
+                        <div data-ui-id="messages-message-error">
+                            <span data-bind="html: message"></span>
+                        </div>
+                    </div>
+                </div>
                 <!-- /ko -->
             </ul>
             <button class="action-secondary" type="button" data-bind="click: function(){ $col.save($row()) }">


### PR DESCRIPTION
### Fixed Issues (if relevant)
1. magento/adobe-stock-integration#286: Pass destination directory path to save preview image call
2. magento/adobe-stock-integration#287: Open media gallery and select the image right after it was saved
3. magento/adobe-stock-integration#260: Add styles for authentication error message when licensing an image