### PR TITLE
Add image name field to license confirmation popup && Image preview is saved event if operation is cancelled

### DIFF
--- a/AdobeStockImageAdminUi/view/adminhtml/web/css/source/_module.less
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/css/source/_module.less
@@ -152,7 +152,7 @@
 
       .modal-content {
         .prompt-message {
-          font-weight: bold;
+          font-weight: normal;
           margin-bottom: 15px;
         }
         .admin__field-wide {

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/actions.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/actions.js
@@ -152,9 +152,10 @@ define([
          * License and save image
          *
          * @param {Object} record
+         * @param fileName
          */
-        licenseAndSave: function (record) {
-            this.save(record, this.generateImageName(record), this.preview().licenseAndDownloadUrl);
+        licenseAndSave: function (record, fileName) {
+            this.save(record, fileName, this.preview().licenseAndDownloadUrl);
         },
 
         /**
@@ -182,11 +183,11 @@ define([
                         this.getPrompt(
                             {
                                 'title': $.mage.__('License Adobe Stock Image?'),
-                                'content': confirmationContent + '<p><b>' + quotaMessage + '</b></p>',
+                                'content': '<p>' + confirmationContent + '</p><p><b>' + quotaMessage + '</p><br>' + $.mage.__('File Name') + '</b>',
                                 'visible': canPurchase,
                                 'actions': {
-                                    confirm: function () {
-                                        canPurchase ? licenseAndSave(record) : window.open(this.preview().buyCreditsUrl);
+                                    confirm: function (fileName) {
+                                        canPurchase ? licenseAndSave(record, fileName) : window.open(this.preview().buyCreditsUrl);
                                     }
                                 },
                                 'buttons': [{
@@ -196,12 +197,8 @@ define([
                                         this.closeModal();
                                     }
                                 }, {
-                                    text: canPurchase ? $.mage.__('OK') : $.mage.__('Buy Credits'),
+                                    text: canPurchase ? $.mage.__('Confirm') : $.mage.__('Buy Credits'),
                                     class: 'action-primary action-accept',
-                                    click: function () {
-                                        this.closeModal();
-                                        this.options.actions.confirm();
-                                    }
                                 }]
 
                             }

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/actions.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/actions.js
@@ -52,40 +52,33 @@ define([
          * Save preview
          */
         savePreview: function () {
-            prompt({
-                title: 'Save Preview',
-                content: 'File Name',
-                value: this.generateImageName(this.preview().displayedRecord()),
-                imageExtension: this.getImageExtension(this.preview().displayedRecord()),
-                promptContentTmpl: adobePromptContentTmpl,
-                modalClass: 'adobe-stock-save-preview-prompt',
-                validation: true,
-                promptField: '[data-role="promptField"]',
-                validationRules: ['required-entry'],
-                attributesForm: {
-                    novalidate: 'novalidate',
-                    action: '',
-                    onkeydown: 'return event.key != \'Enter\';'
-                },
-                attributesField: {
-                    name: 'name',
-                    'data-validate': '{required:true}',
-                    maxlength: '128'
-                },
-                context: this,
-                actions: {
-                    confirm: function (fileName) {
-                        this.save(this.preview().displayedRecord(), fileName, this.preview().downloadImagePreviewUrl);
-                    }.bind(this)
-                },
-                buttons: [{
-                    text: $.mage.__('Cancel'),
-                    class: 'action-secondary action-dismiss'
-                }, {
-                    text: $.mage.__('Confirm'),
-                    class: 'action-primary action-accept'
-                }]
-            });
+            this.getPrompt(
+                {
+                    'title': $.mage.__('Save Preview'),
+                    'content': $.mage.__('File Name'),
+                    'visible': true,
+                    'actions': {
+                        confirm: function (fileName) {
+                            this.save(
+                                this.preview().displayedRecord(),
+                                fileName,
+                                this.preview().downloadImagePreviewUrl
+                            );
+                        }.bind(this)
+                    },
+                    'buttons': [{
+                        text: $.mage.__('Cancel'),
+                        class: 'action-secondary action-dismiss',
+                        click: function () {
+                            this.closeModal();
+                        }
+                    }, {
+                        text: $.mage.__('Confirm'),
+                        class: 'action-primary action-accept'
+                    }]
+
+                }
+            );
         },
 
         /**
@@ -186,33 +179,33 @@ define([
                         var confirmationContent = $.mage.__('License "' + record.title + '"'),
                             quotaMessage = response.result.message,
                             canPurchase = response.result.canLicense;
-                        confirmation({
-                            title: $.mage.__('License Adobe Stock Image?'),
-                            content: confirmationContent + '<p><b>' + quotaMessage + '</b></p>',
-                            actions: {
-                                confirm: function () {
-                                    if (canPurchase) {
-                                        licenseAndSave(record);
-                                    } else {
-                                        window.open(this.preview().buyCreditsUrl);
+                        this.getPrompt(
+                            {
+                                'title': $.mage.__('License Adobe Stock Image?'),
+                                'content': confirmationContent + '<p><b>' + quotaMessage + '</b></p>',
+                                'visible': canPurchase,
+                                'actions': {
+                                    confirm: function () {
+                                        canPurchase ? licenseAndSave(record) : window.open(this.preview().buyCreditsUrl);
                                     }
-                                }
-                            },
-                            buttons: [{
-                                text: $.mage.__('Cancel'),
-                                class: 'action-secondary action-dismiss',
-                                click: function () {
-                                    this.closeModal();
-                                }
-                            }, {
-                                text: canPurchase ? $.mage.__('OK') : $.mage.__('Buy Credits'),
-                                class: 'action-primary action-accept',
-                                click: function () {
-                                    this.closeModal();
-                                    this.options.actions.confirm();
-                                }
-                            }]
-                        })
+                                },
+                                'buttons': [{
+                                    text: $.mage.__('Cancel'),
+                                    class: 'action-secondary action-dismiss',
+                                    click: function () {
+                                        this.closeModal();
+                                    }
+                                }, {
+                                    text: canPurchase ? $.mage.__('OK') : $.mage.__('Buy Credits'),
+                                    class: 'action-primary action-accept',
+                                    click: function () {
+                                        this.closeModal();
+                                        this.options.actions.confirm();
+                                    }
+                                }]
+
+                            }
+                        );
                     },
 
                     error: function (response) {
@@ -221,6 +214,37 @@ define([
                     }
                 }
             );
+        },
+
+        /**
+         * Return configured  prompt with input field.
+         */
+        getPrompt: function (data) {
+            prompt({
+                title: data.title,
+                content:  data.content,
+                value: this.generateImageName(this.preview().displayedRecord()),
+                imageExtension: this.getImageExtension(this.preview().displayedRecord()),
+                visible: data.visible,
+                promptContentTmpl: adobePromptContentTmpl,
+                modalClass: 'adobe-stock-save-preview-prompt',
+                validation: true,
+                promptField: '[data-role="promptField"]',
+                validationRules: ['required-entry'],
+                attributesForm: {
+                    novalidate: 'novalidate',
+                    action: '',
+                    onkeydown: 'return event.key != \'Enter\';'
+                },
+                attributesField: {
+                    name: 'name',
+                    'data-validate': '{required:true}',
+                    maxlength: '128'
+                },
+                context: this,
+                actions: data.actions,
+                buttons: data.buttons
+            });
         },
 
         /**

--- a/AdobeStockImageAdminUi/view/adminhtml/web/template/modal/adobe-modal-prompt-content.html
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/template/modal/adobe-modal-prompt-content.html
@@ -4,6 +4,7 @@
  * See COPYING.txt for license details.
  */
 -->
+<% if (data.visible) { %>
 <form <%= formAttr %>>
 <fieldset class="admin__fieldset">
     <div class="admin__field admin__field-wide">
@@ -19,3 +20,4 @@
     </div>
 </fieldset>
 </form>
+<% } %>


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/adobe-stock-integration#465: Add image name field to license confirmation popup
2.  magento/adobe-stock-integration#512 Image preview is saved event if operation is cancelled

### Manual testing scenarios (*)

1.     Login to admin panel
2.     Open Magento Media Gallery (i.e. go to Cms -> Pages, edit the page and insert image)
3.     Click "Search Adobe Stock" button to open images grid
4.     Click on any image to expand image preview
5.     Click on "License and Save" button
