### PR TITLE
Add Magento version to x-product header for Adobe Stock API requests

### DIFF
--- a/AdobeStockClient/Model/Config.php
+++ b/AdobeStockClient/Model/Config.php
@@ -12,6 +12,7 @@ use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\UrlInterface;
 use Magento\Config\Model\Config\Backend\Admin\Custom;
 use Magento\AdobeStockClientApi\Api\ConfigInterface;
+use Magento\Framework\App\ProductMetadataInterface;
 
 /**
  * Class Config
@@ -37,19 +38,28 @@ class Config implements ConfigInterface
     private $url;
 
     /**
-     * Config constructor.
+     * @var ProductMetadataInterface 
+     */
+    private $metadataInterface;
+
+    /**
+     * Constructor
+     *
      * @param ScopeConfigInterface $scopeConfig
      * @param UrlInterface $url
+     * @param ProductMetadataInterface $metadataInterface
      * @param array $searchResultFields
      */
     public function __construct(
         ScopeConfigInterface $scopeConfig,
-        UrlInterface $url,
+	UrlInterface $url,
+	ProductMetadataInterface $metadataInterface,
         array $searchResultFields = []
     ) {
         $this->scopeConfig = $scopeConfig;
         $this->url = $url;
-        $this->searchResultFields = $searchResultFields;
+	$this->searchResultFields = $searchResultFields;
+	$this->metadataInterface = $metadataInterface;
     }
 
     /**
@@ -68,8 +78,8 @@ class Config implements ConfigInterface
      * @return string|null
      */
     public function getProductName() : ?string
-    {
-        return $this->scopeConfig->getValue(self::XML_PATH_PRODUCT_NAME);
+    {	
+         return $this->scopeConfig->getValue(self::XML_PATH_PRODUCT_NAME) . '/' . $this->metadataInterface->getVersion();
     }
 
     /**

--- a/AdobeStockClient/Model/Config.php
+++ b/AdobeStockClient/Model/Config.php
@@ -8,11 +8,11 @@ declare(strict_types=1);
 
 namespace Magento\AdobeStockClient\Model;
 
-use Magento\Framework\App\Config\ScopeConfigInterface;
-use Magento\Framework\UrlInterface;
-use Magento\Config\Model\Config\Backend\Admin\Custom;
 use Magento\AdobeStockClientApi\Api\ConfigInterface;
+use Magento\Config\Model\Config\Backend\Admin\Custom;
+use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\App\ProductMetadataInterface;
+use Magento\Framework\UrlInterface;
 
 /**
  * Class Config
@@ -38,7 +38,7 @@ class Config implements ConfigInterface
     private $url;
 
     /**
-     * @var ProductMetadataInterface 
+     * @var ProductMetadataInterface
      */
     private $metadataInterface;
 
@@ -52,14 +52,14 @@ class Config implements ConfigInterface
      */
     public function __construct(
         ScopeConfigInterface $scopeConfig,
-	UrlInterface $url,
-	ProductMetadataInterface $metadataInterface,
+        UrlInterface $url,
+        ProductMetadataInterface $metadataInterface,
         array $searchResultFields = []
     ) {
         $this->scopeConfig = $scopeConfig;
         $this->url = $url;
-	$this->searchResultFields = $searchResultFields;
-	$this->metadataInterface = $metadataInterface;
+        $this->searchResultFields = $searchResultFields;
+        $this->metadataInterface = $metadataInterface;
     }
 
     /**
@@ -78,8 +78,8 @@ class Config implements ConfigInterface
      * @return string|null
      */
     public function getProductName() : ?string
-    {	
-         return $this->scopeConfig->getValue(self::XML_PATH_PRODUCT_NAME) . '/' . $this->metadataInterface->getVersion();
+    {
+        return $this->scopeConfig->getValue(self::XML_PATH_PRODUCT_NAME) . '/' . $this->metadataInterface->getVersion();
     }
 
     /**

--- a/AdobeStockClient/etc/config.xml
+++ b/AdobeStockClient/etc/config.xml
@@ -11,7 +11,7 @@
             <integration>
                 <enabled>1</enabled>
                 <environment>PROD</environment>
-                <product_name>magento-adobe-stock-integration</product_name>
+                <product_name>Magento</product_name>
             </integration>
         </adobe_stock>
     </default>


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

x-product header sets to Magento/dev-2.3-develop for requests to Adobe Stock API for the 2.3-develop branch

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/adobe-stock-integration#604: Add Magento version to x-product header for Adobe Stock API requests


### Manual testing scenarios (*)
