### PR TITLE
Added loading animation for license popup

### DIFF
--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/image-preview.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/image-preview.js
@@ -401,6 +401,7 @@ define([
          */
         showLicenseConfirmation: function (record) {
             var licenseAndSave = this.licenseAndSave;
+            $(this.adobeStockModalSelector).trigger('processStart');
             $.ajax(
                 {
                     type: 'POST',
@@ -414,6 +415,7 @@ define([
                     success: function (response) {
                         var quotaInfo = response.result;
                         var confirmationContent = $.mage.__('License "' + record.title + '"');
+                        $(this.adobeStockModalSelector).trigger('processStop');
                         confirmation({
                             title: $.mage.__('License Adobe Stock Image?'),
                             content: confirmationContent + '<p><b>' + quotaInfo + '</b></p>',
@@ -422,7 +424,7 @@ define([
                                     licenseAndSave(record);
                                 }
                             }
-                        });
+                        })
                     },
 
                     error: function (response) {


### PR DESCRIPTION
### Description (*)
The license popup requires some time to be loaded because of an additional AJAX request for retrieving the license quota. As a result, there's a delay between clicking the "License and save" button and showing the popup. By adding the loading animation here we let the user now that something is happening and prevent from clicking the button once again

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios (*)
1. Go to Admin -> Content -> Pages -> Choose a page | create new
2. Open dialog for inserting an image to a content
3. Click on "Open Adobe Stock"
4. Choose an image
5. Click on "License and Save" button

You should see the loading animation before the popup appears.