### PR TITLE
#511 : Provide redirect URL pattern suggestion compatible with admin secret key in configuration

### DIFF
--- a/AdobeStockAdminUi/Model/System/Config/Comment.php
+++ b/AdobeStockAdminUi/Model/System/Config/Comment.php
@@ -18,6 +18,8 @@ class Comment implements CommentInterface
 {
     private const REDIRECT_MCA = 'adobe_ims/oauth/callback';
 
+    private const REG_EXP_URL = '.*';
+
     /**
      * @var UrlInterface
      */
@@ -75,6 +77,6 @@ class Comment implements CommentInterface
      */
     private function getRedirectUrlPattern(): string
     {
-        return str_replace('.', '\\\.', $this->getRedirectUrl());
+        return str_replace('.', '\\\.', $this->getRedirectUrl()).self::REG_EXP_URL;
     }
 }


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR will fix the issue for redirect URL issue when the secret key to URLs is enabled

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/adobe-stock-integration#511: Provide redirect URL pattern suggestion compatible with admin secret key in configuration

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Login to admin panel
2. Go to Stores -> Configuration -> Advanced -> System -> Adobe Stock Integration fieldset
3. See comments next to "Private Key" field
4. Expected Result 
![image](https://user-images.githubusercontent.com/39480008/66381742-83346400-e9d7-11e9-9960-22a4c0ea827d.png)
