### PR TITLE
#issue-502 Fixed the issue with not loaded "More from this series" and "More from this model" sections when the preview was switched via next or previous buttons

### DIFF
--- a/AdobeUi/view/adminhtml/web/js/components/grid/column/image-preview.js
+++ b/AdobeUi/view/adminhtml/web/js/components/grid/column/image-preview.js
@@ -15,8 +15,8 @@ define([
             visibility: [],
             height: 0,
             lastOpenedImage: null,
-            imports: {
-                records: '${ $.provider }:data.items'
+            modules: {
+                masonry: '${ $.parentName }'
             }
         },
 
@@ -26,7 +26,7 @@ define([
          * @param record
          */
         next: function (record) {
-            var recordToShow = this.records[record._rowIndex + 1];
+            var recordToShow = this.getRecord(record._rowIndex + 1);
             recordToShow.rowNumber = record.lastInRow ? record.rowNumber + 1 : record.rowNumber;
             this.show(recordToShow);
         },
@@ -37,9 +37,20 @@ define([
          * @param record
          */
         prev: function (record) {
-            var recordToShow = this.records[record._rowIndex - 1];
+            var recordToShow = this.getRecord(record._rowIndex - 1);
             recordToShow.rowNumber = record.firstInRow ? record.rowNumber - 1 : record.rowNumber;
             this.show(recordToShow);
+        },
+
+        /**
+         * Get record
+         *
+         * @param {Integer} recordIndex
+         *
+         * @return {Object}
+         */
+        getRecord: function (recordIndex) {
+            return this.masonry().rows()[recordIndex];
         },
 
         /**


### PR DESCRIPTION
### Description (*)
This PR fixes the issue with not loaded "More from this series" and "More from this model" sections when an admin user switches the preview via next/previous buttons (arrows).

### Fixed Issues (if relevant)

1. magento/adobe-stock-integration#502: The "More from this series" and "More from this model" sections are not loaded

### Manual testing scenarios (*)

1. Login to admin panel
2. Open Magento Media Gallery (i.e. go to Cms -> Pages, edit the page and insert image)
3. Click "Search Adobe Stock" button to open images grid
4. Click on any image to expand image preview
5. Click on the next or previous buttons