### PR TITLE
Added an ability to specify image name during saving preview

### DIFF
--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/image-preview.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/image-preview.js
@@ -280,7 +280,7 @@ define([
         /**
          * Drop all filters and initiate search on keyword click event
          */
-        searchByKeyWord: function(keyword) {
+        searchByKeyWord: function (keyword) {
             _.invoke(this.chips().elems(), 'clear');
             this.inputValue(keyword);
             this.chipInputValue(keyword);
@@ -336,7 +336,8 @@ define([
          */
         savePreview: function (record) {
             prompt({
-                title: 'Specify image name',
+                title: 'Save Preview',
+                content: 'File Name',
                 value: this.generateImageName(record),
                 validation: true,
                 promptField: '[data-role="promptField"]',
@@ -353,8 +354,8 @@ define([
                 },
                 context: this,
                 actions: {
-                    confirm: function (imageName) {
-                        this.save(record, imageName);
+                    confirm: function (fileName) {
+                        this.save(record, fileName);
                     }.bind(this)
                 }
             });
@@ -364,38 +365,35 @@ define([
          * Save record as image
          *
          * @param {Object} record
-         * @param {String} imageName
+         * @param {String} fileName
          * @return {void}
          */
-        save: function (record, imageName) {
+        save: function (record, fileName) {
             var mediaBrowser = $(this.mediaGallerySelector).data('mageMediabrowser'),
-                imageType = record.content_type.match(/[^/]{1,4}$/),
-                destinationPath = (mediaBrowser.activeNode.path || '') + '/' + imageName + '.' + imageType;
+                destinationPath = (mediaBrowser.activeNode.path || '') + '/' + fileName;
 
             $(this.adobeStockModalSelector).trigger('processStart');
 
-            $.ajax(
-                {
-                    type: 'POST',
-                    url: this.downloadImagePreviewUrl,
-                    dataType: 'json',
-                    data: {
-                        'media_id': record.id,
-                        'destination_path': destinationPath
-                    },
-                    context: this,
-                    success: function () {
-                        $(this.adobeStockModalSelector).trigger('processStop');
-                        $(this.adobeStockModalSelector).trigger('closeModal');
-                        mediaBrowser.reload(true);
-                    },
-                    error: function (response) {
-                        $(this.adobeStockModalSelector).trigger('processStop');
-                        messages.add('error', response.responseJSON.message);
-                        messages.scheduleCleanup(3);
-                    }
+            $.ajax({
+                type: 'POST',
+                url: this.downloadImagePreviewUrl,
+                dataType: 'json',
+                data: {
+                    'media_id': record.id,
+                    'destination_path': destinationPath
+                },
+                context: this,
+                success: function () {
+                    $(this.adobeStockModalSelector).trigger('processStop');
+                    $(this.adobeStockModalSelector).trigger('closeModal');
+                    mediaBrowser.reload(true);
+                },
+                error: function (response) {
+                    $(this.adobeStockModalSelector).trigger('processStop');
+                    messages.add('error', response.responseJSON.message);
+                    messages.scheduleCleanup(3);
                 }
-            );
+            });
         },
 
         /**
@@ -405,7 +403,9 @@ define([
          * @return string
          */
         generateImageName: function (record) {
-            return record.title.substring(0, 32).replace(/\s+/g, '-').toLowerCase();
+            var imageType = record.content_type.match(/[^/]{1,4}$/),
+                imageName = record.title.substring(0, 32).replace(/\s+/g, '-').toLowerCase();
+            return imageName + '.' + imageType;
         },
 
         /**
@@ -454,7 +454,7 @@ define([
                             title: $.mage.__('License Adobe Stock Image?'),
                             content: confirmationContent + '<p><b>' + quotaInfo + '</b></p>',
                             actions: {
-                                confirm: function(){
+                                confirm: function () {
                                     licenseAndSave(record);
                                 }
                             }

--- a/AdobeStockImageAdminUi/view/adminhtml/web/template/grid/column/image-preview.html
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/template/grid/column/image-preview.html
@@ -35,7 +35,7 @@
                 </div>
                 <!-- /ko -->
             </ul>
-            <button class="action-secondary" type="button" data-bind="click: function(){ $col.save($row()) }">
+            <button class="action-secondary" type="button" data-bind="click: function(){ $col.savePreview($row()) }">
                 <span translate="'Save Preview'"/>
             </button>
             <button class="action-default primary"


### PR DESCRIPTION
### Description (*)

This PR adds the changes which allow an admin user to specify an image name during saving a preview.

<img width="1440" alt="Screen Shot 2019-08-31 at 12 21 54" src="https://user-images.githubusercontent.com/31502344/64062130-b96a1100-cbeb-11e9-9bb7-4d14b0bfe0d4.png">
<img width="1440" alt="Screen Shot 2019-08-31 at 12 22 40" src="https://user-images.githubusercontent.com/31502344/64062131-b96a1100-cbeb-11e9-851d-68d7dd4f15a2.png">
<img width="1440" alt="Screen Shot 2019-08-31 at 12 23 42" src="https://user-images.githubusercontent.com/31502344/64062132-b96a1100-cbeb-11e9-982b-986c740ae662.png">
<img width="1440" alt="Screen Shot 2019-08-31 at 12 24 30" src="https://user-images.githubusercontent.com/31502344/64062133-b96a1100-cbeb-11e9-824c-1ee000c8d06c.png">
<img width="1440" alt="Screen Shot 2019-08-31 at 12 25 16" src="https://user-images.githubusercontent.com/31502344/64062134-ba02a780-cbeb-11e9-8282-82cd7c400aca.png">
<img width="1440" alt="Screen Shot 2019-08-31 at 12 27 25" src="https://user-images.githubusercontent.com/31502344/64062135-ba02a780-cbeb-11e9-82a9-f09d25d24cd3.png">

### Fixed Issues (if relevant)

1. magento/adobe-stock-integration#400: Allow user to specify image name during saving preview

### Manual testing scenarios (*)

1. Login to admin panel
2. Open Magento Media Gallery (i.e. go to Cms -> Pages, edit the page and insert image)
3. Click "Search Adobe Stock" button to open images grid
4. Click on any image to open image preview
5. Click on Save preview button
6. Specify image name
7. Click on OK button