### PR TITLE
#521 : Applied sort order of Adobe Stock grid is not preserved after page reload

### DIFF
--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/sorting.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/sorting.js
@@ -17,6 +17,10 @@ define([
             listens: {
                 'selectedOption': 'applyChanges'
             },
+            statefull: {
+                selectedOption: true,
+                applied: true
+            },
             exports: {
                 applied: '${ $.provider }:params.sorting'
             }


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR will fixed the issue regarding sort order which is dropped when the page is reloaded
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/adobe-stock-integration#521: Applied sort order of Adobe Stock grid is not preserved after page reload

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Login to admin panel
2. Open Magento Media Gallery (i.e. go to Cms -> Pages, edit the page and insert image)
3. Click "Search Adobe Stock" button to open images grid
4. Click on any image to expand image preview
5. Change the sort order of the grid to "Downloads"
6. Reload the page and reopen the grid
7. Check if the sort order is still set to "Downloads"