### PR TITLE
Fixed bug when the extra margin was applied to the reopened image preview

### DIFF
--- a/AdobeStockImageAdminUi/view/adminhtml/web/css/source/_module.less
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/css/source/_module.less
@@ -146,7 +146,7 @@
             }
 
             .adobe-stock-related-images-tab-content {
-                height: auto;
+                max-height: 190px;
                 vertical-align: middle;
                 display: inline-block;
                 width: 100%;

--- a/AdobeStockImageAdminUi/view/adminhtml/web/css/source/_module.less
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/css/source/_module.less
@@ -107,92 +107,98 @@
                 }
             }
 
-            .keywords {
-                margin: 30px 0 20px 0;
-                display: inline-block;
-                width: 100%;
+            .keywords-container {
 
-                .title {
-                    margin-bottom: 30px;
-                }
-
-                .keyword {
+                .keywords {
+                    margin: 30px 0 30px 0;
                     display: inline-block;
-                    margin-right: 5px;
-                    line-height: 40px;
+                    width: 100%;
 
-                    &.hide {
-                        display: none;
+                    .title {
+                        margin-bottom: 30px;
                     }
 
-                    .value {
-                        font-size: 15px;
-                        text-transform: capitalize;
-                        border: 1px solid #c6c1bb;
-                        padding: 5px;
-                        border-radius: 3px;
-                        background-color: #f5f5f5;
-                        color: #666666;
-                    }
-                }
-
-                button {
-                    margin-left: 10px;
-                }
-            }
-
-            .adobe-stock-tabs {
-                margin-top: 30px;
-            }
-
-            .adobe-stock-related-images-tab-content {
-                max-height: 190px;
-                vertical-align: middle;
-                display: inline-block;
-                width: 100%;
-
-                .ui-tabs-panel {
-                    margin-top: 30px;
-                    padding: 0;
-
-                    .thumbnail {
+                    .keyword {
                         display: inline-block;
-                        margin-right: 10px;
-                        vertical-align: middle;
+                        margin-right: 5px;
+                        line-height: 40px;
 
-                        img {
-                            max-height: 100px;
-                            max-width: 150px;
-                            width: auto;
-                            height: auto;
+                        &.hide {
+                            display: none;
+                        }
+
+                        .value {
+                            font-size: 15px;
+                            text-transform: capitalize;
+                            border: 1px solid #c6c1bb;
+                            padding: 5px;
+                            border-radius: 3px;
+                            background-color: #f5f5f5;
+                            color: #666666;
                         }
                     }
 
-                    .see-more-wrapper {
-                        display: inline-block;
-                        max-height: 100px;
-                        text-align: center;
-                        max-width: 140px;
-                        vertical-align: middle;
-                        width: 100%;
-                        cursor: pointer;
+                    button {
+                        margin-left: 10px;
+                    }
+                }
+            }
 
-                        .see-more-content {
-                            padding: 30px;
+            .related-container {
 
-                            .three-dots {
-                                margin-bottom: 10px;
+                .adobe-stock-tabs {
+                    margin-top: 30px;
+                }
 
-                                .dots {
-                                    content: "\22EE";
-                                    display: inline-block;
-                                    width: 10px;
-                                    height: 10px;
-                                    color: #fff;
-                                    background-color: #626160;
-                                    border-radius: 50%;
-                                    line-height: 1;
-                                    text-align: center;
+                .adobe-stock-related-images-tab-content {
+                    max-height: 190px;
+                    vertical-align: middle;
+                    display: inline-block;
+                    width: 100%;
+
+                    .ui-tabs-panel {
+                        margin-top: 30px;
+                        padding: 0;
+
+                        .thumbnail {
+                            display: inline-block;
+                            margin-right: 10px;
+                            vertical-align: middle;
+
+                            img {
+                                max-height: 100px;
+                                max-width: 150px;
+                                width: auto;
+                                height: auto;
+                            }
+                        }
+
+                        .see-more-wrapper {
+                            display: inline-block;
+                            max-height: 100px;
+                            text-align: center;
+                            max-width: 140px;
+                            vertical-align: middle;
+                            width: 100%;
+                            cursor: pointer;
+
+                            .see-more-content {
+                                padding: 30px;
+
+                                .three-dots {
+                                    margin-bottom: 10px;
+
+                                    .dots {
+                                        content: "\22EE";
+                                        display: inline-block;
+                                        width: 10px;
+                                        height: 10px;
+                                        color: #fff;
+                                        background-color: #626160;
+                                        border-radius: 50%;
+                                        line-height: 1;
+                                        text-align: center;
+                                    }
                                 }
                             }
                         }

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/image-preview.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/image-preview.js
@@ -69,8 +69,8 @@ define([
          *
          * @return {Boolean}
          */
-        getPreviousButtonDisabled: function (record) {
-            return this.related().getPreviousButtonDisabled(record);
+        cannotViewPrevious: function (record) {
+            return this.related().cannotViewPrevious(record);
         },
 
         /**
@@ -80,15 +80,15 @@ define([
          *
          * @return {Boolean}
          */
-        getNextButtonDisabled: function (record) {
-            return this.related().getNextButtonDisabled(record);
+        cannotViewNext: function (record) {
+            return this.related().cannotViewNext(record);
         },
 
         /**
          * @inheritdoc
          */
         next: function (record) {
-            if (this.related().selectedRelatedType()) {
+            if (this.related().selectedTab()) {
                 this.related().nextRelated(record);
 
                 return;
@@ -101,7 +101,7 @@ define([
          * @inheritdoc
          */
         prev: function (record) {
-            if (this.related().selectedRelatedType()) {
+            if (this.related().selectedTab()) {
                 this.related().prevRelated(record);
 
                 return;
@@ -114,7 +114,7 @@ define([
          * @inheritdoc
          */
         show: function (record) {
-            this.related().selectedRelatedType(null);
+            this.related().selectedTab(null);
             this.related().initRecord(record);
             this.keywords().hideAllKeywords();
             this.displayedRecord(record);

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/image-preview.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/image-preview.js
@@ -142,7 +142,6 @@ define([
             if (record.series && record.model &&
                 record.series() && record.model() &&
                 record.series().length && record.model().length) {
-                this.updateHeight();
                 return;
             }
             $.ajax({

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/image-preview.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/image-preview.js
@@ -142,6 +142,7 @@ define([
             if (record.series && record.model &&
                 record.series() && record.model() &&
                 record.series().length && record.model().length) {
+                this.updateHeight();
                 return;
             }
             $.ajax({

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/actions.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/actions.js
@@ -17,8 +17,6 @@ define([
         defaults: {
             template: 'Magento_AdobeStockImageAdminUi/grid/column/preview/actions',
             loginProvider: 'name = adobe-login, ns = adobe-login',
-            // eslint-disable-next-line max-len
-            previewProvider: 'name = adobe_stock_images_listing.adobe_stock_images_listing.adobe_stock_images_columns.preview, ns = ${ $.ns }',
             mediaGallerySelector: '.media-gallery-modal:has(#search_adobe_stock)',
             adobeStockModalSelector: '#adobe-stock-images-search-modal',
             downloadImagePreviewUrl: 'adobe_stock/preview/download',
@@ -28,7 +26,7 @@ define([
             messageDelay: 5,
             modules: {
                 login: '${ $.loginProvider }',
-                preview: '${ $.previewProvider }'
+                preview: '${ $.parentName }.preview'
             }
         },
 

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/keywords.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/keywords.js
@@ -13,15 +13,13 @@ define([
             template: 'Magento_AdobeStockImageAdminUi/grid/column/preview/keywords',
             chipsProvider: 'componentType = filtersChips, ns = ${ $.ns }',
             searchChipsProvider: 'componentType = keyword_search, ns = ${ $.ns }',
-            // eslint-disable-next-line max-len
-            previewProvider: 'name = adobe_stock_images_listing.adobe_stock_images_listing.adobe_stock_images_columns.preview, ns = ${ $.ns }',
             defaultKeywordsLimit: 5,
             keywordsLimit: 5,
             canViewMoreKeywords: true,
             modules: {
                 searchChips: '${ $.searchChipsProvider }',
                 chips: '${ $.chipsProvider }',
-                preview: '${ $.previewProvider }'
+                preview: '${ $.parentName }.preview'
             },
             exports: {
                 inputValue: '${ $.provider }:params.search',
@@ -74,15 +72,6 @@ define([
         hideAllKeywords: function () {
             this.keywordsLimit(this.defaultKeywordsLimit);
             this.canViewMoreKeywords(true);
-        },
-
-        /**
-         * Check if view all button is visible or not
-         *
-         * @returns {bool}
-         */
-        canViewMoreKeywords: function () {
-            return this.canViewMoreKeywords();
         },
 
         /**

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/related.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/related.js
@@ -15,11 +15,9 @@ define([
         defaults: {
             template: 'Magento_AdobeStockImageAdminUi/grid/column/preview/related',
             filterChipsProvider: 'componentType = filters, ns = ${ $.ns }',
-            // eslint-disable-next-line max-len
-            previewProvider: 'name = adobe_stock_images_listing.adobe_stock_images_listing.adobe_stock_images_columns.preview, ns = ${ $.ns }',
             serieFilterValue: '',
             modelFilterValue: '',
-            selectedRelatedType: null,
+            selectedTab: null,
             statefull: {
                 serieFilterValue: true,
                 modelFilterValue: true
@@ -27,7 +25,7 @@ define([
             modules: {
                 chips: '${ $.chipsProvider }',
                 filterChips: '${ $.filterChipsProvider }',
-                preview: '${ $.previewProvider }'
+                preview: '${ $.parentName }.preview'
             },
             exports: {
                 serieFilterValue: '${ $.provider }:params.filters.serie_id',
@@ -54,7 +52,7 @@ define([
                 .observe([
                     'serieFilterValue',
                     'modelFilterValue',
-                    'selectedRelatedType'
+                    'selectedTab'
                 ]);
 
             return this;
@@ -76,7 +74,7 @@ define([
          * @param {Object} record
          * @returns boolean
          */
-        canShowMoreSeriesImages: function(record) {
+        canShowMoreSeriesImages: function (record) {
             return parseInt(record.series().length) >= this.preview().tabImagesLimit;
         },
 
@@ -96,7 +94,7 @@ define([
          * @param {Object} record
          * @returns boolean
          */
-        canShowMoreModelImages: function(record) {
+        canShowMoreModelImages: function (record) {
             return parseInt(record.model().length) >= this.preview().tabImagesLimit;
         },
 
@@ -136,7 +134,7 @@ define([
          * @param {Object} record
          */
         nextRelated: function (record) {
-            var relatedList = this.selectedRelatedType() === 'series' ? record.series() : record.model(),
+            var relatedList = this.selectedTab() === 'series' ? record.series() : record.model(),
                 nextRelatedIndex = _.findLastIndex(
                     relatedList,
                     {
@@ -149,7 +147,7 @@ define([
                 return;
             }
 
-            this.switchImagePreviewToRelatedImage(nextRelated, record);
+            this.switchImagePreviewToRelatedImage(nextRelated);
         },
 
         /**
@@ -158,7 +156,7 @@ define([
          * @param {Object} record
          */
         prevRelated: function (record) {
-            var relatedList = this.selectedRelatedType() === 'series' ? record.series() : record.model(),
+            var relatedList = this.selectedTab() === 'series' ? record.series() : record.model(),
                 prevRelatedIndex = _.findLastIndex(
                     relatedList,
                     {
@@ -171,7 +169,7 @@ define([
                 return;
             }
 
-            this.switchImagePreviewToRelatedImage(prevRelated, record);
+            this.switchImagePreviewToRelatedImage(prevRelated);
         },
 
         /**
@@ -181,13 +179,13 @@ define([
          *
          * @return {Boolean}
          */
-        getPreviousButtonDisabled: function (record) {
+        cannotViewPrevious: function (record) {
             var relatedList, prevRelatedIndex, prevRelated;
 
-            if (!this.selectedRelatedType()) {
+            if (!this.selectedTab()) {
                 return false;
             }
-            relatedList = this.selectedRelatedType() === 'series' ? record.series() : record.model();
+            relatedList = this.selectedTab() === 'series' ? record.series() : record.model();
             prevRelatedIndex = _.findLastIndex(
                 relatedList,
                 {
@@ -206,13 +204,13 @@ define([
          *
          * @return {Boolean}
          */
-        getNextButtonDisabled: function (record) {
+        cannotViewNext: function (record) {
             var relatedList, nextRelatedIndex, nextRelated;
 
-            if (!this.selectedRelatedType()) {
+            if (!this.selectedTab()) {
                 return false;
             }
-            relatedList = this.selectedRelatedType() === 'series' ? record.series() : record.model();
+            relatedList = this.selectedTab() === 'series' ? record.series() : record.model();
             nextRelatedIndex = _.findLastIndex(
                 relatedList,
                 {
@@ -231,7 +229,7 @@ define([
          */
         switchImagePreviewToRelatedImage: function (relatedImage) {
             if (!relatedImage) {
-                this.selectedRelatedType(null);
+                this.selectedTab(null);
 
                 return;
             }
@@ -246,23 +244,21 @@ define([
         /**
          * Switch image preview to series image
          *
-         * @param {Object} series
          * @param {Object} record
          */
-        switchImagePreviewToSeriesImage: function (series, record) {
-            this.selectedRelatedType('series');
-            this.switchImagePreviewToRelatedImage(series, record);
+        switchImagePreviewToSeriesImage: function (record) {
+            this.selectedTab('series');
+            this.switchImagePreviewToRelatedImage(record);
         },
 
         /**
          * Switch image preview to model image
          *
-         * @param {Object} model
          * @param {Object} record
          */
-        switchImagePreviewToModelImage: function (model, record) {
-            this.selectedRelatedType('model');
-            this.switchImagePreviewToRelatedImage(model, record);
+        switchImagePreviewToModelImage: function (record) {
+            this.selectedTab('model');
+            this.switchImagePreviewToRelatedImage(record);
         }
     });
 });

--- a/AdobeStockImageAdminUi/view/adminhtml/web/template/grid/column/image-preview.html
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/template/grid/column/image-preview.html
@@ -7,10 +7,10 @@
 <div class="masonry-image-preview" if="$col.isVisible($row())" data-image-preview ko-style="$col.getStyles()">
     <div class="container">
         <div class="action-buttons preview-buttons">
-            <button class="action-previous" type="button" disable="$col.getPreviousButtonDisabled($row())" data-bind="click: function () { $col.prev($row()); }">
+            <button class="action-previous" type="button" disable="$col.cannotViewPrevious($row())" data-bind="click: function () { $col.prev($row()); }">
                 <span translate="'Previous'"/>
             </button>
-            <button class="action-next" type="button" disable="$col.getNextButtonDisabled($row())" data-bind="click: function () { $col.next($row()); }">
+            <button class="action-next" type="button" disable="$col.cannotViewNext($row())" data-bind="click: function () { $col.next($row()); }">
                 <span translate="'Next'"/>
             </button>
             <button class="action-close" type="button" data-bind="click: function () { $col.hide($row()); }">
@@ -28,7 +28,7 @@
 
                 <div class="actions">
                     <!-- ko scope: actions -->
-                    <!-- ko template: getTemplate() --><!-- /ko -->
+                        <!-- ko template: getTemplate() --><!-- /ko -->
                     <!-- /ko -->
                 </div>
             </div>
@@ -45,12 +45,12 @@
             <!-- /ko -->
         </div>
 
-        <!-- ko scope: related -->
+        <div class="related-container" ko-scope="related">
             <!-- ko template: getTemplate() --><!-- /ko -->
-        <!-- /ko -->
+        </div>
 
-        <!-- ko scope: keywords -->
+        <div class="keywords-container" ko-scope="keywords">
             <!-- ko template: getTemplate() --><!-- /ko -->
-        <!-- /ko -->
+        </div>
     </div>
 </div>

--- a/AdobeStockImageAdminUi/view/adminhtml/web/template/grid/column/preview/keywords.html
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/template/grid/column/preview/keywords.html
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 -->
-<div class="keywords" afterRender="function () { $col.updateHeight() }">
+<div class="keywords">
     <div class="title" translate="'Similar Keywords'"></div>
     <!-- ko foreach: getKeywords($col.displayedRecord()) -->
         <div class="keyword" data-bind="css: { 'hide': $index() >= $parent.getKeywordsLimit()}">

--- a/AdobeStockImageAdminUi/view/adminhtml/web/template/grid/column/preview/keywords.html
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/template/grid/column/preview/keywords.html
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 -->
-<div class="keywords">
+<div class="keywords" afterRender="function () { $col.updateHeight() }">
     <div class="title" translate="'Similar Keywords'"></div>
     <!-- ko foreach: getKeywords($col.displayedRecord()) -->
         <div class="keyword" data-bind="css: { 'hide': $index() >= $parent.getKeywordsLimit()}">
@@ -13,7 +13,7 @@
             </a>
         </div>
     <!-- /ko -->
-    <button data-bind="visible: canViewMoreKeywords(), click: function(){ viewAllKeywords($col.displayedRecord()) }">
+    <button data-bind="visible: canViewMoreKeywords, click: function(){ viewAllKeywords($col.displayedRecord()) }">
         <span translate="'View all'"/>
     </button>
 </div>

--- a/AdobeStockImageAdminUi/view/adminhtml/web/template/grid/column/preview/related.html
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/template/grid/column/preview/related.html
@@ -29,7 +29,7 @@
 <div id="adobe-stock-tabs-content" class="adobe-stock-related-images-tab-content">
     <div attr="'id': 'series_content_' + $row().id">
         <!-- ko foreach: getSeries($row()) -->
-            <div class="thumbnail" data-bind="click: function(){ $parent.switchImagePreviewToSeriesImage($data, $row()) }">
+            <div class="thumbnail" data-bind="click: function(){ $parent.switchImagePreviewToSeriesImage($data) }">
                 <img attr="src: thumbnail_url, alt: title">
             </div>
         <!-- /ko -->
@@ -48,7 +48,7 @@
     </div>
     <div attr="'id': 'model_content_' + $row().id">
         <!-- ko foreach: getModel($row()) -->
-            <div class="thumbnail" data-bind="click: function(){ $parent.switchImagePreviewToModelImage($data, $row()) }">
+            <div class="thumbnail" data-bind="click: function(){ $parent.switchImagePreviewToModelImage($data) }">
                 <img attr="src: thumbnail_url, alt: title">
             </div>
         <!-- /ko -->

--- a/AdobeUi/view/adminhtml/web/css/source/_module.less
+++ b/AdobeUi/view/adminhtml/web/css/source/_module.less
@@ -47,7 +47,6 @@
             display: table;
             background-color: #ffffff;
             width: 100%;
-            padding: 0 0 30px;
 
             .container {
                 max-width: 880px;

--- a/AdobeUi/view/adminhtml/web/js/components/grid/column/image-preview.js
+++ b/AdobeUi/view/adminhtml/web/js/components/grid/column/image-preview.js
@@ -101,13 +101,24 @@ define([
          * @param {Object} record
          */
         show: function (record) {
+            var img;
+
             this.hide();
             this.displayedRecord(record);
             this._selectRow(record.rowNumber || null);
             this.visibile(record._rowIndex);
 
-            this.updateHeight();
-            this.scrollToPreview();
+            img = $(this.previewImageSelector + ' img');
+
+            if (img.get(0).complete) {
+                this.updateHeight();
+                this.scrollToPreview();
+            } else {
+                img.load(function () {
+                    this.updateHeight();
+                    this.scrollToPreview();
+                }.bind(this));
+            }
 
             this.lastOpenedImage(record._rowIndex);
         },

--- a/AdobeUi/view/adminhtml/web/js/components/grid/column/image-preview.js
+++ b/AdobeUi/view/adminhtml/web/js/components/grid/column/image-preview.js
@@ -12,9 +12,8 @@ define([
     return Column.extend({
         defaults: {
             previewImageSelector: '[data-image-preview]',
-            visibility: [],
+            visibile: null,
             height: 0,
-            previewStyles: {},
             displayedRecord: {},
             lastOpenedImage: null,
             modules: {
@@ -39,9 +38,8 @@ define([
         initObservable: function () {
             this._super()
                 .observe([
-                    'visibility',
+                    'visibile',
                     'height',
-                    'previewStyles',
                     'displayedRecord',
                     'lastOpenedImage'
                 ]);
@@ -103,31 +101,14 @@ define([
          * @param {Object} record
          */
         show: function (record) {
-            var visibility = this.visibility(),
-                img;
-
             this.hide();
             this.displayedRecord(record);
+            this._selectRow(record.rowNumber || null);
+            this.visibile(record._rowIndex);
 
-            if (record.rowNumber) {
-                this._selectRow(record.rowNumber);
-            }
+            this.updateHeight();
+            this.scrollToPreview();
 
-            visibility[record._rowIndex] = true;
-
-            this.visibility(visibility);
-
-            img = $(this.previewImageSelector + ' img');
-
-            if (img.get(0).complete) {
-                this.updateHeight();
-                this.scrollToPreview();
-            } else {
-                img.load(function () {
-                    this.updateHeight();
-                    this.scrollToPreview();
-                }.bind(this));
-            }
             this.lastOpenedImage(record._rowIndex);
         },
 
@@ -136,18 +117,14 @@ define([
          */
         updateHeight: function () {
             this.height($(this.previewImageSelector).height() + 'px');
-            this.visibility(this.visibility());
         },
 
         /**
          * Close image preview
          */
         hide: function () {
-            var visibility = this.visibility();
-
             this.lastOpenedImage(null);
-            visibility.fill(false);
-            this.visibility(visibility);
+            this.visibile(null);
             this.height(0);
             this._selectRow(null);
         },
@@ -160,15 +137,12 @@ define([
          */
         isVisible: function (record) {
             if (this.lastOpenedImage() === record._rowIndex &&
-                (
-                    this.visibility()[record._rowIndex] === undefined ||
-                    this.visibility()[record._rowIndex] === false
-                )
+                this.visibile() === null
             ) {
                 this.show(record);
             }
 
-            return this.visibility()[record._rowIndex] || false;
+            return this.visibile() === record._rowIndex || false;
         },
 
         /**
@@ -177,11 +151,9 @@ define([
          * @returns {Object}
          */
         getStyles: function () {
-            this.previewStyles({
+            return {
                 'margin-top': '-' + this.height()
-            });
-
-            return this.previewStyles();
+            };
         },
 
         /**

--- a/AdobeUi/view/adminhtml/web/js/components/grid/masonry.js
+++ b/AdobeUi/view/adminhtml/web/js/components/grid/masonry.js
@@ -72,7 +72,7 @@ define([
             if (!rows || !rows.length) {
                 return;
             }
-            this.imageMargin = parseInt(this.imageMargin, 10);
+            this.imageMargin = parseInt(this.imageMargin);
             this.container = $('[data-id="' + this.containerId + '"]')[0];
 
             this.setLayoutStyles();
@@ -114,43 +114,61 @@ define([
          * Set layout styles inside the container
          */
         setLayoutStyles: function () {
-            var containerWidth = parseInt(this.container.clientWidth, 10) - this.imageMargin,
-                row = [],
+            var containerWidth = parseInt(this.container.clientWidth),
+                rowImages = [],
                 ratio = 0,
-                imageWidth = 0,
                 rowHeight = 0,
                 calcHeight = 0,
-                isBottom = false,
-                imageRowNumber = 1;
+                isLastRow = false,
+                rowNumber = 1;
 
             this.setMinRatio();
 
             this.rows().forEach(function (image, index) {
                 ratio += parseFloat((image.width / image.height).toFixed(2));
-                row.push(image);
+                rowImages.push(image);
 
-                if (ratio >= this.minRatio || index + 1 === this.rows().length) {
-                    ratio = Math.max(ratio, this.minRatio);
-                    calcHeight = (containerWidth - this.imageMargin * (row.length - 1)) / ratio;
-                    rowHeight = calcHeight < this.maxImageHeight ? calcHeight : this.maxImageHeight;
-                    isBottom = index + 1 === this.rows().length;
-
-                    row.forEach(function (img) {
-                        imageWidth = rowHeight * (img.width / img.height).toFixed(2);
-                        this.setImageStyles(img, imageWidth, rowHeight);
-                        this.setImageClass(img, {
-                            bottom: isBottom
-                        });
-                        img.rowNumber = imageRowNumber;
-                    }.bind(this));
-
-                    row[0].firstInRow = true;
-                    row[row.length - 1].lastInRow = true;
-                    row = [];
-                    ratio = 0;
-                    imageRowNumber++;
+                if (ratio < this.minRatio && index + 1 !== this.rows().length) {
+                    // Row has more space for images and the image is not the last one - proceed to the next iteration
+                    return;
                 }
+
+                ratio = Math.max(ratio, this.minRatio);
+                calcHeight = (containerWidth - this.imageMargin * rowImages.length) / ratio;
+                rowHeight = calcHeight < this.maxImageHeight ? calcHeight : this.maxImageHeight;
+                isLastRow = index + 1 === this.rows().length;
+
+                this.assignImagesToRow(rowImages, rowNumber, rowHeight, isLastRow);
+
+                rowImages = [];
+                ratio = 0;
+                rowNumber++;
+
             }.bind(this));
+        },
+
+        /**
+         * Apply styles, css classes and add properties for images in the row
+         *
+         * @param {Object[]} images
+         * @param {Number} rowNumber
+         * @param {Number} rowHeight
+         * @param {Boolean} isLastRow
+         */
+        assignImagesToRow: function (images, rowNumber, rowHeight, isLastRow) {
+            var imageWidth;
+
+            images.forEach(function (img) {
+                imageWidth = rowHeight * (img.width / img.height).toFixed(2);
+                this.setImageStyles(img, imageWidth, rowHeight);
+                this.setImageClass(img, {
+                    bottom: isLastRow
+                });
+                img.rowNumber = rowNumber;
+            }.bind(this));
+
+            images[0].firstInRow = true;
+            images[images.length - 1].lastInRow = true;
         },
 
         /**
@@ -179,29 +197,30 @@ define([
          * Set styles for every image in layout
          *
          * @param {Object} img
-         * @param {Number} imageWidth
-         * @param {Number} rowHeight
+         * @param {Number} width
+         * @param {Number} height
          */
-        setImageStyles: function (img, imageWidth, rowHeight) {
+        setImageStyles: function (img, width, height) {
             if (!img.styles) {
                 img.styles = ko.observable();
             }
             img.styles({
-                width: parseInt(imageWidth, 10) + 'px',
-                height: parseInt(rowHeight, 10) + 'px'
+                width: parseInt(width) + 'px',
+                height: parseInt(height) + 'px'
             });
         },
 
         /**
+         * Set css classes to and an image
          *
-         * @param {Object} img
+         * @param {Object} image
          * @param {Object} classes
          */
-        setImageClass: function (img, classes) {
-            if (!img.css) {
-                img.css = ko.observable(classes);
+        setImageClass: function (image, classes) {
+            if (!image.css) {
+                image.css = ko.observable(classes);
             }
-            img.css(classes);
+            image.css(classes);
         },
 
         /**


### PR DESCRIPTION
### Description (*)

Fixed bug when the extra margin was applied to the reopened image preview

### Fixed Issues (if relevant)
https://github.com/magento/adobe-stock-integration/issues/519 [Bug] Extra margin is applied under the image preview row when it's opened the second time

### Manual testing scenarios (*)
1. Login to admin panel
2. Open Magento Media Gallery (i.e. go to Cms -> Pages, edit the page and insert image)
3. Click "Search Adobe Stock" button to open images grid
4. Click on any image to expand image preview
5. Close image preview or select another image
6. Reopen image preview from step 4

### Expected result
No excessive empty space is present around the image preview