### PR TITLE
Enhance AdobeIms tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,9 @@ services:
   - elasticsearch
 language: php
 php:
+  - '7.1'
   - '7.2'
+  - '7.3'
 env:
   global:
     - COMPOSER_BIN_DIR=~/bin

--- a/AdobeIms/Test/Unit/Block/Adminhtml/SignInTest.php
+++ b/AdobeIms/Test/Unit/Block/Adminhtml/SignInTest.php
@@ -82,7 +82,7 @@ class SignInTest extends TestCase
     /**
      * Prepare test objects.
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->objectManager = new ObjectManager($this);
         $urlBuilderMock = $this->createMock(UrlInterface::class);

--- a/AdobeIms/Test/Unit/Controller/Adminhtml/OAuth/CallbackTest.php
+++ b/AdobeIms/Test/Unit/Controller/Adminhtml/OAuth/CallbackTest.php
@@ -86,7 +86,7 @@ class CallbackTest extends TestCase
     /**
      * Prepare test objects.
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->objectManager = new ObjectManager($this);
         $this->authMock = $this->createMock(\Magento\Backend\Model\Auth::class);

--- a/AdobeIms/Test/Unit/Controller/Adminhtml/User/LogoutTest.php
+++ b/AdobeIms/Test/Unit/Controller/Adminhtml/User/LogoutTest.php
@@ -54,7 +54,7 @@ class LogoutTest extends TestCase
     /**
      * @inheritdoc
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->logoutInterfaceMock = $this->createMock(LogOutInterface::class);
         $this->context = $this->createMock(\Magento\Backend\App\Action\Context::class);

--- a/AdobeIms/Test/Unit/Controller/Adminhtml/User/ProfileTest.php
+++ b/AdobeIms/Test/Unit/Controller/Adminhtml/User/ProfileTest.php
@@ -62,7 +62,7 @@ class ProfileTest extends TestCase
     /**
      * @inheritdoc
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->action = $this->createMock(\Magento\Backend\App\Action\Context::class);
 

--- a/AdobeIms/Test/Unit/Model/ConfigTest.php
+++ b/AdobeIms/Test/Unit/Model/ConfigTest.php
@@ -38,7 +38,7 @@ class ConfigTest extends TestCase
     /**
      * Prepare test objects.
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->objectManager = new ObjectManager($this);
         $this->scopeConfigMock = $this->createMock(ScopeConfigInterface::class);

--- a/AdobeIms/Test/Unit/Model/FlushUserTokensTest.php
+++ b/AdobeIms/Test/Unit/Model/FlushUserTokensTest.php
@@ -37,7 +37,7 @@ class FlushUserTokensTest extends TestCase
     /**
      * Prepare test objects.
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->userContext = $this->createMock(UserContextInterface::class);
         $this->userProfileRepository = $this->createMock(UserProfileRepositoryInterface::class);

--- a/AdobeIms/Test/Unit/Model/GetAccessTokenTest.php
+++ b/AdobeIms/Test/Unit/Model/GetAccessTokenTest.php
@@ -7,7 +7,6 @@ declare(strict_types=1);
 
 namespace Magento\AdobeIms\Test\Unit\Model;
 
-use Elasticsearch\Endpoints\Get;
 use Magento\AdobeIms\Model\GetAccessToken;
 use Magento\AdobeImsApi\Api\UserProfileRepositoryInterface;
 use Magento\Authorization\Model\UserContextInterface;
@@ -39,7 +38,7 @@ class GetAccessTokenTest extends TestCase
     /**
      * Prepare test objects.
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->userContext = $this->createMock(UserContextInterface::class);
         $this->userProfile = $this->createMock(UserProfileRepositoryInterface::class);

--- a/AdobeIms/Test/Unit/Model/GetImageTest.php
+++ b/AdobeIms/Test/Unit/Model/GetImageTest.php
@@ -61,7 +61,7 @@ class GetImageTest extends TestCase
     /**
      * Prepare test objects.
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->objectManager = new ObjectManager($this);
         $this->configMock = $this->createMock(ScopeConfigInterface::class);

--- a/AdobeIms/Test/Unit/Model/GetTokenTest.php
+++ b/AdobeIms/Test/Unit/Model/GetTokenTest.php
@@ -54,7 +54,7 @@ class GetTokenTest extends TestCase
     /**
      * Prepare test objects.
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->objectManager = new ObjectManager($this);
         $this->configMock = $this->createMock(ConfigInterface::class);

--- a/AdobeIms/Test/Unit/Model/LogOutTest.php
+++ b/AdobeIms/Test/Unit/Model/LogOutTest.php
@@ -192,6 +192,6 @@ class LogOutTest extends TestCase
             );
         $this->loggerInterfaceMock->expects($this->once())
             ->method('critical');
-        $this->assertEquals(false, $this->model->execute());
+        $this->assertFalse($this->model->execute());
     }
 }

--- a/AdobeIms/Test/Unit/Model/UserAuthorizedTest.php
+++ b/AdobeIms/Test/Unit/Model/UserAuthorizedTest.php
@@ -36,7 +36,7 @@ class UserAuthorizedTest extends TestCase
     /**
      * Prepare test objects.
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->userContext = $this->createMock(UserContextInterface::class);
         $this->userProfile = $this->createMock(UserProfileRepositoryInterface::class);
@@ -62,6 +62,6 @@ class UserAuthorizedTest extends TestCase
             ->method('getAccessTokenExpiresAt')
             ->willReturn(date('Y-m-d H:i:s'));
 
-        $this->assertEquals(true, $this->userAuthorized->execute());
+        $this->assertTrue($this->userAuthorized->execute());
     }
 }

--- a/AdobeIms/Test/Unit/Model/UserProfileRepositoryTest.php
+++ b/AdobeIms/Test/Unit/Model/UserProfileRepositoryTest.php
@@ -43,7 +43,7 @@ class UserProfileRepositoryTest extends TestCase
     /**
      * Prepare test objects.
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->objectManager = new ObjectManager($this);
         $this->resource = $this->createMock(ResourceUserProfile::class);
@@ -65,12 +65,12 @@ class UserProfileRepositoryTest extends TestCase
 
     /**
      * Test save with exception.
-     *
-     * @expectedException \Magento\Framework\Exception\CouldNotSaveException
-     * @expectedExceptionMessage Could not save user profile.
      */
     public function testSaveWithException(): void
     {
+        $this->expectException(\Magento\Framework\Exception\CouldNotSaveException::class);
+        $this->expectExceptionMessage('Could not save user profile.');
+
         $userProfile = $this->createMock(UserProfile::class);
         $this->resource->expects($this->once())
             ->method('save')
@@ -94,12 +94,12 @@ class UserProfileRepositoryTest extends TestCase
 
     /**
      * Test get user id with exception.
-     *
-     * @expectedException \Magento\Framework\Exception\NoSuchEntityException
-     * @expectedExceptionMessage The user profile wasn't found.
      */
     public function testGeWithException()
     {
+        $this->expectException(\Magento\Framework\Exception\NoSuchEntityException::class);
+        $this->expectExceptionMessage('The user profile wasn\'t found.');
+
         $entity = $this->objectManager->getObject(UserProfile::class);
         $this->entityFactory->method('create')
             ->willReturn($entity);


### PR DESCRIPTION
### Description (*)
- Enhance assertions. Using the `assertTrue` and `assertFalse` to assert expected is `true` or `false`.
- Enhance `AdobeIms` tests.
- To support future `PHPUnit 8.x` version, replacing `expected` exception annotations with `expectExcpetion` and `expectExceptionMessage` methods.
- Removing unused `Get` class namespace declaring.
- According to the [PHPUnit fixture reference](https://phpunit.de/manual/7.0/en/fixtures.html), the `setUp` method is `protected` with `void` type hint.
- Add the `php-7.1` and `php-7.3` versions tests on Travis CI build.

### Manual testing scenarios (*)
- The Travis CI build will be passed successfully.