### PR TITLE
Covering the SignInConfigProvider by Unit Test

### DIFF
--- a/AdobeIms/Test/Unit/Model/UserAuthorizedTest.php
+++ b/AdobeIms/Test/Unit/Model/UserAuthorizedTest.php
@@ -60,7 +60,7 @@ class UserAuthorizedTest extends TestCase
         $userProfileMock->expects($this->once())->method('getAccessToken')->willReturn('token');
         $userProfileMock->expects($this->exactly(2))
             ->method('getAccessTokenExpiresAt')
-            ->willReturn(date('Y-m-d h:i:s'));
+            ->willReturn(date('Y-m-d H:i:s'));
 
         $this->assertEquals(true, $this->userAuthorized->execute());
     }

--- a/AdobeStockImageAdminUi/Test/Unit/Model/SignInConfigProviderTest.php
+++ b/AdobeStockImageAdminUi/Test/Unit/Model/SignInConfigProviderTest.php
@@ -1,0 +1,176 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Magento\AdobeStockImageAdminUi\Test\Unit\Model;
+
+use Magento\AdobeImsApi\Api\UserAuthorizedInterface;
+use Magento\AdobeStockClientApi\Api\ClientInterface;
+use Magento\AdobeStockClientApi\Api\Data\UserQuotaInterface;
+use Magento\AdobeStockImageAdminUi\Model\SignInConfigProvider;
+use Magento\Framework\Exception\AuthenticationException;
+use Magento\Framework\Exception\AuthorizationException;
+use Magento\Framework\Phrase;
+use Magento\Framework\UrlInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * SignInConfigProviderTest test.
+ */
+class SignInConfigProviderTest extends TestCase
+{
+    /**
+     * @var SignInConfigProvider
+     */
+    private $sut;
+
+    /**
+     * @var ClientInterface|MockObject
+     */
+    private $clientInterfaceMock;
+
+    /**
+     * @var UserAuthorizedInterface|MockObject
+     */
+    private $userAuthorizedMock;
+
+    /**
+     * @var UrlInterface|MockObject
+     */
+    private $urlMock;
+
+    /**
+     * @var UserQuotaInterface|MockObject
+     */
+    private $userQuotaMock;
+
+    /**
+     * Set Up
+     */
+    protected function setUp()
+    {
+        $this->clientInterfaceMock = $this->createMock(ClientInterface::class);
+        $this->userAuthorizedMock = $this->createMock(UserAuthorizedInterface::class);
+        $this->urlMock = $this->createMock(UrlInterface::class);
+        $this->userQuotaMock = $this->createMock(UserQuotaInterface::class);
+
+        $this->sut = new SignInConfigProvider(
+            $this->clientInterfaceMock,
+            $this->userAuthorizedMock,
+            $this->urlMock
+        );
+    }
+
+    /**
+     * Testing the available quota for for authorized and not authorized users
+     *
+     * @dataProvider userQuotaProvider
+     *
+     * @param bool $userIsAuthorized
+     * @param array $userQuota
+     */
+    public function testGettingUserQuota(bool $userIsAuthorized, array $userQuota)
+    {
+        $quotaUrl = 'http://site.com/adobe_stock/license/quota';
+        $expectedResult = [
+            'component' => 'Magento_AdobeStockImageAdminUi/js/signIn',
+            'template' => 'Magento_AdobeStockImageAdminUi/signIn',
+            'userQuota' => $userQuota,
+            'quotaUrl' => $quotaUrl
+        ];
+
+        $this->urlMock->expects($this->once())->method('getUrl')->with('adobe_stock/license/quota')
+            ->willReturn($quotaUrl);
+        $this->userAuthorizedMock->expects($this->once())->method('execute')->willReturn($userIsAuthorized);
+
+        if ($userIsAuthorized) {
+            $this->clientInterfaceMock->expects($this->once())->method('getQuota')->willReturn($this->userQuotaMock);
+            $this->userQuotaMock->expects($this->once())->method('getImages')->willReturn($userQuota['images']);
+            $this->userQuotaMock->expects($this->once())->method('getCredits')->willReturn($userQuota['credits']);
+        }
+
+        $result = $this->sut->get();
+        $this->assertEquals($result, $expectedResult);
+    }
+
+    /**
+     * Testing the available quota for for authorized and not authorized users
+     *
+     * @dataProvider exceptionsDataProvider
+     *
+     * @param $exception
+     * @param array $userQuota
+     */
+    public function testGettingUserQuotaOnExceptions($exception, array $userQuota)
+    {
+        $userIsAuthorized = true;
+        $quotaUrl = 'http://site.com/adobe_stock/license/quota';
+        $expectedResult = [
+            'component' => 'Magento_AdobeStockImageAdminUi/js/signIn',
+            'template' => 'Magento_AdobeStockImageAdminUi/signIn',
+            'userQuota' => $userQuota,
+            'quotaUrl' => $quotaUrl
+        ];
+
+        $this->urlMock->expects($this->once())->method('getUrl')->with('adobe_stock/license/quota')
+            ->willReturn($quotaUrl);
+        $this->userAuthorizedMock->expects($this->once())->method('execute')->willReturn($userIsAuthorized);
+        $this->clientInterfaceMock->expects($this->once())->method('getQuota')
+            ->willThrowException($exception);
+
+        $result = $this->sut->get();
+        $this->assertEquals($result, $expectedResult);
+    }
+
+    /**
+     * Providing quota for authorized and not authorized users
+     *
+     * @return array
+     */
+    public function userQuotaProvider(): array
+    {
+        return [
+            [
+                true,
+                [
+                    'images' => 3,
+                    'credits' => 5
+                ]
+            ], [
+                false,
+                [
+                    'images' => 0,
+                    'credits' => 0
+                ]
+            ]
+        ];
+    }
+
+    /**
+     * Providing the exceptions handling
+     *
+     * @return array
+     */
+    public function exceptionsDataProvider(): array
+    {
+        $defaultQuota = [
+            'images' => 0,
+            'credits' => 0
+        ];
+
+        return [
+            [
+                new AuthenticationException(new Phrase('Adobe API Key is invalid!')),
+                $defaultQuota
+            ], [
+                new AuthorizationException(new Phrase('Adobe API login has expired!')),
+                $defaultQuota
+            ]
+        ];
+    }
+}

--- a/AdobeStockImageAdminUi/Test/Unit/Model/SignInConfigProviderTest.php
+++ b/AdobeStockImageAdminUi/Test/Unit/Model/SignInConfigProviderTest.php
@@ -136,16 +136,16 @@ class SignInConfigProviderTest extends TestCase
     {
         return [
             [
-                true,
-                [
-                    'images' => 3,
-                    'credits' => 5
-                ]
-            ], [
                 false,
                 [
                     'images' => 0,
                     'credits' => 0
+                ]
+            ], [
+                true,
+                [
+                    'images' => 3,
+                    'credits' => 5
                 ]
             ]
         ];


### PR DESCRIPTION
### Description (*)
This PR covers the `Magento\AdobeStockImageAdminUi\Model\SignInConfigProvider` class with an Unit Test

⚠️This PR also fixes the issue introduced by `\Magento\AdobeIms\Test\Unit\Model\UserAuthorizedTest` - that fails the Unit Tests, as the Model was always returning false. The reason is using the 12H time format, instead of 24h time format.

### Fixed Issues (if relevant)

1. magento/adobe-stock-integration#529: Cover SignInConfigProvider class with a unit test


### Manual testing scenarios (*)
N/A