### PR TITLE
Enhance AdobeStockAdminUi & AdobeStockAsset tests

### DIFF
--- a/AdobeStockAdminUi/Test/Unit/Controller/Adminhtml/System/Config/TestConnectionTest.php
+++ b/AdobeStockAdminUi/Test/Unit/Controller/Adminhtml/System/Config/TestConnectionTest.php
@@ -50,7 +50,7 @@ class TestConnectionTest extends TestCase
     /**
      * Prepare test objects.
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->objectManager = new ObjectManager($this);
         $this->clientMock = $this->createMock(ClientInterface::class);

--- a/AdobeStockAsset/Test/Unit/Model/CategoryRepositoryTest.php
+++ b/AdobeStockAsset/Test/Unit/Model/CategoryRepositoryTest.php
@@ -9,10 +9,13 @@ namespace Magento\AdobeStockAsset\Test\Unit\Model;
 
 use Magento\AdobeStockAsset\Model\CategoryFactory;
 use Magento\AdobeStockAsset\Model\CategoryRepository;
+use Magento\AdobeStockAsset\Model\Category;
 use Magento\AdobeStockAsset\Model\ResourceModel\Category as ResourceModel;
 use Magento\AdobeStockAsset\Model\ResourceModel\Category\CollectionFactory as CategoryCollectionFactory;
+use Magento\AdobeStockAsset\Model\ResourceModel\Category\Collection;
 use Magento\AdobeStockAsset\Model\ResourceModel\Category\Command\Save;
 use Magento\AdobeStockAssetApi\Api\Data\CategoryInterface;
+use Magento\AdobeStockAssetApi\Api\Data\CategorySearchResultsInterface;
 use Magento\AdobeStockAssetApi\Api\Data\CategorySearchResultsInterfaceFactory;
 use Magento\Framework\Api\ExtensionAttribute\JoinProcessorInterface;
 use Magento\Framework\Api\SearchCriteria\CollectionProcessorInterface;
@@ -69,7 +72,7 @@ class CategoryRepositoryTest extends TestCase
     /**
      * @inheritdoc
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->resourceModel = $this->createMock(ResourceModel::class);
         $this->commandSave = $this->createMock(Save::class);
@@ -96,9 +99,9 @@ class CategoryRepositoryTest extends TestCase
     public function testGetList(): void
     {
         /** @var MockObject|SearchCriteriaInterface $searchCriteria */
-        $searchCriteria = $this->createMock(\Magento\Framework\Api\SearchCriteriaInterface::class);
+        $searchCriteria = $this->createMock(SearchCriteriaInterface::class);
 
-        $collection = $this->createMock(\Magento\AdobeStockAsset\Model\ResourceModel\Category\Collection::class);
+        $collection = $this->createMock(Collection::class);
         $this->categoryCollectionFactory->expects($this->once())
             ->method('create')
             ->willReturn($collection);
@@ -111,7 +114,7 @@ class CategoryRepositoryTest extends TestCase
             ->method('process')
             ->with($searchCriteria, $collection)
             ->willReturn(null);
-        $searchResults = $this->createMock(\Magento\AdobeStockAssetApi\Api\Data\CategorySearchResultsInterface::class);
+        $searchResults = $this->createMock(CategorySearchResultsInterface::class);
         $this->categorySearchResultsInterfaceFactory->expects($this->once())
             ->method('create')
             ->willReturn($searchResults);
@@ -135,7 +138,7 @@ class CategoryRepositoryTest extends TestCase
      */
     public function testGetById(): void
     {
-        $categoryMock = $this->createMock(\Magento\AdobeStockAsset\Model\Category::class);
+        $categoryMock = $this->createMock(Category::class);
         $this->categoryFactory->expects($this->once())
             ->method('create')
             ->willReturn($categoryMock);
@@ -154,7 +157,7 @@ class CategoryRepositoryTest extends TestCase
     public function testGetByIdWithException(): void
     {
         $this->expectException(NoSuchEntityException::class);
-        $categoryMock = $this->createMock(\Magento\AdobeStockAsset\Model\Category::class);
+        $categoryMock = $this->createMock(Category::class);
         $this->categoryFactory->expects($this->once())
             ->method('create')
             ->willReturn($categoryMock);


### PR DESCRIPTION
### Description (*)
- Enhance AdobeStockAdminUi and AdobeStockAsset tests

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios (*)
The Travis CI build will be passed.

# Changed log
- According to the [PHPUnit fixture reference](https://phpunit.de/manual/7.0/en/fixtures.html), the `setUp` method should be `protected` with native `void` type hint.
- To be consistency, all class namespaces are declared on the head of PHP classes.
And using the `::class` to make class instance call.