### PR TITLE
ASI-472 Use JsonHexTag instead of native json_encode

### DIFF
--- a/AdobeStockAdminUi/Block/Adminhtml/SignIn.php
+++ b/AdobeStockAdminUi/Block/Adminhtml/SignIn.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 
 namespace Magento\AdobeStockAdminUi\Block\Adminhtml;
 
+use Magento\AdobeIms\Controller\Adminhtml\OAuth\Callback;
 use Magento\AdobeIms\Model\Config;
 use Magento\AdobeImsApi\Api\Data\UserProfileInterface;
 use Magento\Backend\Block\Template;
@@ -14,7 +15,7 @@ use Magento\Backend\Block\Template\Context;
 use Magento\Authorization\Model\UserContextInterface;
 use Magento\AdobeImsApi\Api\UserAuthorizedInterface;
 use Magento\AdobeImsApi\Api\UserProfileRepositoryInterface;
-use Magento\Framework\Serialize\Serializer\Json;
+use Magento\Framework\Serialize\Serializer\JsonHexTag;
 
 /**
  * Adobe Stock sign in block
@@ -42,9 +43,9 @@ class SignIn extends Template
     private $userProfileRepository;
 
     /**
-     * Json Serializer Instance
+     * JsonHexTag Serializer Instance
      *
-     * @var Json
+     * @var JsonHexTag
      */
     private $serializer;
 
@@ -56,7 +57,7 @@ class SignIn extends Template
      * @param UserContextInterface $userContext
      * @param UserAuthorizedInterface $userAuthorized
      * @param UserProfileRepositoryInterface $userProfileRepository
-     * @param Json $json
+     * @param JsonHexTag $json
      * @param array $data
      */
     public function __construct(
@@ -65,7 +66,7 @@ class SignIn extends Template
         UserContextInterface $userContext,
         UserAuthorizedInterface $userAuthorized,
         UserProfileRepositoryInterface $userProfileRepository,
-        Json $json,
+        JsonHexTag $json,
         array $data = []
     ) {
         $this->config = $config;
@@ -116,6 +117,16 @@ class SignIn extends Template
     public function isAuthorizedJson(): string
     {
         return $this->isAuthorized() ? 'true' : 'false';
+    }
+
+    /**
+     * Returns response regexp pattern.
+     *
+     * @return string
+     */
+    public function getRegexpPattern(): string
+    {
+        return $this->serializer->serialize(Callback::RESPONSE_REGEXP_PATTERN);
     }
 
     /**

--- a/AdobeStockAdminUi/view/adminhtml/templates/signIn.phtml
+++ b/AdobeStockAdminUi/view/adminhtml/templates/signIn.phtml
@@ -25,7 +25,7 @@ use Magento\AdobeIms\Controller\Adminhtml\OAuth\Callback;
                         "logoutUrl": "<?= /* @noEscape */ $block->getUrl('adobe_ims/user/logout') ?>",
                         "isAuthorized": "<?= /* @noEscape */ $block->isAuthorizedJson() ?>",
                         "callbackParsingParams": {
-                            "regexpPattern": <?= /* @noEscape */ json_encode(Callback::RESPONSE_REGEXP_PATTERN, JSON_HEX_QUOT) ?>,
+                            "regexpPattern": <?= /* @noEscape */ $block->getRegexpPattern() ?>,
                             "codeIndex": "<?= /* @noEscape */ Callback::RESPONSE_CODE_INDEX ?>",
                             "messageIndex": "<?= /* @noEscape */ Callback::RESPONSE_MESSAGE_INDEX ?>",
                             "successCode": "<?= /* @noEscape */ Callback::RESPONSE_SUCCESS_CODE ?>",


### PR DESCRIPTION
Use JsonHexTag instead of native json_encode function in AdobeStockAdminUi signIn template.