### PR TITLE
Issue 282 allow image entity to have multiple image paths

### DIFF
--- a/AdobeStockAsset/Model/Asset.php
+++ b/AdobeStockAsset/Model/Asset.php
@@ -165,17 +165,17 @@ class Asset extends AbstractExtensibleModel implements AssetInterface
     /**
      * @inheritdoc
      */
-    public function getPath(): ?string
+    public function getPaths(): ?array
     {
-        return (string) $this->getData(self::PATH);
+        return $this->getData(self::PATHS);
     }
 
     /**
      * @inheritdoc
      */
-    public function setPath(string $path): void
+    public function setPaths(array $paths): void
     {
-        $this->setData(self::PATH, $path);
+        $this->setData(self::PATHS, $paths);
     }
 
     /**

--- a/AdobeStockAsset/Model/ResourceModel/Asset.php
+++ b/AdobeStockAsset/Model/ResourceModel/Asset.php
@@ -8,6 +8,8 @@ declare(strict_types=1);
 
 namespace Magento\AdobeStockAsset\Model\ResourceModel;
 
+use Magento\AdobeStockAssetApi\Api\Data\AssetInterface;
+use Magento\Framework\Model\AbstractModel;
 use Magento\Framework\Model\ResourceModel\Db\AbstractDb;
 
 /**
@@ -15,6 +17,11 @@ use Magento\Framework\Model\ResourceModel\Db\AbstractDb;
  */
 class Asset extends AbstractDb
 {
+    /**
+     * Asset path table
+     */
+    const ASSET_PATH_TABLE = 'adobe_stock_asset_path';
+
     /**
      * @inheritdoc
      */
@@ -31,5 +38,132 @@ class Asset extends AbstractDb
     protected function _construct()
     {
         $this->_init('adobe_stock_asset', 'id');
+    }
+
+    /**
+     * After delete
+     *
+     * @param AbstractModel|AssetInterface $object
+     * @return AbstractDb
+     */
+    protected function _afterDelete(AbstractModel $object)
+    {
+        $this->deletePaths($object);
+
+        return parent::_afterDelete($object);
+    }
+
+    /**
+     * After load
+     *
+     * @param AbstractModel|AssetInterface $object
+     * @return void
+     */
+    protected function _afterLoad(AbstractModel $object)
+    {
+        $object->setPaths($this->getPaths((int) $object->getId()));
+        parent::_afterLoad($object);
+    }
+
+    /**
+     * After save
+     *
+     * @param AbstractModel|AssetInterface $object
+     * @return AbstractDb
+     */
+    protected function _afterSave(AbstractModel $object)
+    {
+        $this->savePaths($object);
+
+        return parent::_afterSave($object);
+    }
+
+    /**
+     * Get paths
+     *
+     * @param int $assetId
+     * @return array
+     */
+    public function getPaths(int $assetId): array
+    {
+        $connection = $this->getConnection();
+        $tableName = $connection->getTableName(self::ASSET_PATH_TABLE);
+        $select = $connection->select();
+        $select->from($tableName, 'path');
+        $select->where('asset_id = ?', $assetId);
+        $rows = $connection->fetchAll($select);
+
+        if (!$rows) {
+            return [];
+        }
+
+        $paths = [];
+
+        foreach ($rows as $row) {
+            $path = $row['path'] ?? '';
+
+            if ($path) {
+                $paths[] = $path;
+            }
+        }
+
+        return $paths;
+    }
+
+    /**
+     * Save paths
+     *
+     * @param AssetInterface $object
+     * @return void
+     */
+    private function savePaths(AssetInterface $object): void
+    {
+        $connection = $this->getConnection();
+        $assetPathTable = $connection->getTableName(self::ASSET_PATH_TABLE);
+        $oldPaths = $this->getPaths($object->getId());
+        $newPaths = $object->getPaths();
+        $pathsToInsert = array_diff($newPaths, $oldPaths);
+        $pathsToDelete = array_diff($oldPaths, $newPaths);
+
+        if ($pathsToInsert) {
+            $insertData = [];
+
+            foreach ($pathsToInsert as $pathToInsert) {
+                if (!$pathToInsert) {
+                    continue;
+                }
+
+                $insertData[] = [
+                    'asset_id' => (int) $object->getId(),
+                    'path' => (string) $pathToInsert
+                ];
+            }
+
+            $connection->insertMultiple($assetPathTable, $insertData);
+        }
+
+        if ($pathsToDelete) {
+            $deleteCondition = $connection->prepareSqlCondition(
+                sprintf('%s.path', $assetPathTable),
+                ['in' => $pathsToDelete]
+            );
+            $connection->delete($assetPathTable, $deleteCondition);
+        }
+    }
+
+    /**
+     * Delete path
+     *
+     * @param AssetInterface $object
+     * @return void
+     */
+    private function deletePaths(AssetInterface $object): void
+    {
+        $connection = $this->getConnection();
+        $deleteCondition = $connection->prepareSqlCondition(
+            sprintf('%s.asset_id', $connection->getTableName(self::ASSET_PATH_TABLE)),
+            $object->getId()
+        );
+        $connection->delete($deleteCondition);
     }
 }

--- a/AdobeStockAsset/Model/ResourceModel/Asset/Collection.php
+++ b/AdobeStockAsset/Model/ResourceModel/Asset/Collection.php
@@ -10,6 +10,7 @@ namespace Magento\AdobeStockAsset\Model\ResourceModel\Asset;
 
 use Magento\AdobeStockAsset\Model\Asset as Model;
 use Magento\AdobeStockAsset\Model\ResourceModel\Asset as ResourceModel;
+use Magento\AdobeStockAssetApi\Api\Data\AssetInterface;
 use Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection;
 
 /**
@@ -26,5 +27,37 @@ class Collection extends AbstractCollection
             Model::class,
             ResourceModel::class
         );
+    }
+
+    /**
+     * Load data
+     *
+     * @param bool $printQuery
+     * @param bool $logQuery
+     * @return $this|AbstractCollection
+     */
+    public function load($printQuery = false, $logQuery = false)
+    {
+        parent::load($printQuery, $logQuery);
+        $this->addPathsToResult();
+
+        return $this;
+    }
+
+    /**
+     * Add path to result
+     *
+     * @return void
+     */
+    private function addPathsToResult(): void
+    {
+        /** @var ResourceModel $assetResource */
+        $assetResource = $this->getResource();
+
+        /** @var AssetInterface $asset */
+        foreach ($this->_items as $asset) {
+            $paths = $assetResource->getPaths((int) $asset->getId());
+            $asset->setPaths($paths);
+        }
     }
 }

--- a/AdobeStockAsset/etc/db_schema.xml
+++ b/AdobeStockAsset/etc/db_schema.xml
@@ -69,7 +69,6 @@
         <column xsi:type="int" name="category_id" padding="10" unsigned="true" nullable="true" identity="false" comment="Category ID"/>
         <column xsi:type="int" name="creator_id" padding="10" unsigned="true" nullable="true" identity="false" comment="Creator ID"/>
         <column xsi:type="int" name="premium_level_id" padding="10" unsigned="true" nullable="true" identity="false" comment="Premium Level ID"/>
-        <column xsi:type="varchar" length="255" name="path" nullable="true" comment="Path"/>
         <column xsi:type="varchar" length="255" name="stock_id" nullable="true" comment="Stock Id"/>
         <column xsi:type="int" name="is_licensed" padding="10" unsigned="true" nullable="false" identity="false" default="0" comment="Is Licensed"/>
         <column xsi:type="varchar" length="255" name="title" nullable="true" comment="Title"/>
@@ -107,6 +106,18 @@
         </constraint>
         <constraint xsi:type="foreign" referenceId="ADO_STO_ASS_CAT_ID" table="adobe_stock_asset" column="category_id" referenceTable="adobe_stock_category" referenceColumn="id" onDelete="SET NULL"/>
         <constraint xsi:type="foreign" referenceId="ADO_STO_ASS_CRE_ID" table="adobe_stock_asset" column="creator_id" referenceTable="adobe_stock_creator" referenceColumn="id" onDelete="SET NULL"/>
+    </table>
+    <table name="adobe_stock_asset_path" resource="default" engine="innodb" comment="Adobe Stock Asset Path">
+        <column xsi:type="int" name="id" padding="10" unsigned="true" nullable="false" identity="true" comment="Entity ID"/>
+        <column xsi:type="int" name="asset_id" padding="10" unsigned="true" nullable="false" identity="false" comment="Asset ID"/>
+        <column xsi:type="varchar" length="255" name="path" nullable="true" comment="Path"/>
+        <constraint xsi:type="primary" referenceId="PRIMARY">
+            <column name="id"/>
+        </constraint>
+        <constraint xsi:type="unique" referenceId="PATH">
+            <column name="path"/>
+        </constraint>
+        <constraint xsi:type="foreign" referenceId="ADO_STO_ASS_PATH_ASS_ID" table="adobe_stock_asset_path" column="asset_id" referenceTable="adobe_stock_asset" referenceColumn="id" onDelete="CASCADE"/>
     </table>
     <table name="adobe_stock_category" resource="default" engine="innodb" comment="Adobe Stock Category">
         <column xsi:type="int" name="id" padding="10" unsigned="true" nullable="false" identity="true" comment="Entity ID"/>

--- a/AdobeStockAsset/etc/db_schema_whitelist.json
+++ b/AdobeStockAsset/etc/db_schema_whitelist.json
@@ -67,7 +67,6 @@
             "category_id": true,
             "creator_id": true,
             "premium_level_id": true,
-            "path": true,
             "stock_id": true,
             "is_licensed": true,
             "title": true,
@@ -96,6 +95,18 @@
             "PRIMARY": true,
             "ADOBE_STOCK_ASSET_CATEGORY_ID_ADOBE_STOCK_CATEGORY_ID": true,
             "ADOBE_STOCK_ASSET_CREATOR_ID_ADOBE_STOCK_CREATOR_ID": true
+        }
+    },
+    "adobe_stock_asset_path": {
+        "column": {
+            "id": true,
+            "asset_id": true,
+            "path": true
+        },
+        "constraint": {
+            "PRIMARY": true,
+            "PATH": true,
+            "ADO_STO_ASS_PATH_ASS_ID": true
         }
     },
     "adobe_stock_category": {

--- a/AdobeStockAssetApi/Api/Data/AssetInterface.php
+++ b/AdobeStockAssetApi/Api/Data/AssetInterface.php
@@ -17,7 +17,7 @@ interface AssetInterface extends \Magento\Framework\Api\ExtensibleDataInterface
 {
     const ID = 'id';
 
-    const PATH = 'path';
+    const PATHS = 'paths';
 
     const CREATED_AT = 'created_at';
 
@@ -99,19 +99,19 @@ interface AssetInterface extends \Magento\Framework\Api\ExtensibleDataInterface
     public function setId($value): void;
 
     /**
-     * Get Path
+     * Get Paths
      *
-     * @return string|null
+     * @return string[]|null
      */
-    public function getPath(): ?string;
+    public function getPaths(): ?array;
 
     /**
-     * Set Path
+     * Set Paths
      *
-     * @param string $value
+     * @param string[] $paths
      * @return void
      */
-    public function setPath(string $value): void;
+    public function setPaths(array $paths): void;
 
     /**
      * Get URL


### PR DESCRIPTION
### Description 
This PR allows an image entity to have multiple image paths.

### Fixed Issues

1. magento/adobe-stock-integration#282: Allow image entity to have multiple image paths

### Manual testing scenarios 
1. Save/Load/Delete the `AssetInterface` entity with multiple image paths