### PR TITLE
Added regex to sanitize filenames

### DIFF
--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/actions.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/actions.js
@@ -86,8 +86,7 @@ define([
                         class: 'action-secondary action-dismiss',
 
                         /**
-                         * Cancel button click handler
-                         *
+                         * Close modal on button click
                          */
                         click: function () {
                             this.closeModal();
@@ -167,13 +166,17 @@ define([
         },
 
         /**
-         * Generate meaningful name image file
+         * Generate meaningful name image file,
+         * allow only alphanumerics, dashes, and underscores
          *
          * @param {Object} record
          * @return string
          */
         generateImageName: function (record) {
-            return record.title.substring(0, 32).replace(/\s+/g, '-').toLowerCase();
+            return record.title.substring(0, 32)
+                .replace(/[^a-zA-Z0-9_]/g, '-')
+                .replace(/-{2,}/g, '-')
+                .toLowerCase();
         },
 
         /**


### PR DESCRIPTION
### Description 

This PR adds regex to sanitize filenames. 
-  Only allows alphabets, numbers, dashes, and underscores.
-  Also, replaces multiple dashes with a single dash caused by the following example scenario: `India, Asia` would become `India--Asia` due to the comma **and** whitespace being replaced. 

### Fixed Issues
-  magento/adobe-stock-integration#618: Exclude special characters when generating a default name for the image file

### Manual testing scenarios (same as issue)
1. Login to admin panel
2. Open Magento Media Gallery (i.e. go to Cms -> Pages, edit the page and insert image)
3. Find an image with special characters in the name (i.e. 296633404 that has commas in the name)
4. Click on the image to expand the preview
5. Click on "Save Preview" button to open the popup with a field containing default image file name