### PR TITLE
FIX: refactor the getImageByAdobeId and execute SaveImagePreview class methods

### DIFF
--- a/AdobeStockImage/Model/SaveImagePreview.php
+++ b/AdobeStockImage/Model/SaveImagePreview.php
@@ -106,8 +106,7 @@ class SaveImagePreview implements SaveImagePreviewInterface
     public function execute(int $adobeId, string $destinationPath): void
     {
         $searchResult = $this->getImageByAdobeId($adobeId);
-
-        if (1 < $searchResult->getTotalCount()) {
+        if (null === $searchResult || 1 < $searchResult->getTotalCount()) {
             $message = __('Requested image doesn\'t exists');
             $this->logger->critical($message);
             throw new NotFoundException($message);
@@ -206,10 +205,10 @@ class SaveImagePreview implements SaveImagePreviewInterface
      * Get image by adobe id.
      *
      * @param int $adobeId
-     * @return AssetInterface
+     * @return null|AssetInterface
      * @throws LocalizedException
      */
-    private function getImageByAdobeId(int $adobeId): AssetInterface
+    private function getImageByAdobeId(int $adobeId): ?AssetInterface
     {
         $searchCriteria = $this->searchCriteriaBuilder
             ->addFilter('media_id', $adobeId)

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/image-preview.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/image-preview.js
@@ -193,7 +193,6 @@ define([
          * @return {*|boolean}
          */
         isVisible: function (record) {
-            console.log(record)
             if (this.lastOpenedImage === record._rowIndex &&
                 (this.visibility()[record._rowIndex] === undefined || this.visibility()[record._rowIndex] === false)
             ) {


### PR DESCRIPTION
### Description (*)
Refactor the `getImageByAdobeId` method along with the execute class method to coordinate asset receive and save processes.

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios (*)
N/A