### PR TITLE
Adding a bottom toolbar to the images grid

### DIFF
--- a/AdobeStockImageAdminUi/view/adminhtml/ui_component/adobe_stock_images_listing.xml
+++ b/AdobeStockImageAdminUi/view/adminhtml/ui_component/adobe_stock_images_listing.xml
@@ -231,4 +231,13 @@
             </settings>
         </column>
     </columns>
+    <listingToolbar name="listing_bottom" template="Magento_AdobeStockImageAdminUi/grid/toolbar">
+        <paging name="listing_paging">
+            <settings>
+                <sizesConfig>
+                    <component>Magento_AdobeStockImageAdminUi/js/components/images-grid-sizes</component>
+                </sizesConfig>
+            </settings>
+        </paging>
+    </listingToolbar>
 </listing>

--- a/AdobeStockImageAdminUi/view/adminhtml/web/css/source/_module.less
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/css/source/_module.less
@@ -188,4 +188,13 @@
       }
     }
   }
+
+  .masonry-image-grid {
+    + .admin__data-grid-header {
+      .selectmenu-items {
+        bottom: 100%;
+        top: auto;
+      }
+    }
+  }
 }


### PR DESCRIPTION

### Description (*)
This PR adds the pager toolbar to the bottom of images grid.

![Xnip2019-10-20_12-42-49](https://user-images.githubusercontent.com/15868188/67157885-338c5b80-f33a-11e9-960f-59c4f5ec0ffd.jpg)


### Fixed Issues (if relevant)

1. magento/adobe-stock-integration#551: Add pagination controls to the bottom of the images grid

### Manual testing scenarios (*)

Login to admin panel
1. Open Magento Media Gallery (i.e. go to Cms -> Pages, edit the page and insert image)
2. Click "Search Adobe Stock" button to open images grid
3. Scroll to the bottom of images grid
