### PR TITLE
Use hydrator instead of getData method in Save Resource models

### DIFF
--- a/AdobeStockAsset/Model/ResourceModel/Asset/Command/Save.php
+++ b/AdobeStockAsset/Model/ResourceModel/Asset/Command/Save.php
@@ -11,6 +11,7 @@ use Magento\Framework\App\ResourceConnection;
 use Magento\AdobeStockAssetApi\Api\Data\AssetInterface;
 use Magento\AdobeStockAsset\Model\ResourceModel\Asset as AssetResourceModel;
 use Magento\Framework\DB\Adapter\AdapterInterface;
+use Magento\Framework\EntityManager\Hydrator;
 
 /**
  * Save multiple asset service.
@@ -23,13 +24,22 @@ class Save
     private $resourceConnection;
 
     /**
+     * @var Hydrator $hydrator
+     */
+    private $hydrator;
+
+    /**
      * Save constructor.
+     *
      * @param ResourceConnection $resourceConnection
+     * @param Hydrator $hydrate
      */
     public function __construct(
-        ResourceConnection $resourceConnection
+        ResourceConnection $resourceConnection,
+        Hydrator $hydrate
     ) {
         $this->resourceConnection = $resourceConnection;
+        $this->hydrator = $hydrate;
     }
 
     /**
@@ -40,7 +50,7 @@ class Save
      */
     public function execute(AssetInterface $assets): void
     {
-        $data = $assets->getData();
+        $data = $this->hydrator->extract($assets);
         $tableName = $this->resourceConnection->getTableName(
             AssetResourceModel::ADOBE_STOCK_ASSET_TABLE_NAME
         );

--- a/AdobeStockAsset/Model/ResourceModel/Category/Command/Save.php
+++ b/AdobeStockAsset/Model/ResourceModel/Category/Command/Save.php
@@ -11,6 +11,7 @@ use Magento\Framework\App\ResourceConnection;
 use Magento\AdobeStockAssetApi\Api\Data\CategoryInterface;
 use Magento\AdobeStockAsset\Model\ResourceModel\Category as CategoryResourceModel;
 use Magento\Framework\DB\Adapter\AdapterInterface;
+use Magento\Framework\EntityManager\Hydrator;
 
 /**
  * Save multiple category service.
@@ -23,14 +24,22 @@ class Save
     private $resourceConnection;
 
     /**
+     * @var Hydrator $hydrator
+     */
+    private $hydrator;
+
+    /**
      * Save constructor.
      *
      * @param ResourceConnection $resourceConnection
+     * @param Hydrator $hydrator
      */
     public function __construct(
-        ResourceConnection $resourceConnection
+        ResourceConnection $resourceConnection,
+        Hydrator $hydrator
     ) {
         $this->resourceConnection = $resourceConnection;
+        $this->hydrator = $hydrator;
     }
 
     /**
@@ -41,7 +50,7 @@ class Save
      */
     public function execute(CategoryInterface $category): void
     {
-        $data = $category->getData();
+        $data = $this->hydrator->extract($category);
         $connection = $this->getConnection();
         $tableName = $this->resourceConnection->getTableName(
             CategoryResourceModel::ADOBE_STOCK_ASSET_CATEGORY_TABLE_NAME

--- a/AdobeStockAsset/Model/ResourceModel/Creator/Command/Save.php
+++ b/AdobeStockAsset/Model/ResourceModel/Creator/Command/Save.php
@@ -11,6 +11,7 @@ use Magento\Framework\App\ResourceConnection;
 use Magento\AdobeStockAssetApi\Api\Data\CreatorInterface;
 use Magento\AdobeStockAsset\Model\ResourceModel\Creator as CreatorResourceModel;
 use Magento\Framework\DB\Adapter\AdapterInterface;
+use Magento\Framework\EntityManager\Hydrator;
 
 /**
  * Save multiple asset service.
@@ -23,13 +24,22 @@ class Save
     private $resourceConnection;
 
     /**
+     * @var Hydrator $hydrator
+     */
+    private $hydrator;
+
+    /**
      * Save constructor.
+     *
      * @param ResourceConnection $resourceConnection
+     * @param Hydrator $hydrator
      */
     public function __construct(
-        ResourceConnection $resourceConnection
+        ResourceConnection $resourceConnection,
+        Hydrator $hydrator
     ) {
         $this->resourceConnection = $resourceConnection;
+        $this->hydrator = $hydrator;
     }
 
     /**
@@ -40,7 +50,7 @@ class Save
      */
     public function execute(CreatorInterface $creator): void
     {
-        $data = $creator->getData();
+        $data = $this->hydrator->extract($creator);
 
         $connection = $this->getConnection();
         $tableName = $this->resourceConnection->getTableName(

--- a/AdobeStockAssetApi/Api/Data/AssetInterface.php
+++ b/AdobeStockAssetApi/Api/Data/AssetInterface.php
@@ -319,6 +319,7 @@ interface AssetInterface extends \Magento\Framework\Api\ExtensibleDataInterface
      * Sets image URL
      *
      * @param string $url
+     * @return void
      */
     public function setUrl(string $url): void;
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)

Retrieve data from models using \Magento\Framework\EntityManager\Hydrator instead of calling non-interface getData method in:

```
\Magento\AdobeStockAsset\Model\ResourceModel\Asset\Command\Save::execute
\Magento\AdobeStockAsset\Model\ResourceModel\Category\Command\Save::execute
\Magento\AdobeStockAsset\Model\ResourceModel\Creator\Command\Save::execute
```

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/adobe-stock-integration#470: Use hydrator instead of getData method in Save Resource models


### Manual testing scenarios (*)

1. Configure Adobe Stock Integration
2. Try to save image preview
3. Image preview saved correctly.