### PR TITLE
#554 Long image name entered during saving image preview is overlappi…

### DIFF
--- a/AdobeStockImageAdminUi/view/adminhtml/web/css/source/_module.less
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/css/source/_module.less
@@ -166,6 +166,11 @@
           color: #999;
           cursor: default;
         }
+        .admin__field-with-image-ext {
+          .admin__control-text {
+            padding-right: 5rem;
+          }
+        }
       }
       .modal-footer {
         padding: 30px;

--- a/AdobeStockImageAdminUi/view/adminhtml/web/template/modal/adobe-modal-prompt-content.html
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/template/modal/adobe-modal-prompt-content.html
@@ -13,7 +13,7 @@
             <span><%= data.label %></span>
         </label>
         <% } %>
-        <div class="admin__field-control">
+        <div class="admin__field-control admin__field-with-image-ext">
             <input type="text" data-role="promptField" id="prompt-field-<%- data.id %>" class="admin__control-text" <%= inputAttr %>/>
             <span class="image-ext">.<%= data.imageExtension %></span>
         </div>


### PR DESCRIPTION
Fixed the issue https://github.com/magento/adobe-stock-integration/issues/554