### PR TITLE
Resolved issue #581

### DIFF
--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/media-gallery.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/media-gallery.js
@@ -67,8 +67,8 @@ define([
                     locatedImage.click();
                 } else {
                     confirm({
-                        title: $.mage.__('Image location error'),
-                        content: $.mage.__('The image cannot be located!'),
+                        title: $.mage.__('The image cannot be located'),
+                        content: $.mage.__('We cannot find this image in the media gallery.'),
                         buttons: [{
                             text: $.mage.__('Okay'),
                             class: 'action-primary',

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/media-gallery.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/media-gallery.js
@@ -3,8 +3,9 @@
  * See COPYING.txt for license details.
  */
 define([
-    'jquery'
-], function ($) {
+    'jquery',
+    'Magento_Ui/js/modal/confirm'
+], function ($, confirm) {
     'use strict';
 
     return {
@@ -64,8 +65,26 @@ define([
 
                 if (locatedImage.length) {
                     locatedImage.click();
+                } else {
+                    confirm({
+                        title: $.mage.__('Image location error'),
+                        content: $.mage.__('The image cannot be located!'),
+                        buttons: [{
+                            text: $.mage.__('Okay'),
+                            class: 'action-primary',
+                            attr: {},
+
+                            /**
+                             * Close modal on button click
+                             */
+                            click: function (event) {
+                                this.closeModal(event);
+                            }
+                        }]
+                    });
                 }
             }
+
             $.ajaxSetup({
                 async: true
             });


### PR DESCRIPTION
### Description

This PR fixes the issue mentioned below by showing a popup to the user when the saved preview image cannot be located

### Fixed Issues
-  magento/adobe-stock-integration#581: Show warning if locate action was not able to find an image in the media gallery

### Manual testing scenarios (same as issue)
1. Login to admin panel
2. Open Magento Media Gallery (i.e. go to Cms -> Pages, edit the page and insert image)
3. Click "Search Adobe Stock" button to open images grid
4. Click on any image to expand preview section
5. Save Preview version of the image
6. Delete the saved image in the filesystem (but not in the database)
6. Reopen the grid
7. Click the "Locate" button

![image](https://user-images.githubusercontent.com/22623301/68051423-5ee55200-fd0d-11e9-8671-731acd8efd20.png)
