### PR TITLE
Add unit test for 'get asset keywords' command

### DIFF
--- a/AdobeMediaGallery/Test/Unit/Model/Keyword/Command/GetAssetKeywordsTest.php
+++ b/AdobeMediaGallery/Test/Unit/Model/Keyword/Command/GetAssetKeywordsTest.php
@@ -51,40 +51,28 @@ class GetAssetKeywordsTest extends TestCase
         $this->assertInstanceOf( GetAssetKeywords::class, $this->sut);
     }
 
-    public function testFindOne()
+    /**
+     * @dataProvider cases()
+     */
+    public function testFind($databaseQueryResult, $expectedNumberOfFoundKeywords)
     {
-        $assetIdWithOneKeyword = 1;
-        $oneKeywordQueryResult = ['keywordRawData'];
-        $this->configureResourceConnectionStub($oneKeywordQueryResult);
+        $randomAssetId = 12345;
+        $this->configureResourceConnectionStub($databaseQueryResult);
         $this->configureAssetKeywordFactoryStub();
 
-        $keywords = $this->sut->execute($assetIdWithOneKeyword);
+        /** @var KeywordInterface[] $keywords */
+        $keywords = $this->sut->execute($randomAssetId);
 
-        $this->assertCount(1, $keywords);
+        $this->assertCount($expectedNumberOfFoundKeywords, $keywords);
     }
 
-    public function testFindSeveral()
+    public function cases()
     {
-        $assetIdWithSeveralKeywords = 1;
-        $severalKeywordsQueryResult = ['keywordRawData', 'anotherKeywordRawData'];
-        $this->configureResourceConnectionStub($severalKeywordsQueryResult);
-        $this->configureAssetKeywordFactoryStub();
-
-        $keywords = $this->sut->execute($assetIdWithSeveralKeywords);
-
-        $this->assertCount(2, $keywords);
-    }
-
-    public function testNotFound()
-    {
-        $assetIdWithoutKeywords = 1;
-        $emptyKeywordsCommandResponse = [];
-        $emptyQueryResult = [];
-        $this->configureResourceConnectionStub($emptyQueryResult);
-
-        $keywords = $this->sut->execute($assetIdWithoutKeywords);
-
-        $this->assertEquals($emptyKeywordsCommandResponse, $keywords);
+        return [
+            'not_found' => [[],0],
+            'find_one_keyword' => [['keywordRawData'],1],
+            'find_several_keywords' => [['keywordRawData', 'keywordRawData'],2],
+        ];
     }
 
     public function testNotFoundBecauseOfError()

--- a/AdobeMediaGallery/Test/Unit/Model/Keyword/Command/GetAssetKeywordsTest.php
+++ b/AdobeMediaGallery/Test/Unit/Model/Keyword/Command/GetAssetKeywordsTest.php
@@ -1,0 +1,140 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Magento\AdobeMediaGallery\Test\Unit\Model\Keyword\Command;
+
+use Magento\AdobeMediaGallery\Model\Keyword\Command\GetAssetKeywords;
+use Magento\AdobeMediaGalleryApi\Api\Data\KeywordInterface;
+use Magento\AdobeMediaGalleryApi\Api\Data\KeywordInterfaceFactory;
+use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\DB\Adapter\AdapterInterface;
+use Magento\Framework\DB\Select;
+use Magento\Framework\Exception\NotFoundException;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class GetAssetKeywordsTest extends TestCase
+{
+    /**
+     * @var GetAssetKeywords
+     */
+    private $sut;
+
+    /**
+     * @var ResourceConnection | MockObject
+     */
+    private $resourceConnectionStub;
+
+    /**
+     * @var KeywordInterfaceFactory | MockObject
+     */
+    private $assetKeywordFactoryStub;
+
+    protected function setUp()
+    {
+        $this->resourceConnectionStub = $this->createMock(ResourceConnection::class);
+        $this->assetKeywordFactoryStub = $this->createMock(KeywordInterfaceFactory::class);
+
+        $this->sut = new GetAssetKeywords(
+            $this->resourceConnectionStub,
+            $this->assetKeywordFactoryStub
+        );
+    }
+
+    public function testCanBeCreated()
+    {
+        $this->assertInstanceOf( GetAssetKeywords::class, $this->sut);
+    }
+
+    public function testFindOne()
+    {
+        $assetIdWithOneKeyword = 1;
+        $oneKeywordQueryResult = ['keywordRawData'];
+        $this->configureResourceConnectionStub($oneKeywordQueryResult);
+        $this->configureAssetKeywordFactoryStub();
+
+        $keywords = $this->sut->execute($assetIdWithOneKeyword);
+
+        $this->assertCount(1, $keywords);
+    }
+
+    public function testFindSeveral()
+    {
+        $assetIdWithSeveralKeywords = 1;
+        $severalKeywordsQueryResult = ['keywordRawData', 'anotherKeywordRawData'];
+        $this->configureResourceConnectionStub($severalKeywordsQueryResult);
+        $this->configureAssetKeywordFactoryStub();
+
+        $keywords = $this->sut->execute($assetIdWithSeveralKeywords);
+
+        $this->assertCount(2, $keywords);
+    }
+
+    public function testNotFound()
+    {
+        $assetIdWithoutKeywords = 1;
+        $emptyKeywordsCommandResponse = [];
+        $emptyQueryResult = [];
+        $this->configureResourceConnectionStub($emptyQueryResult);
+
+        $keywords = $this->sut->execute($assetIdWithoutKeywords);
+
+        $this->assertEquals($emptyKeywordsCommandResponse, $keywords);
+    }
+
+    public function testNotFoundBecauseOfError()
+    {
+        $randomAssetId = 1;
+
+        $this->resourceConnectionStub
+            ->method('getConnection')
+            ->willThrowException((new \Exception()));
+
+        $this->expectException(NotFoundException::class);
+
+        $this->sut->execute($randomAssetId);
+    }
+
+    /**
+     * Very fragile and coupled to the implementation
+     *
+     * @param array $queryResult
+     */
+    private function configureResourceConnectionStub(array $queryResult)
+    {
+        $statementMock = $this->getMockBuilder(\Zend_Db_Statement_Interface::class)->getMock();
+        $statementMock
+            ->method('fetchAll')
+            ->willReturn($queryResult);
+
+        $selectStub = $this->createMock(Select::class);
+        $selectStub->method('from')->willReturnSelf();
+        $selectStub->method('join')->willReturnSelf();
+        $selectStub->method('where')->willReturnSelf();
+
+        $connectionMock = $this->getMockBuilder(AdapterInterface::class)->getMock();
+        $connectionMock
+            ->method('select')
+            ->willReturn($selectStub);
+        $connectionMock
+            ->method('query')
+            ->willReturn($statementMock);
+
+        $this->resourceConnectionStub
+            ->method('getConnection')
+            ->willReturn($connectionMock);
+    }
+
+    private function configureAssetKeywordFactoryStub(): void
+    {
+        $keywordStub = $this->getMockBuilder(KeywordInterface::class)->getMock();
+        $this->assetKeywordFactoryStub
+            ->method('create')
+            ->willReturn($keywordStub);
+    }
+}

--- a/AdobeMediaGallery/Test/Unit/Model/Keyword/Command/GetAssetKeywordsTest.php
+++ b/AdobeMediaGallery/Test/Unit/Model/Keyword/Command/GetAssetKeywordsTest.php
@@ -3,7 +3,6 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-
 declare(strict_types=1);
 
 namespace Magento\AdobeMediaGallery\Test\Unit\Model\Keyword\Command;
@@ -35,7 +34,7 @@ class GetAssetKeywordsTest extends TestCase
      */
     private $assetKeywordFactoryStub;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->resourceConnectionStub = $this->createMock(ResourceConnection::class);
         $this->assetKeywordFactoryStub = $this->createMock(KeywordInterfaceFactory::class);
@@ -46,15 +45,15 @@ class GetAssetKeywordsTest extends TestCase
         );
     }
 
-    public function testCanBeCreated()
-    {
-        $this->assertInstanceOf( GetAssetKeywords::class, $this->sut);
-    }
-
     /**
-     * @dataProvider cases()
+     * Posive test for the main case
+     *
+     * @dataProvider casesProvider()
+     * @param array $databaseQueryResult
+     * @param int $expectedNumberOfFoundKeywords
+     * @throws NotFoundException
      */
-    public function testFind($databaseQueryResult, $expectedNumberOfFoundKeywords)
+    public function testFind(array $databaseQueryResult, int $expectedNumberOfFoundKeywords): void
     {
         $randomAssetId = 12345;
         $this->configureResourceConnectionStub($databaseQueryResult);
@@ -66,7 +65,12 @@ class GetAssetKeywordsTest extends TestCase
         $this->assertCount($expectedNumberOfFoundKeywords, $keywords);
     }
 
-    public function cases()
+    /**
+     * Data provider for testFind
+     *
+     * @return array
+     */
+    public function casesProvider(): array
     {
         return [
             'not_found' => [[],0],
@@ -75,7 +79,12 @@ class GetAssetKeywordsTest extends TestCase
         ];
     }
 
-    public function testNotFoundBecauseOfError()
+    /**
+     * Negative test
+     *
+     * @throws NotFoundException
+     */
+    public function testNotFoundBecauseOfError(): void
     {
         $randomAssetId = 1;
 
@@ -93,7 +102,7 @@ class GetAssetKeywordsTest extends TestCase
      *
      * @param array $queryResult
      */
-    private function configureResourceConnectionStub(array $queryResult)
+    private function configureResourceConnectionStub(array $queryResult): void
     {
         $statementMock = $this->getMockBuilder(\Zend_Db_Statement_Interface::class)->getMock();
         $statementMock


### PR DESCRIPTION
### Description (*)
Add unit test for 'get asset keywords' command implemented here `\Magento\AdobeMediaGallery\Model\Keyword\Command\GetAssetKeywords`

### Fixed Issues
1. magento/adobe-stock-integration#587: Cover GetAssetKeywords class with a unit tes
