### PR TITLE
#463 : [Styles] "See more" link for Series and Model related images styles

### DIFF
--- a/AdobeStockImageAdminUi/view/adminhtml/web/css/source/_module.less
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/css/source/_module.less
@@ -63,23 +63,48 @@
     .adobe-stock-related-images-tab-content {
       height: 120px;
       vertical-align: middle;
+      display: inline-block;
+      width: 100%;
+      .ui-tabs-panel {
+        width: 100%;
 
-      .thumbnail {
-        display: inline-block;
-        margin: 10px 10px 10px 0;
+        .thumbnail {
+          display: inline-block;
+          margin: 10px 10px 10px 0;
+          vertical-align: middle;
 
-        img {
-          max-height: 100px;
-          max-width: 160px;
+          img {
+            max-height: 100px;
+            max-width: 160px;
+          }
         }
-      }
 
-      .see-more-wrapper {
-        display: inline-block;
-        vertical-align: top;
-        height: 120px;
-        padding-top: 50px;
-        margin-left: 30px;
+        .see-more-wrapper {
+          display: inline-block;
+          max-height: 100px;
+          text-align: center;
+          max-width: 140px;
+          vertical-align: middle;
+          width: 100%;
+          cursor: pointer;
+          .see-more-content {
+            padding: 30px;
+            .three-dots {
+              margin-bottom: 10px;
+              .dots {
+                content: "\22EE";
+                display: inline-block;
+                width: 10px;
+                height: 10px;
+                color: #fff;
+                background-color: #626160;
+                border-radius: 50%;
+                line-height: 1;
+                text-align: center;
+              }
+            }
+          }
+        }
       }
     }
   }

--- a/AdobeStockImageAdminUi/view/adminhtml/web/template/grid/column/image-preview.html
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/template/grid/column/image-preview.html
@@ -97,7 +97,14 @@
                 </div>
                 <!-- /ko -->
                 <div class="see-more-wrapper" data-bind="click: function(){ $col.seeMoreFromSeries($row()) }">
-                    <a href="" class="see-more">See more</a>
+                    <div class="see-more-content">
+                        <div class="three-dots">
+                            <span class="dots"></span>
+                            <span class="dots"></span>
+                            <span class="dots"></span>
+                        </div>
+                        <a href="" class="see-more">See more</a>
+                    </div>
                 </div>
             </div>
             <div attr="'id': 'model_content_' + $row().id">


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR will fix the styling issue as per the design mock up for "See more" link
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/adobe-stock-integration#463: [Styles] "See more" link for Series and Model related images styles

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Login to admin panel
2. Open Magento Media Gallery (i.e. go to Cms -> Pages, edit the page and insert image)
3. Click "Search Adobe Stock" button to open images grid
4. Click on any image
5. Expected result
![image](https://user-images.githubusercontent.com/39480008/65580744-e1a12180-df97-11e9-9995-6e25d8571714.png)
