### PR TITLE
#462 : "See more" link applies Model filter to the grid

### DIFF
--- a/AdobeStockImageAdminUi/Ui/Component/Listing/Filter/RelatedImages.php
+++ b/AdobeStockImageAdminUi/Ui/Component/Listing/Filter/RelatedImages.php
@@ -11,9 +11,9 @@ namespace Magento\AdobeStockImageAdminUi\Ui\Component\Listing\Filter;
 use Magento\Ui\Component\Filters\Type\Input;
 
 /**
- * SerieId filter
+ * RelatedImages filter
  */
-class SerieId extends Input
+class RelatedImages extends Input
 {
     const NAME = 'filter_input';
 

--- a/AdobeStockImageAdminUi/view/adminhtml/ui_component/adobe_stock_images_listing.xml
+++ b/AdobeStockImageAdminUi/view/adminhtml/ui_component/adobe_stock_images_listing.xml
@@ -139,7 +139,7 @@
                     <label translate="true">Isolated Assets</label>
                 </settings>
             </filterInput>
-            <filterInput name="serie_id" class="\Magento\AdobeStockImageAdminUi\Ui\Component\Listing\Filter\SerieId" provider="${ $.parentName }" sortOrder="70">
+            <filterInput name="serie_id" class="\Magento\AdobeStockImageAdminUi\Ui\Component\Listing\Filter\RelatedImages" provider="${ $.parentName }" sortOrder="70">
                 <argument name="data" xsi:type="array">
                     <item name="config" xsi:type="array">
                         <item name="label" xsi:type="string" translate="true">Serie Id</item>
@@ -149,6 +149,18 @@
                 </argument>
                 <settings>
                     <label translate="true">Serie Id</label>
+                </settings>
+            </filterInput>
+            <filterInput name="model_id" class="\Magento\AdobeStockImageAdminUi\Ui\Component\Listing\Filter\RelatedImages" provider="${ $.parentName }" sortOrder="80">
+                <argument name="data" xsi:type="array">
+                    <item name="config" xsi:type="array">
+                        <item name="label" xsi:type="string" translate="true">Model Id</item>
+                        <item name="visible" xsi:type="boolean">false</item>
+                        <item name="dataScope" xsi:type="string">model_id</item>
+                    </item>
+                </argument>
+                <settings>
+                    <label translate="true">Model Id</label>
                 </settings>
             </filterInput>
         </filters>

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/image-preview.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/image-preview.js
@@ -26,6 +26,7 @@ define([
             inputValue: '',
             chipInputValue: '',
             serieFilterValue: '',
+            modelFilterValue: '',
             keywordsLimit: 5,
             saveAvailable: true,
             searchValue: null,
@@ -34,7 +35,8 @@ define([
                 visible: true,
                 sorting: true,
                 lastOpenedImage: true,
-                serieFilterValue: true
+                serieFilterValue: true,
+                modelFilterValue: true
             },
             tracks: {
                 lastOpenedImage: true
@@ -47,21 +49,22 @@ define([
             },
             listens: {
                 '${ $.provider }:params.filters': 'hide',
-                '${ $.provider }:params.search': 'hide',
+                '${ $.provider }:params.search': 'hide'
             },
             exports: {
                 inputValue: '${ $.provider }:params.search',
                 serieFilterValue: '${ $.provider }:params.filters.serie_id',
+                modelFilterValue: '${ $.provider }:params.filters.model_id',
                 chipInputValue: '${ $.searchChipsProvider }:value'
             }
         },
 
         /**
          *
-         * @param {Obejct} record
+         * @param {Object} record
          * @private
          */
-        _initRecord(record) {
+        _initRecord: function(record) {
             if (!record.model || !record.series) {
                 record.series = ko.observable([]);
                 record.model = ko.observable([]);
@@ -108,7 +111,8 @@ define([
                     'height',
                     'inputValue',
                     'chipInputValue',
-                    'serieFilterValue'
+                    'serieFilterValue',
+                    'modelFilterValue'
                 ]);
             this.height.subscribe(function () {
                 this.thumbnailComponent().previewHeight(this.height());
@@ -131,7 +135,7 @@ define([
                 data: {
                     'image_id': record.id,
                     'limit': 4
-                },
+                }
             }).done(function (data) {
                 record.series(data.result.same_series);
                 record.model(data.result.same_model);
@@ -235,6 +239,17 @@ define([
         seeMoreFromSeries: function(record) {
             this.serieFilterValue(record.id);
             this.filterChips().set('applied', {'serie_id' : record.id.toString()})
+        },
+
+        /**
+         * Filter images from serie_id
+         *
+         * @param record
+         * @returns {*}
+         */
+        seeMoreFromModel: function(record) {
+            this.modelFilterValue(record.id);
+            this.filterChips().set('applied', {'model_id' : record.id.toString()})
         },
 
         /**

--- a/AdobeStockImageAdminUi/view/adminhtml/web/template/grid/column/image-preview.html
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/template/grid/column/image-preview.html
@@ -106,6 +106,9 @@
                     <img attr="src: thumbnail_url, alt: title">
                 </div>
                 <!-- /ko -->
+                <div class="see-more-wrapper" data-bind="click: function(){ $col.seeMoreFromModel($row()) }">
+                    <a href="" class="see-more">See more</a>
+                </div>
             </div>
         </div>
     </div>

--- a/AdobeStockImageAdminUi/view/adminhtml/web/template/grid/column/image-preview.html
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/template/grid/column/image-preview.html
@@ -114,7 +114,14 @@
                 </div>
                 <!-- /ko -->
                 <div class="see-more-wrapper" data-bind="click: function(){ $col.seeMoreFromModel($row()) }">
-                    <a href="" class="see-more">See more</a>
+                    <div class="see-more-content">
+                        <div class="three-dots">
+                            <span class="dots"></span>
+                            <span class="dots"></span>
+                            <span class="dots"></span>
+                        </div>
+                        <a href="" class="see-more">See more</a>
+                    </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR will introduce the feature to view more related images from the model
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/adobe-stock-integration#462: "See more" link applies Model filter to the grid

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Login to admin panel
2. Open Magento Media Gallery (i.e. go to Cms -> Pages, edit the page and insert image)
3. Click "Search Adobe Stock" button to open images grid
4. Click on any image
5. Click on "More from this model" tab in the expanded image preview
6. Expected Result 
![image](https://user-images.githubusercontent.com/39480008/65596625-df998b80-dfb4-11e9-954e-330ec75db672.png)
![image](https://user-images.githubusercontent.com/39480008/65596565-c1339000-dfb4-11e9-82a6-193128c9b458.png)
