### PR TITLE
#448 : [MFTF] User sees images from the same series as the currently viewed image

### DIFF
--- a/AdobeStockImageAdminUi/Test/Mftf/ActionGroup/AssertNumberOfImagesUnderMoreForThisSeriesActionGroup.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/ActionGroup/AssertNumberOfImagesUnderMoreForThisSeriesActionGroup.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="AssertNumberOfImagesUnderMoreForThisSeriesActionGroup">
+        <arguments>
+            <argument name="imagesNumber" type="string"/>
+        </arguments>
+        <seeNumberOfElements selector="{{AdobeStockImagePreviewSection.moreFromThisSeriesImages}}" userInput="{{imagesNumber}}" stepKey="seeCorrectImagesNumber"/>
+    </actionGroup>
+</actionGroups>

--- a/AdobeStockImageAdminUi/Test/Mftf/Section/AdobeStockImagePreviewSection.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Section/AdobeStockImagePreviewSection.xml
@@ -21,5 +21,7 @@
         <element name="generatedImageName" selector="//*[@data-role='promptField']" type="input"/>
         <element name="moreFromThisModel" selector="//*[@id='model_tab']" type="block"/>
         <element name="moreFromThisModelImages" selector="//div[@aria-labelledby='model_tab']//div[@class='thumbnail']" type="block"/>
+        <element name="moreFromThisSeries" selector="//*[@id='series_tab']" type="block"/>
+        <element name="moreFromThisSeriesImages" selector="//div[@aria-labelledby='series_tab']//div[@class='thumbnail']" type="block"/>
     </section>
 </sections>

--- a/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockImagePreviewSameSeriesTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockImagePreviewSameSeriesTest.xml
@@ -13,6 +13,8 @@
             <title value="Admin should be able to see images with same series"/>
             <description value="User sees images with the same series"/>
             <severity value="CRITICAL"/>
+            <group value="adobe_stock_integration_preview"/>
+            <group value="adobe_stock_integration"/>
         </annotations>
         <before>
             <actionGroup ref="LoginAsAdmin" stepKey="loginAsAdmin"/>

--- a/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockImagePreviewSameSeriesTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockImagePreviewSameSeriesTest.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+    <test name="AdminAdobeStockImagePreviewSameSeriesTest">
+        <annotations>
+            <stories value="Cover scenario: User sees images with the same series as the currently viewed one"/>
+            <title value="Admin should be able to see images with same series"/>
+            <description value="User sees images with the same series"/>
+            <severity value="CRITICAL"/>
+        </annotations>
+        <before>
+            <actionGroup ref="LoginAsAdmin" stepKey="loginAsAdmin"/>
+            <actionGroup ref="AdminOpenMediaGalleryForPageNoEditorActionGroup" stepKey="openMediaGalleryForPage"/>
+            <actionGroup ref="AdminAdobeStockOpenPanelFromMediaGalleryActionGroup" stepKey="openAdobeStockPanel"/>
+        </before>
+        <after>
+            <actionGroup ref="resetAdminDataGridToDefaultView" stepKey="resetAdminDataGridToDefaultView"/>
+            <actionGroup ref="logout" stepKey="logout"/>
+        </after>
+
+        <actionGroup ref="AdminAdobeStockExpandImagePreviewActionGroup" stepKey="expandImagePreview"/>
+        <conditionalClick selector="{{AdobeStockImagePreviewSection.moreFromThisSeries}}" dependentSelector="{{AdobeStockImagePreviewSection.moreFromThisSeries}}" visible="false" stepKey="clickOnTabMoreForThisSeries"/>
+        <actionGroup ref="AssertNumberOfImagesUnderMoreForThisSeriesActionGroup" stepKey="assertImagesUnderMoreForThisSeriesCount">
+            <argument name="imagesNumber" value="4"/>
+        </actionGroup>
+    </test>
+</tests>


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR will introduce the MFTF testing for the user can see the series images for the currently viewed image
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/adobe-stock-integration#448: [MFTF] User sees images from the same series as the currently viewed image
