### PR TITLE
Enhance AdobeStockAssetApi & AdobeStockClient test

### DIFF
--- a/AdobeStockAssetApi/Api/GetAssetByIdInterface.php
+++ b/AdobeStockAssetApi/Api/GetAssetByIdInterface.php
@@ -8,6 +8,8 @@ declare(strict_types=1);
 
 namespace Magento\AdobeStockAssetApi\Api;
 
+use Magento\Framework\Api\Search\Document;
+
 /**
  * Get asset by Adobe ID
  *
@@ -23,5 +25,5 @@ interface GetAssetByIdInterface
      * @throws \Magento\Framework\Exception\NotFoundException
      * @throws \Magento\Framework\Exception\LocalizedException
      */
-    public function execute(int $adobeId): \Magento\Framework\Api\Search\Document;
+    public function execute(int $adobeId): Document;
 }

--- a/AdobeStockAssetApi/Api/SaveAssetInterface.php
+++ b/AdobeStockAssetApi/Api/SaveAssetInterface.php
@@ -8,6 +8,8 @@ declare(strict_types=1);
 
 namespace Magento\AdobeStockAssetApi\Api;
 
+use Magento\AdobeStockAssetApi\Api\Data\AssetInterface;
+
 /**
  * Save asset and all it's relations
  *
@@ -21,5 +23,5 @@ interface SaveAssetInterface
      * @param \Magento\AdobeStockAssetApi\Api\Data\AssetInterface $asset
      * @throws \Magento\Framework\Exception\AlreadyExistsException
      */
-    public function execute(\Magento\AdobeStockAssetApi\Api\Data\AssetInterface $asset): void;
+    public function execute(AssetInterface $asset): void;
 }

--- a/AdobeStockClient/Test/Unit/Model/ClientTest.php
+++ b/AdobeStockClient/Test/Unit/Model/ClientTest.php
@@ -9,8 +9,10 @@ namespace Magento\AdobeStockClient\Test\Unit\Model;
 
 use AdobeStock\Api\Models\LicenseEntitlement;
 use AdobeStock\Api\Models\LicensePurchaseOptions;
+use AdobeStock\Api\Models\LicenseEntitlementQuota;
 use AdobeStock\Api\Models\StockFile;
 use AdobeStock\Api\Request\License;
+use AdobeStock\Api\Response\License as ResponseLicense;
 use AdobeStock\Api\Request\LicenseFactory as LicenseRequestFactory;
 use AdobeStock\Api\Response\SearchFiles as SearchFilesResponse;
 use Magento\AdobeStockClient\Model\Client;
@@ -106,9 +108,8 @@ class ClientTest extends TestCase
     /**
      * Prepare test objects.
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
-
         $this->config = $this->createMock(ConfigInterface::class);
         $this->connectionFactory = $this->createMock(ConnectionWrapperFactory::class);
         $this->searchResultFactory = $this->createMock(SearchResultFactory::class);
@@ -120,9 +121,9 @@ class ClientTest extends TestCase
         $this->stockFileToDocument = $this->createMock(StockFileToDocument::class);
         $this->licenseConfirmationFactory = $this->createMock(LicenseConfirmationInterfaceFactory::class);
 
-        $this->connectionWrapper = $this->createMock(\Magento\AdobeStockClient\Model\ConnectionWrapper::class);
+        $this->connectionWrapper = $this->createMock(ConnectionWrapper::class);
         $this->connectionFactory->expects($this->any())->method('create')->willReturn($this->connectionWrapper);
-        $this->licenseResponse = $this->createMock(\AdobeStock\Api\Response\License::class);
+        $this->licenseResponse = $this->createMock(ResponseLicense::class);
 
         $this->client = (new ObjectManager($this))->getObject(
             Client::class,
@@ -144,7 +145,7 @@ class ClientTest extends TestCase
     /**
      * Search test
      */
-    public function testSearch()
+    public function testSearch(): void
     {
         $this->localeResolver->expects($this->once())->method('getLocale')->willReturn('ru_RU');
         $this->config->expects($this->once())
@@ -179,7 +180,7 @@ class ClientTest extends TestCase
     /**
      * Test get user quota
      */
-    public function testGetQuota()
+    public function testGetQuota(): void
     {
         $this->connectionWrapper->expects($this->once())
             ->method('getMemberProfile')
@@ -188,9 +189,9 @@ class ClientTest extends TestCase
         $this->licenseResponse->expects($this->once())->method('getEntitlement')->willReturn($licenseEntitielement);
         $licenseEntitielement->expects($this->once())
             ->method('getFullEntitlementQuota')
-            ->willReturn($this->createMock(\AdobeStock\Api\Models\LicenseEntitlementQuota::class));
+            ->willReturn($this->createMock(LicenseEntitlementQuota::class));
         $this->setLicense();
-        $quota = $this->createMock(\Magento\AdobeStockClientApi\Api\Data\UserQuotaInterface::class);
+        $quota = $this->createMock(UserQuotaInterface::class);
         $this->userQuotaFactory->expects($this->once())
             ->method('create')
             ->willReturn($quota);
@@ -203,7 +204,7 @@ class ClientTest extends TestCase
     /**
      * Get license confirmation test
      */
-    public function testGetLicenseConfirmation()
+    public function testGetLicenseConfirmation(): void
     {
 
         $this->connectionWrapper->expects($this->exactly(2))
@@ -219,7 +220,7 @@ class ClientTest extends TestCase
         $LicensePurchaseOptions->expects($this->once())
             ->method('getPurchaseState')
             ->willReturn('possible');
-        $quota = $this->createMock(\Magento\AdobeStockClientApi\Api\Data\LicenseConfirmationInterface::class);
+        $quota = $this->createMock(LicenseConfirmationInterface::class);
         $this->licenseConfirmationFactory->expects($this->once())
             ->method('create')
             ->willReturn($quota);
@@ -235,7 +236,7 @@ class ClientTest extends TestCase
     /**
      * License image test
      */
-    public function testLicenseImage()
+    public function testLicenseImage(): void
     {
         $this->connectionWrapper->expects($this->once())
             ->method('getContentLicense')
@@ -247,7 +248,7 @@ class ClientTest extends TestCase
     /**
      *  Test get image Download Url
      */
-    public function testGetImageDownloadUrl()
+    public function testGetImageDownloadUrl(): void
     {
         $this->connectionWrapper->expects($this->once())
             ->method('downloadAssetUrl')
@@ -259,7 +260,7 @@ class ClientTest extends TestCase
     /**
      * Test for test connection method
      */
-    public function testTestConnection()
+    public function testTestConnection(): void
     {
         $this->connectionWrapper->expects($this->once())
             ->method('testApiKey')
@@ -272,7 +273,7 @@ class ClientTest extends TestCase
      *
      * @param int $expectInvocation
      */
-    private function setLicense(int $expectInvocation = 1)
+    private function setLicense(int $expectInvocation = 1): void
     {
         $licenseRequest = $this->createMock(License::class);
         $this->licenseRequestFactory->expects($this->exactly($expectInvocation))

--- a/AdobeStockClient/Test/Unit/Model/ConfigTest.php
+++ b/AdobeStockClient/Test/Unit/Model/ConfigTest.php
@@ -18,8 +18,6 @@ use PHPUnit\Framework\TestCase;
  */
 class ConfigTest extends TestCase
 {
-    private const CONFIG_XML_PATH_API_KEY = 'adobe_stock/integration/api_key';
-
     private const CONFIG_XML_PATH_ENVIRONMENT = 'adobe_stock/integration/environment';
 
     private const CONFIG_XML_PATH_PRODUCT_NAME = 'adobe_stock/integration/product_name';
@@ -42,7 +40,7 @@ class ConfigTest extends TestCase
     /**
      * Prepare test objects.
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->objectManager = new ObjectManager($this);
         $this->scopeConfigMock = $this->createMock(ScopeConfigInterface::class);

--- a/AdobeStockClient/Test/Unit/Model/ConnectionFactoryTest.php
+++ b/AdobeStockClient/Test/Unit/Model/ConnectionFactoryTest.php
@@ -30,7 +30,7 @@ class ConnectionFactoryTest extends TestCase
     /**
      * Prepare test objects.
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->objectManager = new ObjectManager($this);
         $this->connectionFactory = $this->objectManager->getObject(ConnectionFactory::class);

--- a/AdobeStockClient/Test/Unit/Model/ConnectionWrapperTest.php
+++ b/AdobeStockClient/Test/Unit/Model/ConnectionWrapperTest.php
@@ -76,7 +76,7 @@ class ConnectionWrapperTest extends TestCase
     /**
      * Prepare test objects.
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->connectionFactory = $this->createMock(ConnectionFactory::class);
         $this->configInterface = $this->createMock(ConfigInterface::class);
@@ -118,7 +118,7 @@ class ConnectionWrapperTest extends TestCase
     /**
      * Search file initialize
      */
-    public function testSearchFilesInitialize()
+    public function testSearchFilesInitialize(): void
     {
         $this->imsConfig->expects($this->once())->method('getApiKey')->willReturn('key');
         $searchFileRequest = new SearchFilesRequest();
@@ -136,7 +136,7 @@ class ConnectionWrapperTest extends TestCase
     /**
      * Search file initialize with exception.
      */
-    public function testSearchFilesInitializeException()
+    public function testSearchFilesInitializeException(): void
     {
         $this->expectExceptionMessage('Failed to initialize Adobe Stock search files request: New error');
         $this->imsConfig->expects($this->once())->method('getApiKey')->willReturn('key');
@@ -152,7 +152,7 @@ class ConnectionWrapperTest extends TestCase
     /**
      * Nest response test
      */
-    public function testGetNextResponse()
+    public function testGetNextResponse(): void
     {
         $this->imsConfig->expects($this->once())->method('getApiKey')->willReturn('key');
         $this->adobeStockMock->expects($this->once())->method('getNextResponse')->willReturn(new SearchFiles());
@@ -162,7 +162,7 @@ class ConnectionWrapperTest extends TestCase
     /**
      * Next response with exception
      */
-    public function testGetNextResponseWithException()
+    public function testGetNextResponseWithException(): void
     {
         $this->expectExceptionMessage('Failed to retrieve Adobe Stock search files results: New error');
         $this->imsConfig->expects($this->once())->method('getApiKey')->willReturn('key');
@@ -175,7 +175,7 @@ class ConnectionWrapperTest extends TestCase
     /**
      * Get member profile test
      */
-    public function testGetMemberProfile()
+    public function testGetMemberProfile(): void
     {
         $this->setTokens();
         $this->adobeStockMock->expects($this->once())
@@ -187,7 +187,7 @@ class ConnectionWrapperTest extends TestCase
     /**
      * Get member profile with exception
      */
-    public function testGetMemberProfileWithException()
+    public function testGetMemberProfileWithException(): void
     {
         $this->expectExceptionMessage('Failed to retrieve Adobe Stock member profile');
         $this->setTokens();
@@ -203,7 +203,7 @@ class ConnectionWrapperTest extends TestCase
     /**
      * Test get Content license
      */
-    public function testGetContentLicense()
+    public function testGetContentLicense(): void
     {
         $this->setTokens();
         $this->adobeStockMock->expects($this->once())
@@ -218,7 +218,7 @@ class ConnectionWrapperTest extends TestCase
     /**
      * Test get Content license with exception
      */
-    public function testGetContentLicenseWithException()
+    public function testGetContentLicenseWithException(): void
     {
         $this->expectExceptionMessage('Failed to retrieve Adobe Stock content license');
         $this->setTokens();
@@ -231,7 +231,7 @@ class ConnectionWrapperTest extends TestCase
     /**
      * Download asset url test
      */
-    public function testDownloadAssetUrl()
+    public function testDownloadAssetUrl(): void
     {
         $this->setTokens();
         $this->adobeStockMock->expects($this->once())
@@ -243,7 +243,7 @@ class ConnectionWrapperTest extends TestCase
     /**
      * Download asset url with exception
      */
-    public function testDownloadAssetUrlWithExeption()
+    public function testDownloadAssetUrlWithExeption(): void
     {
         $this->expectExceptionMessage('Failed to retrieve Adobe Stock asset download URL');
         $this->setTokens();
@@ -256,7 +256,7 @@ class ConnectionWrapperTest extends TestCase
     /**
      * If invalid token ensure that tokens flushed
      */
-    public function testFlushTokens()
+    public function testFlushTokens(): void
     {
         $this->expectExceptionMessage('Adobe API login has expired!');
         $this->setTokens();
@@ -270,7 +270,7 @@ class ConnectionWrapperTest extends TestCase
     /**
      * Ste's tokens
      */
-    private function setTokens()
+    private function setTokens(): void
     {
         $this->imsConfig->expects($this->once())->method('getApiKey')->willReturn('key');
         $this->getAccessToken->expects($this->once())->method('execute')->willReturn('token');

--- a/AdobeStockClient/Test/Unit/Model/SearchParametersProvider/ContentTypeTest.php
+++ b/AdobeStockClient/Test/Unit/Model/SearchParametersProvider/ContentTypeTest.php
@@ -34,7 +34,7 @@ class ContentTypeTest extends TestCase
     /**
      * Prepare test objects.
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->objectManager = new ObjectManager($this);
         $this->contentType = $this->objectManager->getObject(ContentType::class);

--- a/AdobeStockClient/Test/Unit/Model/SearchParametersProvider/IsolatedTest.php
+++ b/AdobeStockClient/Test/Unit/Model/SearchParametersProvider/IsolatedTest.php
@@ -34,7 +34,7 @@ class IsolatedTest extends TestCase
     /**
      * Prepare test objects.
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->objectManager = new ObjectManager($this);
         $this->isolated = $this->objectManager->getObject(Isolated::class);

--- a/AdobeStockClient/Test/Unit/Model/SearchParametersProvider/MediaIdTest.php
+++ b/AdobeStockClient/Test/Unit/Model/SearchParametersProvider/MediaIdTest.php
@@ -34,7 +34,7 @@ class MediaIdTest extends TestCase
     /**
      * Prepare test objects.
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->objectManager = new ObjectManager($this);
         $this->mediaId = $this->objectManager->getObject(MediaId::class);

--- a/AdobeStockClient/Test/Unit/Model/SearchParametersProvider/OffensiveTest.php
+++ b/AdobeStockClient/Test/Unit/Model/SearchParametersProvider/OffensiveTest.php
@@ -34,7 +34,7 @@ class OffensiveTest extends TestCase
     /**
      * Prepare test objects.
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->objectManager = new ObjectManager($this);
         $this->offensive = $this->objectManager->getObject(Offensive::class);

--- a/AdobeStockClient/Test/Unit/Model/SearchParametersProvider/OrientationTest.php
+++ b/AdobeStockClient/Test/Unit/Model/SearchParametersProvider/OrientationTest.php
@@ -34,7 +34,7 @@ class OrientationTest extends TestCase
     /**
      * Prepare test objects.
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->objectManager = new ObjectManager($this);
         $this->orientation = $this->objectManager->getObject(Orientation::class);

--- a/AdobeStockClient/Test/Unit/Model/SearchParametersProvider/PaginationTest.php
+++ b/AdobeStockClient/Test/Unit/Model/SearchParametersProvider/PaginationTest.php
@@ -32,7 +32,7 @@ class PaginationTest extends TestCase
     /**
      * Prepare test objects.
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->objectManager = new ObjectManager($this);
         $this->pagination = $this->objectManager->getObject(Pagination::class);

--- a/AdobeStockClient/Test/Unit/Model/SearchParametersProvider/PremiumTest.php
+++ b/AdobeStockClient/Test/Unit/Model/SearchParametersProvider/PremiumTest.php
@@ -56,7 +56,7 @@ class PremiumTest extends TestCase
     /**
      * Prepare test objects.
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->objectManager = new ObjectManager($this);
         $this->searchCriteriaMock = $this->createMock(SearchCriteriaInterface::class);

--- a/AdobeStockClient/Test/Unit/Model/SearchParametersProvider/SimilarTest.php
+++ b/AdobeStockClient/Test/Unit/Model/SearchParametersProvider/SimilarTest.php
@@ -34,7 +34,7 @@ class SimilarTest extends TestCase
     /**
      * Prepare test objects.
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->objectManager = new ObjectManager($this);
         $this->similar = $this->objectManager->getObject(Similar::class);

--- a/AdobeStockClient/Test/Unit/Model/SearchParametersProvider/SimpleFiltersTest.php
+++ b/AdobeStockClient/Test/Unit/Model/SearchParametersProvider/SimpleFiltersTest.php
@@ -49,7 +49,7 @@ class SimpleFiltersTest extends TestCase
     /**
      * Prepare test objects.
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->objectManager = new ObjectManager($this);
         $this->escaperMock = $this->createMock(Escaper::class);

--- a/AdobeStockClient/Test/Unit/Model/SearchParametersProvider/SortingTest.php
+++ b/AdobeStockClient/Test/Unit/Model/SearchParametersProvider/SortingTest.php
@@ -33,7 +33,7 @@ class SortingTest extends TestCase
     /**
      * Prepare test objects.
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->objectManager = new ObjectManager($this);
         $this->sorting = $this->objectManager->getObject(Sorting::class);

--- a/AdobeStockClient/Test/Unit/Model/SearchParametersProvider/WordsTest.php
+++ b/AdobeStockClient/Test/Unit/Model/SearchParametersProvider/WordsTest.php
@@ -42,7 +42,7 @@ class WordsTest extends TestCase
     /**
      * Prepare test objects.
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->objectManager = new ObjectManager($this);
         $this->escaperMock = $this->createMock(Escaper::class);
@@ -62,7 +62,7 @@ class WordsTest extends TestCase
      * @throws StockApi
      * @dataProvider requestValuesDataProvider
      */
-    public function testApplyWithRequestValue(string $requestValue, string $encodedValue)
+    public function testApplyWithRequestValue(string $requestValue, string $encodedValue): void
     {
         /** @var SearchCriteriaInterface|MockObject $searchCriteriaMock */
         $searchCriteriaMock = $this->createMock(SearchCriteriaInterface::class);
@@ -98,7 +98,7 @@ class WordsTest extends TestCase
      *
      * @throws StockApi
      */
-    public function testApplyWithoutWordsField()
+    public function testApplyWithoutWordsField(): void
     {
         /** @var SearchCriteriaInterface|MockObject $searchCriteriaMock */
         $searchCriteriaMock = $this->createMock(SearchCriteriaInterface::class);
@@ -131,7 +131,7 @@ class WordsTest extends TestCase
      *
      * @throws StockApi
      */
-    public function testApplyWithEmptyWords()
+    public function testApplyWithEmptyWords(): void
     {
         /** @var SearchCriteriaInterface|MockObject $searchCriteriaMock */
         $searchCriteriaMock = $this->createMock(SearchCriteriaInterface::class);
@@ -165,7 +165,7 @@ class WordsTest extends TestCase
      *
      * @throws StockApi
      */
-    public function testApplyWithOnlyQuotes()
+    public function testApplyWithOnlyQuotes(): void
     {
         /** @var SearchCriteriaInterface|MockObject $searchCriteriaMock */
         $searchCriteriaMock = $this->createMock(SearchCriteriaInterface::class);

--- a/AdobeStockClient/Test/Unit/Model/SearchParametersProviderCompositeTest.php
+++ b/AdobeStockClient/Test/Unit/Model/SearchParametersProviderCompositeTest.php
@@ -38,7 +38,7 @@ class SearchParametersProviderCompositeTest extends TestCase
     /**
      * Prepare test objects.
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->objectManager = new ObjectManager($this);
         $this->searchParametersProviderMock =  $this->createMock(SearchParameterProviderInterface::class);

--- a/AdobeStockClient/Test/Unit/Model/StockFileToDocumentTest.php
+++ b/AdobeStockClient/Test/Unit/Model/StockFileToDocumentTest.php
@@ -43,7 +43,7 @@ class StockFileToDocumentTest extends TestCase
     /**
      * @inheritdoc
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->objectManager = new ObjectManager($this);
 
@@ -67,7 +67,7 @@ class StockFileToDocumentTest extends TestCase
      *
      * @dataProvider convertDataProvider
      */
-    public function testConvert(StockFile $stockFile, array $attributesData)
+    public function testConvert(StockFile $stockFile, array $attributesData): void
     {
         $item = $this->createMock(Document::class);
 
@@ -106,7 +106,7 @@ class StockFileToDocumentTest extends TestCase
     /**
      * @return array
      */
-    public function convertDataProvider()
+    public function convertDataProvider(): array
     {
         /** @var StockFile $stockFile */
         $stockFile = new StockFile([]);


### PR DESCRIPTION
### Description (*)
- Enhancements for AdobeStockAssetApi and AdobeStockClient tests.

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios (*)
The Travis CI build will be passed.

# Changed log
- Using the `protected` and native returning `void` type hint for PHPUnit fixture `setUp` method.
- Removing unused private const value on specific test class.
- To be consistency, using the `::class` to make specific class instance call.
And declaring required class namespace with `use` syntax on every head of PHP file.