### PR TITLE
#467 : [Styles] Keywords appearance in the image preview

### DIFF
--- a/AdobeStockImageAdminUi/view/adminhtml/web/css/source/_module.less
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/css/source/_module.less
@@ -40,44 +40,62 @@
     }
 
     .keywords {
-
+      margin: 30px 0;
+      display: inline-block;
+      width: 100%;
       .title {
-        margin-top: 10px;
+        margin-bottom: 30px;
       }
 
       .keyword {
+        display: inline-block;
+        margin-right: 5px;
+        line-height: 40px;
         &.hide {
           display: none;
         }
-
-        display: inline-block;
-        margin: 15px 15px 15px 0;
-
         .value {
           font-size: 15px;
           text-transform: capitalize;
+          border: 1px solid #c6c1bb;
+          padding: 5px;
+          border-radius: 3px;
+          background-color: #f5f5f5;
+          color: #666666;
         }
+      }
+      button {
+        margin-left: 10px;
       }
     }
 
+    .adobe-stock-tabs {
+      margin-top: 30px;
+    }
+
     .adobe-stock-related-images-tab-content {
-      height: 120px;
+      height: auto;
       vertical-align: middle;
+      display: inline-block;
+      width: 100%;
+      .ui-tabs-panel {
+        margin-top: 30px;
+        padding: 0;
+        .thumbnail {
+          display: inline-block;
+          margin-right: 10px;
 
-      .thumbnail {
-        display: inline-block;
-        margin: 10px 10px 10px 0;
-
-        img {
-          max-height: 100px;
-          max-width: 160px;
+          img {
+            max-height: 100px;
+            max-width: 160px;
+          }
         }
       }
 
       .see-more-wrapper {
         display: inline-block;
         vertical-align: top;
-        height: 120px;
+        height: auto;
         padding-top: 50px;
         margin-left: 30px;
       }

--- a/AdobeStockImageAdminUi/view/adminhtml/web/template/grid/column/image-preview.html
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/template/grid/column/image-preview.html
@@ -55,20 +55,9 @@
             </div>
             <!-- /ko -->
         </div>
-        <div class="keywords">
-            <div class="title" translate="'Similar Keywords'"></div>
-            <!-- ko foreach: $col.getKeywords($row()) -->
-            <div class="keyword" data-bind="css: { 'hide': $index() >= $col.getKeywordsLimit($row())}">
-                <a href="" class="value" data-bind="click: function(){ $col.searchByKeyWord(name) }">
-                    <span text="name"/>
-                </a>
-            </div>
-            <!-- /ko -->
-            <button data-bind="visible: $col.canViewMoreKeywords($row()), click: function(){ $col.viewAllKeywords($row()) }">
-                <span translate="'View all'"/>
-            </button>
-        </div>
+
         <div id="adobe-stock-tabs"
+             class="adobe-stock-tabs"
              data-bind="mageInit: {
                     'mage/backend/tabs': {
                     active: 'series_content_' + $row().id,
@@ -107,6 +96,19 @@
                 </div>
                 <!-- /ko -->
             </div>
+        </div>
+        <div class="keywords">
+            <div class="title" translate="'Similar Keywords'"></div>
+            <!-- ko foreach: $col.getKeywords($row()) -->
+            <div class="keyword" data-bind="css: { 'hide': $index() >= $col.getKeywordsLimit($row())}">
+                <a href="" class="value" data-bind="click: function(){ $col.searchByKeyWord(name) }">
+                    <span text="name"/>
+                </a>
+            </div>
+            <!-- /ko -->
+            <button data-bind="visible: $col.canViewMoreKeywords($row()), click: function(){ $col.viewAllKeywords($row()) }">
+                <span translate="'View all'"/>
+            </button>
         </div>
     </div>
 </div>


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR will introduce the css changes as per the design mockup

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/adobe-stock-integration#467: [Styles] Keywords appearance in the image preview

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
Login to admin panel
1. Open Magento Media Gallery (i.e. go to Cms -> Pages, edit the page and insert image)
2. Click "Search Adobe Stock" button to open images grid
3. Click on any image to expand image preview
4. Expected Result 
![image](https://user-images.githubusercontent.com/39480008/65612179-7d02b880-dfd1-11e9-88cb-b238bad25f3c.png)

