### PR TITLE
fixing eslint warnings in JS files

### DIFF
--- a/AdobeIms/view/adminhtml/web/js/action/authorization.js
+++ b/AdobeIms/view/adminhtml/web/js/action/authorization.js
@@ -60,6 +60,8 @@ define([], function () {
              * Start handle
              */
             function startHandle() {
+                var responseData;
+
                 try {
 
                     if (authWindow.document.domain !== document.domain ||
@@ -75,7 +77,7 @@ define([], function () {
                         reject(new Error('Time\'s up.'));
                     }, config.popupWindowTimeout || 60000);
 
-                    var responseData = authWindow.document.body.innerText.match(
+                    responseData = authWindow.document.body.innerText.match(
                         config.callbackParsingParams.regexpPattern
                     );
 
@@ -85,7 +87,8 @@ define([], function () {
 
                     stopHandle();
 
-                    if (responseData[config.callbackParsingParams.codeIndex] === config.callbackParsingParams.successCode) {
+                    if (responseData[config.callbackParsingParams.codeIndex] ===
+                        config.callbackParsingParams.successCode) {
                         resolve({
                             isAuthorized: true,
                             lastAuthSuccessMessage: responseData[config.callbackParsingParams.messageIndex]

--- a/AdobeIms/view/adminhtml/web/js/signIn.js
+++ b/AdobeIms/view/adminhtml/web/js/signIn.js
@@ -14,7 +14,8 @@ define([
         defaults: {
             profileUrl: 'adobe_ims/user/profile',
             logoutUrl: 'adobe_ims/user/logout',
-            defaultProfileImage: 'https://a5.behance.net/27000444e0c8b62c56deff3fc491e1a92d07f0cb/img/profile/no-image-276.png',
+            defaultProfileImage:
+              'https://a5.behance.net/27000444e0c8b62c56deff3fc491e1a92d07f0cb/img/profile/no-image-276.png',
             user: {
                 isAuthorized: false,
                 name: '',
@@ -124,7 +125,7 @@ define([
                 }.bind(this),
                 error: function (response) {
                     return response.message;
-                }.bind(this)
+                }
             });
         }
     });

--- a/AdobeStockAdminUi/view/adminhtml/web/js/connection.js
+++ b/AdobeStockAdminUi/view/adminhtml/web/js/connection.js
@@ -20,6 +20,7 @@ define([
         success: ko.observable(false),
         message: ko.observable(''),
         visible: ko.observable(false),
+
         /**
          * @override
          */
@@ -30,7 +31,7 @@ define([
             }, this);
             if (!this.serverSuccess) {
                 this.visible(true);
-                this.message(this.defaultErrorMessage)
+                this.message(this.defaultErrorMessage);
             }
         },
         showMessage: function (success, message) {
@@ -38,6 +39,7 @@ define([
             this.success(success);
             this.visible(true);
         },
+
         /**
          * Send request to server to test connection to Adobe Stock API and display the result
          */
@@ -52,7 +54,7 @@ define([
                     this.showMessage(response.success === true, response.message);
                 }, this),
                 error: $.proxy(function() {
-                    this.showMessage(false, this.defaultErrorMessage)
+                    this.showMessage(false, this.defaultErrorMessage);
                 }, this)
             });
         }

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/actions.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/actions.js
@@ -17,6 +17,7 @@ define([
         defaults: {
             template: 'Magento_AdobeStockImageAdminUi/grid/column/preview/actions',
             loginProvider: 'name = adobe-login, ns = adobe-login',
+            // eslint-disable-next-line max-len
             previewProvider: 'name = adobe_stock_images_listing.adobe_stock_images_listing.adobe_stock_images_columns.preview, ns = ${ $.ns }',
             mediaGallerySelector: '.media-gallery-modal:has(#search_adobe_stock)',
             adobeStockModalSelector: '#adobe-stock-images-search-modal',
@@ -90,7 +91,8 @@ define([
          */
         save: function (record, fileName, actionURI) {
             var mediaBrowser = $(this.preview().mediaGallerySelector).data('mageMediabrowser'),
-                destinationPath = (mediaBrowser.activeNode.path || '') + '/' + fileName + '.' + this.getImageExtension(record);
+                destinationPath = (mediaBrowser.activeNode.path || '') + '/' + fileName + '.' +
+                                  this.getImageExtension(record);
 
             $.ajax({
                 type: 'POST',
@@ -104,6 +106,7 @@ define([
                 context: this,
                 success: function () {
                     var displayedRecord = this.preview().displayedRecord();
+
                     displayedRecord.is_downloaded = 1;
                     displayedRecord.path = destinationPath;
                     this.preview().displayedRecord(displayedRecord);
@@ -125,6 +128,7 @@ define([
          */
         generateImageName: function (record) {
             var imageName = record.title.substring(0, 32).replace(/\s+/g, '-').toLowerCase();
+
             return imageName;
         },
 
@@ -136,6 +140,7 @@ define([
          */
         getImageExtension: function (record) {
             var imageType = record.content_type.match(/[^/]{1,4}$/);
+
             return imageType;
         },
 
@@ -165,6 +170,7 @@ define([
          */
         showLicenseConfirmation: function (record) {
             var licenseAndSave = this.licenseAndSave.bind(this);
+
             $.ajax(
                 {
                     type: 'POST',
@@ -180,14 +186,18 @@ define([
                         var confirmationContent = $.mage.__('License "' + record.title + '"'),
                             quotaMessage = response.result.message,
                             canPurchase = response.result.canLicense;
+
                         this.getPrompt(
                             {
                                 'title': $.mage.__('License Adobe Stock Image?'),
-                                'content': '<p>' + confirmationContent + '</p><p><b>' + quotaMessage + '</p><br>' + $.mage.__('File Name') + '</b>',
+                                'content': '<p>' + confirmationContent + '</p><p><b>' + quotaMessage + '</p><br>' +
+                                           $.mage.__('File Name') + '</b>',
                                 'visible': canPurchase,
                                 'actions': {
                                     confirm: function (fileName) {
-                                        canPurchase ? licenseAndSave(record, fileName) : window.open(this.preview().buyCreditsUrl);
+                                        canPurchase ?
+                                            licenseAndSave(record, fileName) :
+                                            window.open(this.preview().buyCreditsUrl);
                                     }
                                 },
                                 'buttons': [{
@@ -255,9 +265,9 @@ define([
                 .catch(function (error) {
                     messages.add('error', error.message);
                 })
-                .finally((function () {
+                .finally(function () {
                     messages.scheduleCleanup(this.messageDelay);
-                }).bind(this));
+                }.bind(this));
         }
     });
 });

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/keywords.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/keywords.js
@@ -13,6 +13,7 @@ define([
             template: 'Magento_AdobeStockImageAdminUi/grid/column/preview/keywords',
             chipsProvider: 'componentType = filtersChips, ns = ${ $.ns }',
             searchChipsProvider: 'componentType = keyword_search, ns = ${ $.ns }',
+            // eslint-disable-next-line max-len
             previewProvider: 'name = adobe_stock_images_listing.adobe_stock_images_listing.adobe_stock_images_columns.preview, ns = ${ $.ns }',
             defaultKeywordsLimit: 5,
             keywordsLimit: 5,

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/related.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/related.js
@@ -186,7 +186,6 @@ define([
          * Switch image preview to related image
          *
          * @param {Object|null} relatedImage
-         * @param {Object} record
          */
         switchImagePreviewToRelatedImage: function (relatedImage) {
             if (!relatedImage) {

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/related.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/related.js
@@ -15,6 +15,7 @@ define([
         defaults: {
             template: 'Magento_AdobeStockImageAdminUi/grid/column/preview/related',
             filterChipsProvider: 'componentType = filters, ns = ${ $.ns }',
+            // eslint-disable-next-line max-len
             previewProvider: 'name = adobe_stock_images_listing.adobe_stock_images_listing.adobe_stock_images_columns.preview, ns = ${ $.ns }',
             serieFilterValue: '',
             modelFilterValue: '',
@@ -86,7 +87,7 @@ define([
          */
         seeMoreFromSeries: function(record) {
             this.serieFilterValue(record.id);
-            this.filterChips().set('applied', {'serie_id' : record.id.toString()})
+            this.filterChips().set('applied', {'serie_id' : record.id.toString()});
         },
 
         /**
@@ -96,7 +97,7 @@ define([
          */
         seeMoreFromModel: function(record) {
             this.modelFilterValue(record.id);
-            this.filterChips().set('applied', {'model_id' : record.id.toString()})
+            this.filterChips().set('applied', {'model_id' : record.id.toString()});
         },
 
         /**
@@ -141,13 +142,12 @@ define([
          * @return {Boolean}
          */
         getPreviousButtonDisabled: function (record) {
+            var relatedList, prevRelatedIndex, prevRelated;
+
             if (!this.selectedRelatedType()) {
                 return false;
             }
-            var relatedList = this.selectedRelatedType() === 'series' ? record.series() : record.model(),
-                prevRelatedIndex,
-                prevRelated;
-
+            relatedList = this.selectedRelatedType() === 'series' ? record.series() : record.model();
             prevRelatedIndex = _.findLastIndex(relatedList, {id: this.preview().displayedRecord().id}) - 1;
             prevRelated = relatedList[prevRelatedIndex];
 
@@ -166,13 +166,12 @@ define([
          * @return {Boolean}
          */
         getNextButtonDisabled: function (record) {
+            var relatedList, nextRelatedIndex, nextRelated;
+
             if (!this.selectedRelatedType()) {
                 return false;
             }
-            var relatedList = this.selectedRelatedType() === 'series' ? record.series() : record.model(),
-                nextRelatedIndex,
-                nextRelated;
-
+            relatedList = this.selectedRelatedType() === 'series' ? record.series() : record.model();
             nextRelatedIndex = _.findLastIndex(relatedList, {id: this.preview().displayedRecord().id}) + 1;
             nextRelated = relatedList[nextRelatedIndex];
 
@@ -189,7 +188,7 @@ define([
          * @param {Object|null} relatedImage
          * @param {Object} record
          */
-        switchImagePreviewToRelatedImage: function (relatedImage, record) {
+        switchImagePreviewToRelatedImage: function (relatedImage/*, record (unused param)*/) {
             if (!relatedImage) {
                 this.selectedRelatedType(null);
 

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/related.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/related.js
@@ -188,7 +188,7 @@ define([
          * @param {Object|null} relatedImage
          * @param {Object} record
          */
-        switchImagePreviewToRelatedImage: function (relatedImage/*, record (unused param)*/) {
+        switchImagePreviewToRelatedImage: function (relatedImage) {
             if (!relatedImage) {
                 this.selectedRelatedType(null);
 

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/sorting.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/sorting.js
@@ -12,6 +12,7 @@ define([
         defaults: {
             template: 'Magento_AdobeStockImageAdminUi/sorting',
             options: [],
+            // eslint-disable-next-line max-len
             previewProvider: 'name = adobe_stock_images_listing.adobe_stock_images_listing.adobe_stock_images_columns.preview, ns = ${ $.ns }',
             applied: {},
             selectedOption: '',
@@ -57,7 +58,7 @@ define([
                             label: column.label
                         });
                     }
-                }.bind(this))
+                }.bind(this));
             }
         },
 

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/media-gallery.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/media-gallery.js
@@ -17,26 +17,31 @@ define([
          * @param {String} path
          */
         locate: function (path) {
-            $.ajaxSetup({async: false});
+            var i, folderName, openFolderChildrenButton, imageFolder, locatedImage;
             var imagePath = path.replace(/^\/+/, '');
             var imagePathParts = imagePath.split('/');
             var imageFilename = imagePath;
             var imageFolderName = this.jsTreeRootFolderName;
 
+            $.ajaxSetup({async: false});
+
             if (imagePathParts.length > 1) {
                 imageFilename = imagePathParts[imagePathParts.length - 1];
                 imageFolderName = imagePathParts[imagePathParts.length - 2];
 
-                for (var i = 0; i < imagePathParts.length - 2; i++) {
-                    var folderName = imagePathParts[i];
+                for (i = 0; i < imagePathParts.length - 2; i++) {
+                    folderName = imagePathParts[i];
 
                     /* folder name is being cut in file browser */
+                    // eslint-disable-next-line max-depth
                     if (folderName.length > this.jsTreeFolderNameMaxLength) {
                         folderName = folderName.substring(0, this.jsTreeFolderNameMaxLength) + '...';
                     }
 
                     //var folderSelector = ".jstree a:contains('" + folderName + "')";
-                    var openFolderChildrenButton = $(".jstree a:contains('" + folderName + "')").prev('.jstree-icon');
+                    openFolderChildrenButton = $(".jstree a:contains('" + folderName + "')").prev('.jstree-icon');
+
+                    // eslint-disable-next-line max-depth
                     if (openFolderChildrenButton.length) {
                         openFolderChildrenButton.click();
                     }
@@ -44,16 +49,18 @@ define([
             }
 
             //select folder
-            var imageFolder = $(".jstree a:contains('" + imageFolderName + "')");
+            imageFolder = $(".jstree a:contains('" + imageFolderName + "')");
+
             if (imageFolder.length) {
                 imageFolder[0].click();
                 //select image
-                var locatedImage = $("div[data-row='file']:has(img[alt=\"" + imageFilename + "\"])");
+                locatedImage = $("div[data-row='file']:has(img[alt=\"" + imageFilename + "\"])");
+
                 if (locatedImage.length) {
                     locatedImage.click();
                 }
             }
             $.ajaxSetup({async: true});
         }
-    }
+    };
 });

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/media-gallery.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/media-gallery.js
@@ -17,11 +17,15 @@ define([
          * @param {String} path
          */
         locate: function (path) {
-            var i, folderName, openFolderChildrenButton, imageFolder, locatedImage;
-            var imagePath = path.replace(/^\/+/, '');
-            var imagePathParts = imagePath.split('/');
-            var imageFilename = imagePath;
-            var imageFolderName = this.jsTreeRootFolderName;
+            var i,
+                folderName,
+                openFolderChildrenButton,
+                imageFolder,
+                locatedImage,
+                imagePath = path.replace(/^\/+/, ''),
+                imagePathParts = imagePath.split('/'),
+                imageFilename = imagePath,
+                imageFolderName = this.jsTreeRootFolderName;
 
             $.ajaxSetup({async: false});
 

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/model/messages.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/model/messages.js
@@ -45,6 +45,7 @@ define([
          * @param {Number} delay in seconds
          */
         scheduleCleanup: function (delay) {
+            // eslint-disable-next-line no-unused-vars
             var timerId;
 
             delay = delay || 3;

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/signIn.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/signIn.js
@@ -37,7 +37,7 @@ define([
                 dataType: 'json',
                 context: this,
                 success: function (response) {
-                    this.userQuota(response.result)
+                    this.userQuota(response.result);
                 },
                 error: function (response) {
                     return response.message;

--- a/AdobeUi/view/adminhtml/web/js/components/grid/column/image-preview.js
+++ b/AdobeUi/view/adminhtml/web/js/components/grid/column/image-preview.js
@@ -59,6 +59,7 @@ define([
          */
         next: function (record) {
             var recordToShow = this.getRecord(record._rowIndex + 1);
+
             recordToShow.rowNumber = record.lastInRow ? record.rowNumber + 1 : record.rowNumber;
             this.show(recordToShow);
         },
@@ -70,6 +71,7 @@ define([
          */
         prev: function (record) {
             var recordToShow = this.getRecord(record._rowIndex - 1);
+
             recordToShow.rowNumber = record.firstInRow ? record.rowNumber - 1 : record.rowNumber;
             this.show(recordToShow);
         },


### PR DESCRIPTION
### Description (*)

This PR fixes eslint warnings for all JS files in the project, based on the `.eslintrc` file found in the core magento2 project.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
magento/adobe-stock-integration#541: Fix eslint javascript static tests

### Manual testing scenarios (*)
1. Clone the magento2 repo
2. Install eslint: `npm install -g eslint`
3. Use the `.eslintrc-magento` file inside the magento2 repo to eslint against the codebase:
    ```
    cd adobe-stock-integration
    eslint -c ../magento2/dev/tests/static/testsuite/Magento/Test/Js/_files/eslint/.eslintrc .
    ```
4. Ensure the exit code is 0 and there are no warnings printed to the console.