### PR TITLE
WIP- 435: Remove hardcoded keys from StockFileToDocument converter

### DIFF
--- a/AdobeStockAsset/Model/Asset.php
+++ b/AdobeStockAsset/Model/Asset.php
@@ -85,6 +85,22 @@ class Asset extends AbstractExtensibleModel implements AssetInterface
     /**
      * @inheritdoc
      */
+    public function getCategoryName(): ?string
+    {
+        return $this->getData(self::CATEGORY_NAME);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function setCategoryName(string $categoryName): void
+    {
+        $this->setData(self::CATEGORY_NAME, $categoryName);
+    }
+
+    /**
+     * @inheritdoc
+     */
     public function getCategory(): ?CategoryInterface
     {
         return $this->getData(self::CATEGORY);

--- a/AdobeStockAsset/Model/DocumentToAsset.php
+++ b/AdobeStockAsset/Model/DocumentToAsset.php
@@ -48,9 +48,9 @@ class DocumentToAsset
             }
             $asset = $this->createEntity(
                 $data,
-                $this->mapping['factory'],
-                $this->mapping['fields'],
-                $this->mapping['children']
+                $this->mapping[AssetInterface::FACTORY],
+                $this->mapping[AssetInterface::FIELDS],
+                $this->mapping[AssetInterface::CHILDREN]
             );
             foreach ($data as $key => $value) {
                 $asset->setData($key, $value);
@@ -80,9 +80,9 @@ class DocumentToAsset
                 $childName,
                 $this->createEntity(
                     $data,
-                    $childMapping['factory'],
-                    $childMapping['fields'] ?? [],
-                    $childMapping['children'] ?? []
+                    $childMapping[AssetInterface::FACTORY],
+                    $childMapping[AssetInterface::FIELDS] ?? [],
+                    $childMapping[AssetInterface::CHILDREN] ?? []
                 )
             );
             unset($data[$childName]);

--- a/AdobeStockAssetApi/Api/Data/AssetInterface.php
+++ b/AdobeStockAssetApi/Api/Data/AssetInterface.php
@@ -63,10 +63,21 @@ interface AssetInterface extends \Magento\Framework\Api\ExtensibleDataInterface
 
     const FIELD_UPDATED_AT = 'updated_at';
 
+    const FACTORY = 'factory';
+
+    const FIELDS = 'fields';
+
+    const CHILDREN = 'children';
+
     /**
      * Category id is an id of a category entry related to the asset
      */
     const CATEGORY_ID = 'category_id';
+
+    /**
+     * Category name is an name of a category entry related to the asset
+     */
+    const CATEGORY_NAME = 'category_name';
 
     /**
      * Creator id is an id of a category entry related to the asset
@@ -187,6 +198,21 @@ interface AssetInterface extends \Magento\Framework\Api\ExtensibleDataInterface
      * @return void
      */
     public function setCategoryId(int $categoryId): void;
+
+    /**
+     * Get category name
+     *
+     * @return string|null
+     */
+    public function getCategoryName(): ?string;
+
+    /**
+     * Set category
+     *
+     * @param string $categoryName
+     * @return void
+     */
+    public function setCategoryName(string $categoryName): void;
 
     /**
      * Get category

--- a/AdobeStockClient/Model/StockFileToDocument.php
+++ b/AdobeStockClient/Model/StockFileToDocument.php
@@ -17,6 +17,8 @@ use Magento\Framework\Exception\IntegrationException;
 use Magento\Framework\Api\AttributeValueFactory;
 use Magento\Framework\Phrase;
 use Psr\Log\LoggerInterface;
+use Magento\AdobeStockAssetApi\Api\Data\AssetInterface;
+use Magento\AdobeStockAssetApi\Api\Data\CategoryInterface;
 
 /**
  * Class StockFileToDocument
@@ -63,15 +65,15 @@ class StockFileToDocument
     public function convert(StockFile $file): DocumentInterface
     {
         $itemData = (array) $file;
-        $itemId = $itemData['id'];
+        $itemId = $itemData[AssetInterface::ID];
 
-        $category = (array) $itemData['category'];
+        $category = (array) $itemData[AssetInterface::CATEGORY];
 
-        $itemData['category'] = $category;
-        $itemData['category_id'] = $category['id'];
-        $itemData['category_name'] = $category['name'];
+        $itemData[AssetInterface::CATEGORY] = $category;
+        $itemData[AssetInterface::CATEGORY_ID] = $category[CategoryInterface::ID];
+        $itemData[AssetInterface::CATEGORY_NAME] = $category[CategoryInterface::NAME];
 
-        $attributes = $this->createAttributes('id', $itemData);
+        $attributes = $this->createAttributes(DocumentInterface::ID, $itemData);
 
         $item = $this->documentFactory->create();
         $item->setId($itemId);


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
Remove hardcoded keys by retrieving them from interfaces.

### Fixed Issues (if relevant)
1. magento/adobe-stock-integration#435: [Refactoring] Remove hardcoded keys from StockFileToDocument converter

### Manual testing scenarios (*)
1. Cms -> Pages -> Edit -> Insert Image (WYSIWYG) -> Select from gallery -> Search Adobe Stock button -> insert image from Adobe Stock
2. Cms -> Blocks -> Edit -> Insert Image (WYSIWYG) -> Select from gallery -> Search Adobe Stock button -> insert image from Adobe Stock
3. Catalog -> Categories -> Select category -> Content fieldset -> Select Image from gallery -> Search Adobe Stock button -> insert image from Adobe Stock