### PR TITLE
Fixed blank page issue After adobe stock integration installation

### DIFF
--- a/AdobeStockAdminUi/Block/Adminhtml/System/Config/TestConnection.php
+++ b/AdobeStockAdminUi/Block/Adminhtml/System/Config/TestConnection.php
@@ -89,7 +89,10 @@ class TestConnection extends Field
      */
     public function isConnectionSuccessful(): bool
     {
-        return $this->client->testConnection($this->config->getApiKey());
+        if($this->config->getApiKey())
+            return $this->client->testConnection($this->config->getApiKey());
+
+        return false;
     }
 
     /**


### PR DESCRIPTION
**Story:**
Fixed Blank Page on system configuration after installation of adobe stock integration

**Steps to reproduce (*)**

    Login to admin panel
    go to Stores->Configuration->Advanced->System for adding integration keys 

**Expected result (*)**
   Fields should display to add integration keys 

**Current result (*)**
   Fileds are blank and in system log getting errors like 
   2 exception(s):
Exception #0 (AdobeStock\Api\Exception\StockApi): Client error: `GET https://stock.adobe.io/Rest/Media/1/Search/Files?locale=en_GB&search_parameters%5Blimit%5D=32&search_parameters%5Boffset%5D=0&result_columns%5B0%5D=nb_results` resulted in a `403 Forbidden` response:
{"error_code":"403003","message":"Api Key is invalid"}
