### PR TITLE
Fixed the issue with broken overlay functionality

### DIFF
--- a/AdobeStockImageAdminUi/view/adminhtml/ui_component/adobe_stock_images_listing.xml
+++ b/AdobeStockImageAdminUi/view/adminhtml/ui_component/adobe_stock_images_listing.xml
@@ -147,19 +147,19 @@
                 <item name="containerId" xsi:type="string">adobe-stock-images-masonry-grid</item>
             </item>
         </argument>
-        <column name="thumbnail_url" component="Magento_AdobeUi/js/components/grid/column/image">
-            <settings>
-                <label translate="true">Thumbnail Image</label>
-                <bodyTmpl>Magento_AdobeUi/grid/column/image</bodyTmpl>
-                <visible>true</visible>
-                <sortable>false</sortable>
-            </settings>
-        </column>
         <column name="overlay" component="Magento_AdobeUi/js/components/grid/column/overlay">
             <settings>
                 <label translate="true">Overlay</label>
                 <bodyTmpl>Magento_AdobeUi/grid/column/overlay</bodyTmpl>
                 <visible>false</visible>
+                <sortable>false</sortable>
+            </settings>
+        </column>
+        <column name="thumbnail_url" component="Magento_AdobeUi/js/components/grid/column/image">
+            <settings>
+                <label translate="true">Thumbnail Image</label>
+                <bodyTmpl>Magento_AdobeUi/grid/column/image</bodyTmpl>
+                <visible>true</visible>
                 <sortable>false</sortable>
             </settings>
         </column>

--- a/AdobeUi/view/adminhtml/web/css/source/_module.less
+++ b/AdobeUi/view/adminhtml/web/css/source/_module.less
@@ -10,9 +10,13 @@
             position: relative;
             margin: @admin__masonry_grid_image__space/2 -(@admin__masonry_grid_image__space/2);
             overflow: hidden;
-            &:hover .masonry-image-overlay {
-                display: block;
+
+            .masonry-image-column {
+                &:hover .masonry-image-overlay {
+                    display: block;
+                }
             }
+
             .no-data-message-container {
                 font-size: @data-grid__no-records__font-size;
                 padding: @data-grid__no-records__padding;
@@ -38,10 +42,6 @@
         &-overlay {
             display: none;
             position: absolute;
-            top: 0;
-            left: 0;
-            right: 0;
-            bottom: 0;
             color: #fff;
             z-index: 10;
             height: 3rem;


### PR DESCRIPTION
### Description (*)
The issue with broken overlay functionality is fixed.
<img width="1440" alt="Screen Shot 2019-08-31 at 10 52 18" src="https://user-images.githubusercontent.com/31502344/64061046-95073800-cbdd-11e9-9706-616fa55c4946.png">
<img width="1440" alt="Screen Shot 2019-08-31 at 10 53 05" src="https://user-images.githubusercontent.com/31502344/64061047-95073800-cbdd-11e9-9065-96551a6a3feb.png">

### Fixed Issues (if relevant)

1. magento/adobe-stock-integration#266: Overlay functionality is broken

### Preconditions

- change `visible` value to **true** for `overlay` column in the `AdobeStockImageAdminUi/view/adminhtml/ui_component/adobe_stock_images_listing.xml`
- clear the cache 
- clear the rows in *ui_bookmark* table with `namespace` equal to `adobe_stock_images_listing`

### Manual testing scenarios (*)

- Open Adobe Stock Integration panel
- Hover any image