### PR TITLE
Adjust the code to Magento general static tests

### DIFF
--- a/AdobeIms/Block/Adminhtml/SignIn.php
+++ b/AdobeIms/Block/Adminhtml/SignIn.php
@@ -20,6 +20,8 @@ use Magento\Framework\Serialize\Serializer\JsonHexTag;
 
 /**
  * Adobe sign in block
+ *
+ * @api
  */
 class SignIn extends Template
 {

--- a/AdobeStockAsset/composer.json
+++ b/AdobeStockAsset/composer.json
@@ -5,7 +5,8 @@
         "php": "~7.1.3||~7.2.0||~7.3.0",
         "magento/framework": "*",
         "magento/module-adobe-stock-asset-api": "*",
-        "magento/module-config": "*"
+        "magento/module-config": "*",
+        "magento/module-payment": "*"
     },
     "type": "magento2-module",
     "license": [

--- a/AdobeStockAsset/composer.json
+++ b/AdobeStockAsset/composer.json
@@ -5,6 +5,7 @@
         "php": "~7.1.3||~7.2.0||~7.3.0",
         "magento/framework": "*",
         "magento/module-adobe-stock-asset-api": "*",
+        "magento/module-adobe-stock-client-api": "*",
         "magento/module-config": "*",
         "magento/module-payment": "*"
     },

--- a/AdobeStockImageAdminUi/Controller/Adminhtml/Preview/RelatedImages.php
+++ b/AdobeStockImageAdminUi/Controller/Adminhtml/Preview/RelatedImages.php
@@ -20,6 +20,10 @@ use Psr\Log\LoggerInterface;
 class RelatedImages extends Action
 {
     /**
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Backend::admin';
+    /**
      * Successful get related image result code.
      */
     const HTTP_OK = 200;


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR fix some error during Magento general static tests

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/adobe-stock-integration#540: Adjust the code to Magento general static tests

This fix:
- ~Backend controller Magento\AdobeStockImageAdminUi\Controller\Adminhtml\Preview\RelatedImages have to overwrite _isAllowed method or ADMIN_RESOURCE constant~
- ~Magento\AdobeIms\Block\Adminhtml\SignIn block should be marked with API annotation~
- ~Phrase: 'An error occurred during logout operation: %1' /var/www/html/app/code/Magento/AdobeIms/Model/LogOut.php:102~
- ~Module Magento\AdobeStockAsset has undeclared dependencies: hard [Magento\Payment] (dependency has to be removed)~
- ~Module Magento\AdobeStockAsset has undeclared dependencies: hard [Magento\AdobeStockClientApi] (dependency has to be declared)~

### Manual testing scenarios (*)
/