### PR TITLE
Display attributes under the preview image

### DIFF
--- a/AdobeStockImageAdminUi/view/adminhtml/web/css/source/_module.less
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/css/source/_module.less
@@ -101,6 +101,18 @@
                         margin: 0 0 30px;
                     }
                 }
+                .attributes {
+                    .attribute {
+                        display: inline-block;
+                        margin-right: 2em;
+                        .title {
+                            font-weight: bold;
+                        }
+                        .value {
+                            margin-top: 1em;
+                        }
+                    }
+                }
             }
         }
     }

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/image-preview.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/image-preview.js
@@ -108,7 +108,34 @@ define([
          * @returns {String}
          */
         getAuthor: function (record) {
-            return record.author || 'Author';
+            return record.creator.name || 'Author';
+        },
+
+        /**
+         * Returns attributes to display under the preview image
+         *
+         * @param record
+         * @returns {*[]}
+         */
+        getDisplayAttributes: function(record) {
+            return [
+                {
+                    name: 'Dimensions',
+                    value: record.width + ' x ' + record.height + ' px'
+                },
+                {
+                    name: 'File type',
+                    value: record.content_type.toUpperCase()
+                },
+                {
+                    name: 'Cateogory',
+                    value: record.category.name
+                },
+                {
+                    name: 'File #',
+                    value: record.id
+                }
+            ];
         },
 
         /**

--- a/AdobeStockImageAdminUi/view/adminhtml/web/template/grid/column/image-preview.html
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/template/grid/column/image-preview.html
@@ -44,5 +44,15 @@
                 <span data-bind="i18n: 'License and Save'"></span>
             </button>
         </div>
+        <div class="attributes">
+            <!-- ko foreach: $col.getDisplayAttributes($row()) -->
+            <div class="attribute">
+                <span class="title" translate="name"/>
+                <div class="value">
+                   <span text="value" />
+                </div>
+            </div>
+            <!-- /ko -->
+        </div>
     </div>
 </div>


### PR DESCRIPTION
### Description (*)
Corrected author attribute display source and added attributes displayed under the image preview

### Fixed Issues
magento/adobe-stock-integration#9: Render image attributes on the preview 

### Story

magento/adobe-stock-integration#24: [Story #3] User views the image details

### Manual testing scenarios (*)

1. Open Magento media gallery
2. Click "Search Adobe Stock" button
3. Click on any image in Adobe Stock grid

![image](https://user-images.githubusercontent.com/2028541/62842307-ccd22e00-bc76-11e9-88df-cb13bb24bcd9.png)
