### PR TITLE
#322 Track code coverage of unit test in scope of travis build

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,3 @@
+coverage_clover: dev/tests/build/logs/clover.xml
+json_path: dev/tests/build/logs/coveralls-upload.json
+service_name: travis-ci

--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,3 +1,3 @@
-coverage_clover: dev/tests/build/logs/clover.xml
-json_path: dev/tests/build/logs/coveralls-upload.json
+coverage_clover: magento2/dev/tests/unit/build/logs/clover.xml
+json_path: magento2/dev/tests/unit/build/logs/coveralls-upload.json
 service_name: travis-ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,3 +64,5 @@ script:
   - if [ $TEST_SUITE == 'integration' ]; then phpunit -c dev/tests/integration; fi
   - if [ $TEST_SUITE == 'api' ]; then phpunit -c dev/tests/api-functional; fi
   - if [ $TEST_SUITE == 'functional' ]; then codecept run functional --verbose --steps -g AdobeStockIntegration -c dev/tests/acceptance/codeception.yml; fi
+after_success:
+  - if [ $TEST_SUITE == 'unit' ]; then travis_retry php vendor/bin/coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,4 +65,4 @@ script:
   - if [ $TEST_SUITE == 'api' ]; then phpunit -c dev/tests/api-functional; fi
   - if [ $TEST_SUITE == 'functional' ]; then codecept run functional --verbose --steps -g AdobeStockIntegration -c dev/tests/acceptance/codeception.yml; fi
 after_success:
-  - if [ $TEST_SUITE == 'unit' ]; then travis_retry php vendor/bin/coveralls; fi
+  - if [ $TEST_SUITE == 'unit' ]; then cd ../ && travis_retry coveralls; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,4 +65,4 @@ script:
   - if [ $TEST_SUITE == 'api' ]; then phpunit -c dev/tests/api-functional; fi
   - if [ $TEST_SUITE == 'functional' ]; then codecept run functional --verbose --steps -g AdobeStockIntegration -c dev/tests/acceptance/codeception.yml; fi
 after_success:
-  - if [ $TEST_SUITE == 'unit' ]; then travis_retry php vendor/bin/coveralls
+  - if [ $TEST_SUITE == 'unit' ]; then travis_retry php vendor/bin/coveralls; fi

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# Adobe Stock Integration
+
+[![Coverage Status](https://coveralls.io/repos/github/magento/adobe-stock-integration/badge.svg?branch=develop)](https://coveralls.io/github/magento/adobe-stock-integration?branch=develop)
+
 Welcome to the Adobe Stock Integration community project!
 
 ## Overview

--- a/dev/tests/unit/phpunit.xml
+++ b/dev/tests/unit/phpunit.xml
@@ -15,4 +15,15 @@
     <testsuite name="Magento Adobe Stock Unit Tests">
         <directory suffix="Test.php">../../../vendor/magento/module-adobe*/Test/Unit/</directory>
     </testsuite>
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">../../../vendor/magento/module-adobe*/</directory>
+            <exclude>
+                <directory>../../../vendor/magento/module-adobe*/Test</directory>
+            </exclude>
+        </whitelist>
+    </filter>
+    <logging>
+        <log type="coverage-clover" target="build/logs/clover.xml"/>
+    </logging>
 </phpunit>

--- a/dev/tests/unit/phpunit.xml
+++ b/dev/tests/unit/phpunit.xml
@@ -20,6 +20,7 @@
             <directory suffix=".php">../../../vendor/magento/module-adobe*/</directory>
             <exclude>
                 <directory>../../../vendor/magento/module-adobe*/Test</directory>
+                <file>../../../vendor/magento/module-adobe*/registration.php</file>
             </exclude>
         </whitelist>
     </filter>

--- a/dev/travis/before_install.sh
+++ b/dev/travis/before_install.sh
@@ -13,7 +13,9 @@ smtp-sink -d "%d.%H.%M.%S" localhost:2500 1000 &
 echo 'sendmail_path = "/usr/sbin/sendmail -t -i "' > ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/sendmail.ini
 
 # disable xdebug and adjust memory limit
-echo > ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini
+if [[ $TEST_SUITE != "unit" ]]; then
+  echo > ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini
+fi
 echo 'memory_limit = -1' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
 phpenv rehash;
 

--- a/dev/travis/before_script.sh
+++ b/dev/travis/before_script.sh
@@ -64,3 +64,9 @@ if [[ $TEST_SUITE = "api" ]]; then
         php bin/magento config:sensitive:set adobe_stock/integration/private_key ${ADOBE_STOCK_PRIVATE_KEY}
         php bin/magento cache:flush
 fi
+
+if [[ $TEST_SUITE = "unit" ]]; then
+      echo "Prepare unit tests for runining"
+      composer require "mustache/mustache":"~2.5"
+      composer require "php-coveralls/php-coveralls":"^1.0"
+fi


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/adobe-stock-integration#322: Track code coverage of unit test in scope of travis build

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. https://coveralls.io/github/diazwatson/adobe-stock-integration (temp url)
2. https://coveralls.io/github/magento/adobe-stock-integration (final url)

### Expected result
See coverage report of the Adobe Stock module

### Actual
This is just an example using [my fork](https://github.com/diazwatson/adobe-stock-integration), we will need add coveralls token to Travis CI for it to work.

![Screenshot 2019-09-25 at 13 20 22](https://user-images.githubusercontent.com/1080386/65600789-ba971f80-df98-11e9-8419-8506130a4437.png)


