### PR TITLE
#437 : PHP versions in modules are inconsistent with version in magento composer.json

### DIFF
--- a/AdobeIms/composer.json
+++ b/AdobeIms/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-adobe-ims",
     "description": "N/A",
     "require": {
-        "php": "~7.1.3||~7.2.0",
+        "php": "~7.1.3||~7.2.0||~7.3.0",
         "magento/framework": "*",
         "magento/module-user": "*",
         "magento/module-adobe-ims-api": "*"

--- a/AdobeImsApi/composer.json
+++ b/AdobeImsApi/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-adobe-ims-api",
     "description": "N/A",
     "require": {
-        "php": "~7.1.3||~7.2.0",
+        "php": "~7.1.3||~7.2.0||~7.3.0",
         "magento/framework": "*"
     },
     "type": "magento2-module",

--- a/AdobeStockAdminUi/composer.json
+++ b/AdobeStockAdminUi/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-adobe-stock-admin-ui",
     "description": "N/A",
     "require": {
-        "php": "~7.1.3||~7.2.0",
+        "php": "~7.1.3||~7.2.0||~7.3.0",
         "magento/framework": "*",
         "magento/module-ui": "*",
         "magento/module-backend": "*",

--- a/AdobeStockAsset/composer.json
+++ b/AdobeStockAsset/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-adobe-stock-asset",
     "description": "N/A",
     "require": {
-        "php": "~7.1.3||~7.2.0",
+        "php": "~7.1.3||~7.2.0||~7.3.0",
         "magento/framework": "*",
         "magento/module-user": "*",
         "magento/module-adobe-stock-asset-api": "*",

--- a/AdobeStockAssetApi/composer.json
+++ b/AdobeStockAssetApi/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-adobe-stock-asset-api",
     "description": "N/A",
     "require": {
-        "php": "~7.1.3||~7.2.0",
+        "php": "~7.1.3||~7.2.0||~7.3.0",
         "magento/framework": "*"
     },
     "type": "magento2-module",

--- a/AdobeStockClient/composer.json
+++ b/AdobeStockClient/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-adobe-stock-client",
     "description": "N/A",
     "require": {
-        "php": "~7.1.3||~7.2.0",
+        "php": "~7.1.3||~7.2.0||~7.3.0",
         "magento/framework": "*",
         "magento/module-config": "*",
         "magento/module-adobe-stock-client-api": "*",

--- a/AdobeStockClientApi/composer.json
+++ b/AdobeStockClientApi/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-adobe-stock-client-api",
     "description": "N/A",
     "require": {
-        "php": "~7.1.3||~7.2.0",
+        "php": "~7.1.3||~7.2.0||~7.3.0",
         "magento/framework": "*"
     },
     "type": "magento2-module",

--- a/AdobeStockImage/composer.json
+++ b/AdobeStockImage/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-adobe-stock-image",
     "description": "N/A",
     "require": {
-        "php": "~7.1.3||~7.2.0",
+        "php": "~7.1.3||~7.2.0||~7.3.0",
         "magento/framework": "*",
         "magento/module-adobe-stock-asset-api": "*",
         "magento/module-adobe-stock-image-api": "*"

--- a/AdobeStockImageAdminUi/composer.json
+++ b/AdobeStockImageAdminUi/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-adobe-stock-image-admin-ui",
     "description": "N/A",
     "require": {
-        "php": "~7.1.3||~7.2.0",
+        "php": "~7.1.3||~7.2.0||~7.3.0",
         "magento/framework": "*",
         "magento/module-ui": "*",
         "magento/module-backend": "*",

--- a/AdobeStockImageApi/composer.json
+++ b/AdobeStockImageApi/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-adobe-stock-image-api",
     "description": "N/A",
     "require": {
-        "php": "~7.1.3||~7.2.0",
+        "php": "~7.1.3||~7.2.0||~7.3.0",
         "magento/framework": "*"
     },
     "type": "magento2-module",

--- a/AdobeUi/composer.json
+++ b/AdobeUi/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-adobe-ui",
     "description": "N/A",
     "require": {
-        "php": "~7.1.3||~7.2.0",
+        "php": "~7.1.3||~7.2.0||~7.3.0",
         "magento/framework": "*"
     },
     "type": "magento2-module",


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR fixed the inconsistent PHP version with root composer.json file
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/adobe-stock-integration#437: PHP versions in modules are inconsistent with version in magento composer.json
