### PR TITLE
Fixes the empty system config when the credentials are wrong.

### DIFF
--- a/AdobeStockClient/Model/ConnectionWrapper.php
+++ b/AdobeStockClient/Model/ConnectionWrapper.php
@@ -172,7 +172,7 @@ class ConnectionWrapper
             $client->searchFilesInitialize($searchRequest);
 
             return (bool)$client->getNextResponse()->nb_results;
-        } catch (Exception $exception) {
+        } catch (\Exception $exception) {
             return false;
         }
     }


### PR DESCRIPTION
<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
This PR fixes the empty System Config page, when credentials are wrong provided. 

### Fixed Issues (if relevant)
N/A

The System Config is empty because of thrown and not caught exception:
`{"error_code":"403003","message":"Api Key is invalid"}`

![image](https://user-images.githubusercontent.com/15868188/66927500-94651c80-f038-11e9-8284-14ddeee8ab1f.png)

### Manual testing scenarios (*)
1. Set some wrong credentials
2. Save the configs
3. Open again the System Page