### PR TITLE
Code adjustments after architecture review

### DIFF
--- a/AdobeIms/Controller/Adminhtml/OAuth/Callback.php
+++ b/AdobeIms/Controller/Adminhtml/OAuth/Callback.php
@@ -30,7 +30,7 @@ class Callback extends Action
     /**
      * @see _isAllowed()
      */
-    const ADMIN_RESOURCE = 'Magento_AdobeIms::login';
+    public const ADMIN_RESOURCE = 'Magento_AdobeIms::login';
 
     /**
      * Constants of response

--- a/AdobeIms/Controller/Adminhtml/User/Logout.php
+++ b/AdobeIms/Controller/Adminhtml/User/Logout.php
@@ -10,6 +10,7 @@ namespace Magento\AdobeIms\Controller\Adminhtml\User;
 use Magento\AdobeImsApi\Api\LogOutInterface;
 use Magento\Backend\App\Action;
 use Magento\Backend\App\Action\Context;
+use Magento\Framework\Controller\Result\Json;
 use Magento\Framework\Controller\ResultFactory;
 use Magento\Framework\HTTP\Client\CurlFactory;
 
@@ -24,7 +25,7 @@ class Logout extends Action
     /**
      * @see _isAllowed()
      */
-    const ADMIN_RESOURCE = 'Magento_AdobeIms::logout';
+    public const ADMIN_RESOURCE = 'Magento_AdobeIms::logout';
 
     /**
      * @var CurlFactory
@@ -60,7 +61,7 @@ class Logout extends Action
                 'success' => false,
             ];
         }
-        /** @var \Magento\Framework\Controller\Result\Json $resultJson */
+        /** @var Json $resultJson */
         $resultJson = $this->resultFactory->create(ResultFactory::TYPE_JSON);
         $resultJson->setHttpResponseCode($responseCode);
         $resultJson->setData($response);

--- a/AdobeIms/Controller/Adminhtml/User/Profile.php
+++ b/AdobeIms/Controller/Adminhtml/User/Profile.php
@@ -32,7 +32,7 @@ class Profile extends Action
     /**
      * @see _isAllowed()
      */
-    const ADMIN_RESOURCE = 'Magento_AdobeIms::profile';
+    public const ADMIN_RESOURCE = 'Magento_AdobeIms::profile';
 
     /**
      * @var UserContextInterface

--- a/AdobeIms/Model/ResourceModel/UserProfile.php
+++ b/AdobeIms/Model/ResourceModel/UserProfile.php
@@ -18,7 +18,7 @@ class UserProfile extends AbstractDb
     /**
      * @inheritdoc
      */
-    protected function _construct()
+    protected function _construct(): void
     {
         $this->_init('adobe_user_profile', 'id');
     }

--- a/AdobeIms/Model/ResourceModel/UserProfile/Collection.php
+++ b/AdobeIms/Model/ResourceModel/UserProfile/Collection.php
@@ -20,7 +20,7 @@ class Collection extends AbstractCollection
     /**
      * @inheritdoc
      */
-    protected function _construct()
+    protected function _construct(): void
     {
         $this->_init(UserProfileModel::class, UserProfileResource::class);
     }

--- a/AdobeIms/Model/UserProfile.php
+++ b/AdobeIms/Model/UserProfile.php
@@ -36,7 +36,7 @@ class UserProfile extends AbstractExtensibleModel implements UserProfileInterfac
     /**
      * @inheritdoc
      */
-    protected function _construct()
+    protected function _construct(): void
     {
         $this->_init(UserProfileResource::class);
     }

--- a/AdobeIms/Model/UserProfileRepository.php
+++ b/AdobeIms/Model/UserProfileRepository.php
@@ -21,7 +21,6 @@ use Magento\Framework\Exception\NoSuchEntityException;
 class UserProfileRepository implements UserProfileRepositoryInterface
 {
     private const ID = 'id';
-    private const ADMIN_USER_ID = 'id';
 
     /**
      * @var ResourceModel\UserProfile
@@ -89,7 +88,7 @@ class UserProfileRepository implements UserProfileRepositoryInterface
     public function getByUserId(int $userId): UserProfileInterface
     {
         $entity = $this->entityFactory->create();
-        $this->resource->load($entity, $userId, self::ADMIN_USER_ID);
+        $this->resource->load($entity, $userId, self::ID);
         if (!$entity->getId()) {
             throw new NoSuchEntityException(__('The user profile wasn\'t found.'));
         }

--- a/AdobeIms/Test/Unit/Controller/Adminhtml/OAuth/CallbackTest.php
+++ b/AdobeIms/Test/Unit/Controller/Adminhtml/OAuth/CallbackTest.php
@@ -65,7 +65,7 @@ class CallbackTest extends TestCase
     private $callback;
 
     /**
-     * @var \PHPUnit\Framework\MockObject\MockObject $request
+     * @var MockObject $request
      */
     private $request;
 
@@ -98,7 +98,7 @@ class CallbackTest extends TestCase
         $this->authMock = $this->createMock(Auth::class);
         $this->resultFactory = $this->createMock(ResultFactory::class);
         $this->context = $this->objectManager->getObject(
-            \Magento\Backend\App\Action\Context::class,
+            Context::class,
             [
                 'auth' => $this->authMock,
                 'resultFactory' => $this->resultFactory

--- a/AdobeIms/Test/Unit/Controller/Adminhtml/User/LogoutTest.php
+++ b/AdobeIms/Test/Unit/Controller/Adminhtml/User/LogoutTest.php
@@ -11,7 +11,9 @@ namespace Magento\AdobeIms\Test\Unit\Controller\Adminhtml\User;
 use Magento\AdobeIms\Controller\Adminhtml\User\Logout;
 use Magento\AdobeImsApi\Api\LogOutInterface;
 use Magento\Backend\App\Action\Context as ActionContext;
+use Magento\Framework\App\RequestInterface;
 use Magento\Framework\Controller\Result\Json;
+use Magento\Framework\Controller\ResultFactory;
 use Magento\Framework\Exception\NotFoundException;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -57,9 +59,9 @@ class LogoutTest extends TestCase
     protected function setUp(): void
     {
         $this->logoutInterfaceMock = $this->createMock(LogOutInterface::class);
-        $this->context = $this->createMock(\Magento\Backend\App\Action\Context::class);
-        $this->request = $this->createMock(\Magento\Framework\App\RequestInterface::class);
-        $this->resultFactory = $this->createMock(\Magento\Framework\Controller\ResultFactory::class);
+        $this->context = $this->createMock(ActionContext::class);
+        $this->request = $this->createMock(RequestInterface::class);
+        $this->resultFactory = $this->createMock(ResultFactory::class);
         $this->context->expects($this->once())
             ->method('getResultFactory')
             ->willReturn($this->resultFactory);
@@ -76,7 +78,7 @@ class LogoutTest extends TestCase
     /**
      * Verify that user can be logout
      */
-    public function testExecute()
+    public function testExecute(): void
     {
         $this->logoutInterfaceMock->expects($this->once())
             ->method('execute')
@@ -92,7 +94,7 @@ class LogoutTest extends TestCase
      * Verify that return will be false if there is an error in logout.
      * @throws NotFoundException
      */
-    public function testExecuteWithError()
+    public function testExecuteWithError(): void
     {
         $result = [
             'success' => false,

--- a/AdobeIms/Test/Unit/Controller/Adminhtml/User/ProfileTest.php
+++ b/AdobeIms/Test/Unit/Controller/Adminhtml/User/ProfileTest.php
@@ -8,11 +8,14 @@ declare(strict_types=1);
 
 namespace Magento\AdobeIms\Test\Unit\Controller\Adminhtml\User;
 
+use Magento\AdobeImsApi\Api\Data\UserProfileInterface;
 use Magento\AdobeImsApi\Api\UserProfileRepositoryInterface;
 use Magento\Authorization\Model\UserContextInterface;
 use Magento\Backend\App\Action;
+use Magento\Backend\App\Action\Context;
 use Magento\Framework\Controller\ResultFactory;
 use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Framework\Exception\NotFoundException;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 use Magento\AdobeIms\Controller\Adminhtml\User\Profile;
@@ -35,7 +38,7 @@ class ProfileTest extends TestCase
     private $userContext;
 
     /**
-     * @var MockObject|Action\Context $action
+     * @var MockObject|Context $action
      */
     private $action;
 
@@ -64,13 +67,13 @@ class ProfileTest extends TestCase
      */
     protected function setUp(): void
     {
-        $this->action = $this->createMock(\Magento\Backend\App\Action\Context::class);
+        $this->action = $this->createMock(Context::class);
 
-        $this->userContext = $this->createMock(\Magento\Authorization\Model\UserContextInterface::class);
+        $this->userContext = $this->createMock(UserContextInterface::class);
         $this->userProfileRepository = $this->createMock(UserProfileRepositoryInterface::class);
         $this->logger = $this->createMock(LoggerInterface::class);
         $this->jsonObject = $this->createMock(Json::class);
-        $this->resultFactory = $this->createMock(\Magento\Framework\Controller\ResultFactory::class);
+        $this->resultFactory = $this->createMock(ResultFactory::class);
         $this->action->expects($this->once())
             ->method('getResultFactory')
             ->willReturn($this->resultFactory);
@@ -89,12 +92,12 @@ class ProfileTest extends TestCase
      *
      * @dataProvider userDataProvider
      * @param array $result
-     * @throws \Magento\Framework\Exception\NotFoundException
+     * @throws NotFoundException
      */
     public function testExecute(array $result): void
     {
         $this->userContext->expects($this->once())->method('getUserId')->willReturn(1);
-        $userProfileMock = $this->createMock(\Magento\AdobeImsApi\Api\Data\UserProfileInterface::class);
+        $userProfileMock = $this->createMock(UserProfileInterface::class);
         $userProfileMock->expects($this->once())->method('getEmail')->willReturn('exaple@adobe.com');
         $userProfileMock->expects($this->once())->method('getName')->willReturn('Smith');
         $userProfileMock->expects($this->once())->method('getImage')->willReturn('https://adobe.com/sample-image.png');
@@ -112,7 +115,7 @@ class ProfileTest extends TestCase
     /**
      * Execute with exception
      */
-    public function testExecuteWithExecption()
+    public function testExecuteWithExecption(): void
     {
         $this->userContext->expects($this->once())->method('getUserId')->willReturn(null);
         $this->userProfileRepository->expects($this->exactly(1))
@@ -131,8 +134,10 @@ class ProfileTest extends TestCase
 
     /**
      * User data provider
+     *
+     * @return array
      */
-    public function userDataProvider()
+    public function userDataProvider(): array
     {
         return
             [

--- a/AdobeIms/Test/Unit/Model/FlushUserTokensTest.php
+++ b/AdobeIms/Test/Unit/Model/FlushUserTokensTest.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 namespace Magento\AdobeIms\Test\Unit\Model;
 
 use Magento\AdobeIms\Model\FlushUserTokens;
+use Magento\AdobeImsApi\Api\Data\UserProfileInterface;
 use Magento\AdobeImsApi\Api\UserProfileRepositoryInterface;
 use Magento\Authorization\Model\UserContextInterface;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -54,7 +55,7 @@ class FlushUserTokensTest extends TestCase
     public function testExecute(): void
     {
         $this->userContext->expects($this->once())->method('getUserId')->willReturn(1);
-        $userProfileMock = $this->createMock(\Magento\AdobeImsApi\Api\Data\UserProfileInterface::class);
+        $userProfileMock = $this->createMock(UserProfileInterface::class);
         $this->userProfileRepository->expects($this->exactly(1))
             ->method('getByUserId')
             ->willReturn($userProfileMock);

--- a/AdobeIms/Test/Unit/Model/GetAccessTokenTest.php
+++ b/AdobeIms/Test/Unit/Model/GetAccessTokenTest.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 namespace Magento\AdobeIms\Test\Unit\Model;
 
 use Magento\AdobeIms\Model\GetAccessToken;
+use Magento\AdobeImsApi\Api\Data\UserProfileInterface;
 use Magento\AdobeImsApi\Api\UserProfileRepositoryInterface;
 use Magento\Authorization\Model\UserContextInterface;
 use Magento\Framework\Exception\NoSuchEntityException;
@@ -58,7 +59,7 @@ class GetAccessTokenTest extends TestCase
     public function testExecute(?string $token): void
     {
         $this->userContext->expects($this->once())->method('getUserId')->willReturn(1);
-        $userProfileMock = $this->createMock(\Magento\AdobeImsApi\Api\Data\UserProfileInterface::class);
+        $userProfileMock = $this->createMock(UserProfileInterface::class);
         $this->userProfile->expects($this->exactly(1))
             ->method('getByUserId')
             ->willReturn($userProfileMock);
@@ -70,7 +71,7 @@ class GetAccessTokenTest extends TestCase
     /**
      * Test execute with exception
      */
-    public function testExecuteWIthException()
+    public function testExecuteWIthException(): void
     {
         $this->userContext->expects($this->once())->method('getUserId')->willReturn(1);
         $this->userProfile->expects($this->exactly(1))
@@ -82,8 +83,10 @@ class GetAccessTokenTest extends TestCase
 
     /**
      * Data provider for get acces token method.
+     *
+     * @return array
      */
-    public function expectedDataProvider()
+    public function expectedDataProvider(): array
     {
         return
             [

--- a/AdobeIms/Test/Unit/Model/GetImageTest.php
+++ b/AdobeIms/Test/Unit/Model/GetImageTest.php
@@ -110,7 +110,7 @@ class GetImageTest extends TestCase
     /**
      * Get Image with exception
      */
-    public function testGetImageWithException()
+    public function testGetImageWithException(): void
     {
         $this->curlFactoryMock->expects($this->once())
             ->method('create')
@@ -128,7 +128,7 @@ class GetImageTest extends TestCase
      *
      * @return array
      */
-    public function imagesDataProvider()
+    public function imagesDataProvider(): array
     {
         return [
             [

--- a/AdobeIms/Test/Unit/Model/GetTokenTest.php
+++ b/AdobeIms/Test/Unit/Model/GetTokenTest.php
@@ -8,8 +8,10 @@ declare(strict_types=1);
 namespace Magento\AdobeIms\Test\Unit\Model;
 
 use Magento\AdobeIms\Model\GetToken;
+use Magento\AdobeIms\Model\OAuth\TokenResponse;
 use Magento\AdobeImsApi\Api\ConfigInterface;
 use Magento\AdobeImsApi\Api\Data\TokenResponseInterfaceFactory;
+use Magento\Framework\HTTP\Client\Curl;
 use Magento\Framework\HTTP\Client\CurlFactory;
 use Magento\Framework\Serialize\Serializer\Json;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
@@ -74,7 +76,7 @@ class GetTokenTest extends TestCase
      */
     public function testExecute(): void
     {
-        $curl = $this->createMock(\Magento\Framework\HTTP\Client\Curl::class);
+        $curl = $this->createMock(Curl::class);
         $this->curlFactoryMock->expects($this->once())
             ->method('create')
             ->willReturn($curl);
@@ -96,7 +98,7 @@ class GetTokenTest extends TestCase
         $this->jsonMock->expects($this->once())
             ->method('unserialize')
             ->willReturn(['string']);
-        $tokenResponse = $this->createMock(\Magento\AdobeIms\Model\OAuth\TokenResponse::class);
+        $tokenResponse = $this->createMock(TokenResponse::class);
         $this->tokenResponseFactoryMock->expects($this->once())
             ->method('create')
             ->willReturn($tokenResponse);

--- a/AdobeIms/Test/Unit/Model/LogOutTest.php
+++ b/AdobeIms/Test/Unit/Model/LogOutTest.php
@@ -8,11 +8,13 @@ declare(strict_types=1);
 
 namespace Magento\AdobeIms\Test\Unit\Model;
 
+use Exception;
 use Magento\AdobeIms\Model\LogOut;
 use Magento\AdobeImsApi\Api\ConfigInterface;
 use Magento\AdobeImsApi\Api\Data\UserProfileInterface;
 use Magento\AdobeImsApi\Api\UserProfileRepositoryInterface;
 use Magento\Authorization\Model\UserContextInterface;
+use Magento\Framework\HTTP\Client\Curl;
 use Magento\Framework\HTTP\Client\CurlFactory;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -101,7 +103,7 @@ class LogOutTest extends TestCase
         $this->userProfileRepositoryInterfaceMock->expects($this->exactly(1))
             ->method('getByUserId')
             ->willReturn($this->userProfileInterfaceMock);
-        $curl = $this->createMock(\Magento\Framework\HTTP\Client\Curl::class);
+        $curl = $this->createMock(Curl::class);
         $this->curlFactoryMock->expects($this->once())
             ->method('create')
             ->willReturn($curl);
@@ -137,7 +139,7 @@ class LogOutTest extends TestCase
         $this->userProfileRepositoryInterfaceMock->expects($this->exactly(1))
             ->method('getByUserId')
             ->willReturn($this->userProfileInterfaceMock);
-        $curl = $this->createMock(\Magento\Framework\HTTP\Client\Curl::class);
+        $curl = $this->createMock(Curl::class);
         $this->curlFactoryMock->expects($this->once())
             ->method('create')
             ->willReturn($curl);
@@ -168,7 +170,7 @@ class LogOutTest extends TestCase
         $this->userProfileRepositoryInterfaceMock->expects($this->exactly(1))
             ->method('getByUserId')
             ->willReturn($this->userProfileInterfaceMock);
-        $curl = $this->createMock(\Magento\Framework\HTTP\Client\Curl::class);
+        $curl = $this->createMock(Curl::class);
         $this->curlFactoryMock->expects($this->once())
             ->method('create')
             ->willReturn($curl);
@@ -188,7 +190,7 @@ class LogOutTest extends TestCase
         $this->userProfileRepositoryInterfaceMock->expects($this->once())
             ->method('save')
             ->willThrowException(
-                new \Exception('Could not save user profile.')
+                new Exception('Could not save user profile.')
             );
         $this->loggerInterfaceMock->expects($this->once())
             ->method('critical');

--- a/AdobeIms/Test/Unit/Model/UserAuthorizedTest.php
+++ b/AdobeIms/Test/Unit/Model/UserAuthorizedTest.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 namespace Magento\AdobeIms\Test\Unit\Model;
 
 use Magento\AdobeIms\Model\UserAuthorized;
+use Magento\AdobeImsApi\Api\Data\UserProfileInterface;
 use Magento\AdobeImsApi\Api\UserProfileRepositoryInterface;
 use Magento\Authorization\Model\UserContextInterface;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -52,7 +53,7 @@ class UserAuthorizedTest extends TestCase
     public function testExecute(): void
     {
         $this->userContext->expects($this->once())->method('getUserId')->willReturn(1);
-        $userProfileMock = $this->createMock(\Magento\AdobeImsApi\Api\Data\UserProfileInterface::class);
+        $userProfileMock = $this->createMock(UserProfileInterface::class);
         $this->userProfile->expects($this->exactly(1))
             ->method('getByUserId')
             ->willReturn($userProfileMock);

--- a/AdobeIms/Test/Unit/Model/UserProfileRepositoryTest.php
+++ b/AdobeIms/Test/Unit/Model/UserProfileRepositoryTest.php
@@ -11,6 +11,8 @@ use Magento\AdobeIms\Model\ResourceModel\UserProfile as ResourceUserProfile;
 use Magento\AdobeIms\Model\UserProfile;
 use Magento\AdobeIms\Model\UserProfileRepository;
 use Magento\AdobeImsApi\Api\Data\UserProfileInterfaceFactory;
+use Magento\Framework\Exception\CouldNotSaveException;
+use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -68,7 +70,7 @@ class UserProfileRepositoryTest extends TestCase
      */
     public function testSaveWithException(): void
     {
-        $this->expectException(\Magento\Framework\Exception\CouldNotSaveException::class);
+        $this->expectException(CouldNotSaveException::class);
         $this->expectExceptionMessage('Could not save user profile.');
 
         $userProfile = $this->createMock(UserProfile::class);
@@ -76,7 +78,7 @@ class UserProfileRepositoryTest extends TestCase
             ->method('save')
             ->with($userProfile)
             ->willThrowException(
-                new \Magento\Framework\Exception\CouldNotSaveException(__('Could not save user profile.'))
+                new CouldNotSaveException(__('Could not save user profile.'))
             );
         $this->model->save($userProfile);
     }
@@ -84,7 +86,7 @@ class UserProfileRepositoryTest extends TestCase
     /**
      * Test get  id.
      */
-    public function testGet()
+    public function testGet(): void
     {
         $entity = $this->objectManager->getObject(UserProfile::class)->setId(1);
         $this->entityFactory->method('create')
@@ -95,9 +97,9 @@ class UserProfileRepositoryTest extends TestCase
     /**
      * Test get user id with exception.
      */
-    public function testGeWithException()
+    public function testGeWithException(): void
     {
-        $this->expectException(\Magento\Framework\Exception\NoSuchEntityException::class);
+        $this->expectException(NoSuchEntityException::class);
         $this->expectExceptionMessage('The user profile wasn\'t found.');
 
         $entity = $this->objectManager->getObject(UserProfile::class);
@@ -106,7 +108,7 @@ class UserProfileRepositoryTest extends TestCase
         $this->resource->expects($this->once())
             ->method('load')
             ->willThrowException(
-                new \Magento\Framework\Exception\NoSuchEntityException(__('The user profile wasn\'t found.'))
+                new NoSuchEntityException(__('The user profile wasn\'t found.'))
             );
         $this->model->get(1);
     }
@@ -114,7 +116,7 @@ class UserProfileRepositoryTest extends TestCase
     /**
      * Test get by user id.
      */
-    public function testGetByUserId()
+    public function testGetByUserId(): void
     {
         $entity = $this->objectManager->getObject(UserProfile::class)->setId(1);
         $this->entityFactory->method('create')

--- a/AdobeImsApi/Api/Data/UserProfileInterface.php
+++ b/AdobeImsApi/Api/Data/UserProfileInterface.php
@@ -24,14 +24,6 @@ interface UserProfileInterface extends ExtensibleDataInterface
     public function getId();
 
     /**
-     * Set ID
-     *
-     * @param int $value
-     * @return void
-     */
-    public function setId($value);
-
-    /**
      * Get user ID
      *
      * @return int

--- a/AdobeMediaGallery/Model/Asset/Command/DeleteByPath.php
+++ b/AdobeMediaGallery/Model/Asset/Command/DeleteByPath.php
@@ -59,7 +59,7 @@ class DeleteByPath implements DeleteByPathInterface
         try {
             /** @var AdapterInterface $connection */
             $connection = $this->resourceConnection->getConnection();
-            $tableName = $connection->getTableName(self::TABLE_MEDIA_GALLERY_ASSET);
+            $tableName = $this->resourceConnection->getTableName(self::TABLE_MEDIA_GALLERY_ASSET);
             $connection->delete($tableName, [self::MEDIA_GALLERY_ASSET_PATH . ' = ?' => $mediaAssetPath]);
         } catch (\Exception $exception) {
             $message = __(

--- a/AdobeMediaGallery/Model/Asset/Command/GetById.php
+++ b/AdobeMediaGallery/Model/Asset/Command/GetById.php
@@ -68,7 +68,7 @@ class GetById implements GetByIdInterface
         try {
             $connection = $this->resourceConnection->getConnection();
             $select = $connection->select()
-                ->from(['amg' => self::TABLE_MEDIA_GALLERY_ASSET])
+                ->from(['amg' => $this->resourceConnection->getTableName(self::TABLE_MEDIA_GALLERY_ASSET)])
                 ->where('amg.id = ?', $mediaAssetId);
             $data = $connection->query($select)->fetch();
 

--- a/AdobeMediaGallery/Model/Asset/Command/GetByPath.php
+++ b/AdobeMediaGallery/Model/Asset/Command/GetByPath.php
@@ -69,7 +69,7 @@ class GetByPath implements GetByPathInterface
         try {
             $connection = $this->resourceConnection->getConnection();
             $select = $connection->select()
-                ->from(self::TABLE_MEDIA_GALLERY_ASSET)
+                ->from($this->resourceConnection->getTableName(self::TABLE_MEDIA_GALLERY_ASSET))
                 ->where(self::MEDIA_GALLERY_ASSET_PATH . ' = ?', $mediaFilePath);
             $data = $connection->query($select)->fetch();
 

--- a/AdobeMediaGallery/Model/Keyword/Command/GetAssetKeywords.php
+++ b/AdobeMediaGallery/Model/Keyword/Command/GetAssetKeywords.php
@@ -59,7 +59,7 @@ class GetAssetKeywords implements GetAssetKeywordsInterface
             $connection = $this->resourceConnection->getConnection();
 
             $select = $connection->select()
-                ->from(['k' => self::TABLE_KEYWORD])
+                ->from(['k' => $this->resourceConnection->getTableName(self::TABLE_KEYWORD)])
                 ->join(['ak' => self::TABLE_ASSET_KEYWORD], 'k.id = ak.keyword_id')
                 ->where('ak.asset_id = ?', $assetId);
             $data = $connection->query($select)->fetchAll();

--- a/AdobeMediaGallery/Model/Keyword/Command/SaveAssetKeywords.php
+++ b/AdobeMediaGallery/Model/Keyword/Command/SaveAssetKeywords.php
@@ -11,6 +11,7 @@ use Magento\AdobeMediaGalleryApi\Api\Data\KeywordInterface;
 use Magento\AdobeMediaGalleryApi\Model\Keyword\Command\SaveAssetKeywordsInterface;
 use Magento\Framework\App\ResourceConnection;
 use Magento\Framework\DB\Adapter\AdapterInterface;
+use Magento\Framework\DB\Adapter\Pdo\Mysql;
 use Magento\Framework\Exception\CouldNotSaveException;
 
 /**
@@ -59,10 +60,10 @@ class SaveAssetKeywords implements SaveAssetKeywordsInterface
             }
 
             if (!empty($data)) {
-                /** @var \Magento\Framework\DB\Adapter\Pdo\Mysql $connection */
+                /** @var Mysql $connection */
                 $connection = $this->resourceConnection->getConnection();
                 $connection->insertArray(
-                    self::TABLE_KEYWORD,
+                    $this->resourceConnection->getTableName(self::TABLE_KEYWORD),
                     [self::KEYWORD],
                     $data,
                     AdapterInterface::INSERT_IGNORE

--- a/AdobeMediaGallery/Model/Keyword/Command/SaveAssetLinks.php
+++ b/AdobeMediaGallery/Model/Keyword/Command/SaveAssetLinks.php
@@ -11,6 +11,7 @@ use Magento\AdobeMediaGalleryApi\Api\Data\KeywordInterface;
 use Magento\AdobeMediaGalleryApi\Model\Keyword\Command\SaveAssetLinksInterface;
 use Magento\Framework\App\ResourceConnection;
 use Magento\Framework\DB\Adapter\AdapterInterface;
+use Magento\Framework\DB\Adapter\Pdo\Mysql;
 use Magento\Framework\Exception\CouldNotSaveException;
 
 /**
@@ -54,10 +55,10 @@ class SaveAssetLinks
                 $values[] = [$assetId, $keywordId];
             }
 
-            /** @var \Magento\Framework\DB\Adapter\Pdo\Mysql $connection */
+            /** @var Mysql $connection */
             $connection = $this->resourceConnection->getConnection();
             $connection->insertArray(
-                self::TABLE_ASSET_KEYWORD,
+                $this->resourceConnection->getTableName(self::TABLE_ASSET_KEYWORD),
                 [self::FIELD_ASSET_ID, self::FIELD_KEYWORD_ID],
                 $values,
                 AdapterInterface::INSERT_IGNORE

--- a/AdobeMediaGallery/Plugin/Product/Gallery/Processor.php
+++ b/AdobeMediaGallery/Plugin/Product/Gallery/Processor.php
@@ -46,14 +46,18 @@ class Processor
      * Remove media asset image after the product gallery image remove
      *
      * @param ProcessorSubject $subject
-     * @param $result
+     * @param ProcessorSubject $result
      * @param Product $product
-     * @param $file
+     * @param string $file
      *
-     * @return mixed
+     * @return ProcessorSubject
      */
-    public function afterRemoveImage(ProcessorSubject $subject, $result, Product $product, $file)
-    {
+    public function afterRemoveImage(
+        ProcessorSubject $subject,
+        ProcessorSubject $result,
+        Product $product,
+        $file
+    ): ProcessorSubject {
         if (!is_string($file)) {
             return $result;
         }

--- a/AdobeMediaGallery/Plugin/Wysiwyg/Images/Storage.php
+++ b/AdobeMediaGallery/Plugin/Wysiwyg/Images/Storage.php
@@ -65,13 +65,13 @@ class Storage
      * Delete media data after the image delete action from Wysiwyg
      *
      * @param StorageSubject $subject
-     * @param $result
-     * @param $target
+     * @param StorageSubject $result
+     * @param string $target
      *
-     * @return mixed
+     * @return StorageSubject
      * @throws ValidatorException
      */
-    public function afterDeleteFile(StorageSubject $subject, $result, $target)
+    public function afterDeleteFile(StorageSubject $subject, StorageSubject $result, $target): StorageSubject
     {
         if (!is_string($target)) {
             return $result;

--- a/AdobeMediaGallery/Test/Unit/Model/Asset/Command/DeleteByPathTest.php
+++ b/AdobeMediaGallery/Test/Unit/Model/Asset/Command/DeleteByPathTest.php
@@ -50,7 +50,7 @@ class DeleteByPathTest extends TestCase
     /**
      * Initialize basic test class mocks
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->logger = $this->createMock(LoggerInterface::class);
         $resourceConnection = $this->createMock(ResourceConnection::class);
@@ -75,7 +75,7 @@ class DeleteByPathTest extends TestCase
     /**
      * Test delete media asset by path command
      */
-    public function testSuccessfulDeleteByIdExecution()
+    public function testSuccessfulDeleteByIdExecution(): void
     {
         $tableName = 'media_gallery_asset';
         $this->adapter->expects($this->once())
@@ -92,7 +92,7 @@ class DeleteByPathTest extends TestCase
     /**
      * Assume that delete action will thrown an Exception
      */
-    public function testExceptionOnDeleteExecution()
+    public function testExceptionOnDeleteExecution(): void
     {
         $tableName = 'media_gallery_asset';
         $this->adapter->expects($this->once())

--- a/AdobeMediaGallery/Test/Unit/Model/Asset/Command/DeleteByPathTest.php
+++ b/AdobeMediaGallery/Test/Unit/Model/Asset/Command/DeleteByPathTest.php
@@ -13,6 +13,7 @@ use Magento\AdobeMediaGalleryApi\Model\Asset\Command\GetByIdInterface;
 use Magento\Framework\App\ResourceConnection;
 use Magento\Framework\DB\Adapter\AdapterInterface;
 use Magento\Framework\Exception\CouldNotDeleteException;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Psr\Log\LoggerInterface;
@@ -22,18 +23,21 @@ use Psr\Log\LoggerInterface;
  */
 class DeleteByPathTest extends TestCase
 {
+    private const TABLE_NAME = 'media_gallery_asset';
+    private const FILE_PATH = 'test-file-path/test.jpg';
+
     /**
      * @var DeleteByPath
      */
     private $deleteMediaAssetByPath;
 
     /**
-     * @var AdapterInterface
+     * @var AdapterInterface|MockObject
      */
     private $adapter;
 
     /**
-     * @var LoggerInterface
+     * @var LoggerInterface|MockObject
      */
     private $logger;
 
@@ -67,9 +71,10 @@ class DeleteByPathTest extends TestCase
         $resourceConnection->expects($this->once())
             ->method('getConnection')
             ->willReturn($this->adapter);
-
-        $this->mediaAssetTable = 'media_gallery_asset';
-        $this->testFilePath = 'test-file-path/test.jpg';
+        $resourceConnection->expects($this->once())
+            ->method('getTableName')
+            ->with(self::TABLE_NAME)
+            ->willReturn('prefix_' . self::TABLE_NAME);
     }
 
     /**
@@ -77,16 +82,11 @@ class DeleteByPathTest extends TestCase
      */
     public function testSuccessfulDeleteByIdExecution(): void
     {
-        $tableName = 'media_gallery_asset';
-        $this->adapter->expects($this->once())
-            ->method('getTableName')
-            ->with($this->mediaAssetTable)
-            ->willReturn($this->mediaAssetTable);
         $this->adapter->expects($this->once())
             ->method('delete')
-            ->with($tableName, ['path = ?' => $this->testFilePath]);
+            ->with('prefix_' . self::TABLE_NAME, ['path = ?' => self::FILE_PATH]);
 
-        $this->deleteMediaAssetByPath->execute($this->testFilePath);
+        $this->deleteMediaAssetByPath->execute(self::FILE_PATH);
     }
 
     /**
@@ -94,20 +94,15 @@ class DeleteByPathTest extends TestCase
      */
     public function testExceptionOnDeleteExecution(): void
     {
-        $tableName = 'media_gallery_asset';
-        $this->adapter->expects($this->once())
-            ->method('getTableName')
-            ->with($this->mediaAssetTable)
-            ->willReturn($this->mediaAssetTable);
         $this->adapter->expects($this->once())
             ->method('delete')
-            ->with($tableName, ['path = ?' => $this->testFilePath])
+            ->with('prefix_' . self::TABLE_NAME, ['path = ?' => self::FILE_PATH])
             ->willThrowException(new \Exception());
 
         $this->expectException(CouldNotDeleteException::class);
         $this->logger->expects($this->once())
             ->method('critical')
             ->willReturnSelf();
-        $this->deleteMediaAssetByPath->execute($this->testFilePath);
+        $this->deleteMediaAssetByPath->execute(self::FILE_PATH);
     }
 }

--- a/AdobeMediaGallery/Test/Unit/Model/Keyword/Command/SaveAssetKeywordsTest.php
+++ b/AdobeMediaGallery/Test/Unit/Model/Keyword/Command/SaveAssetKeywordsTest.php
@@ -83,7 +83,7 @@ class SaveAssetKeywordsTest extends TestCase
             $this->connectionMock->expects($this->once())
                 ->method('insertArray')
                 ->with(
-                    'media_gallery_keyword',
+                    'prefix_media_gallery_keyword',
                     ['keyword'],
                     $items,
                     2
@@ -125,9 +125,13 @@ class SaveAssetKeywordsTest extends TestCase
         $this->connectionMock
             ->method('fetchCol')
             ->willReturn([['id'=> 1], ['id' => 2]]);
-        $this->resourceConnectionMock->expects($this->exactly(2))
+        $this->resourceConnectionMock->expects($this->any())
             ->method('getConnection')
             ->willReturn($this->connectionMock);
+        $this->resourceConnectionMock->expects($this->any())
+            ->method('getTableName')
+            ->with('media_gallery_keyword')
+            ->willReturn('prefix_media_gallery_keyword');
     }
 
     /**

--- a/AdobeStockAdminUi/Controller/Adminhtml/System/Config/TestConnection.php
+++ b/AdobeStockAdminUi/Controller/Adminhtml/System/Config/TestConnection.php
@@ -25,7 +25,7 @@ class TestConnection extends Action
      *
      * @see _isAllowed()
      */
-    const ADMIN_RESOURCE = 'Magento_Config::config_system';
+    public const ADMIN_RESOURCE = 'Magento_Config::config_system';
 
     /**
      * @var JsonFactory

--- a/AdobeStockAsset/Model/Asset.php
+++ b/AdobeStockAsset/Model/Asset.php
@@ -32,7 +32,7 @@ class Asset extends AbstractExtensibleModel implements AssetInterface
     /**
      * @inheritdoc
      */
-    protected function _construct()
+    protected function _construct(): void
     {
         $this->_init(AssetResourceModel::class);
     }

--- a/AdobeStockAsset/Model/AssetRepository.php
+++ b/AdobeStockAsset/Model/AssetRepository.php
@@ -118,15 +118,9 @@ class AssetRepository implements AssetRepositoryInterface
 
             $this->collectionProcessor->process($searchCriteria, $collection);
 
-            $items = [];
-            /** @var AssetInterface $item */
-            foreach ($collection->getItems() as $item) {
-                $items[] = $item;
-            }
-
             /** @var AssetSearchResultsInterface $searchResults */
             $searchResults = $this->searchResultFactory->create();
-            $searchResults->setItems($items);
+            $searchResults->setItems($collection->getItems());
             $searchResults->setSearchCriteria($searchCriteria);
             $searchResults->setTotalCount($collection->getSize());
 

--- a/AdobeStockAsset/Model/Category.php
+++ b/AdobeStockAsset/Model/Category.php
@@ -24,7 +24,7 @@ class Category extends AbstractExtensibleModel implements CategoryInterface
     /**
      * @inheritdoc
      */
-    protected function _construct()
+    protected function _construct(): void
     {
         $this->_init(CategoryResourceModel::class);
     }

--- a/AdobeStockAsset/Model/Config.php
+++ b/AdobeStockAsset/Model/Config.php
@@ -41,7 +41,7 @@ class Config implements ConfigInterface
      *
      * @return bool
      */
-    public function isEnabled() : bool
+    public function isEnabled(): bool
     {
         return $this->scopeConfig->isSetFlag(self::XML_PATH_ENABLED);
     }

--- a/AdobeStockAsset/Model/Creator.php
+++ b/AdobeStockAsset/Model/Creator.php
@@ -24,7 +24,7 @@ class Creator extends AbstractExtensibleModel implements CreatorInterface
     /**
      * @inheritdoc
      */
-    protected function _construct()
+    protected function _construct(): void
     {
         $this->_init(CreatorResourceModel::class);
     }

--- a/AdobeStockAsset/Model/ResourceModel/Asset.php
+++ b/AdobeStockAsset/Model/ResourceModel/Asset.php
@@ -30,7 +30,7 @@ class Asset extends AbstractDb
     /**
      * Initialize with table name and primary field
      */
-    protected function _construct()
+    protected function _construct(): void
     {
         $this->_init(self::ADOBE_STOCK_ASSET_TABLE_NAME, 'id');
     }

--- a/AdobeStockAsset/Model/ResourceModel/Asset/Collection.php
+++ b/AdobeStockAsset/Model/ResourceModel/Asset/Collection.php
@@ -20,7 +20,7 @@ class Collection extends AbstractCollection
     /**
      * Define model & resource model
      */
-    protected function _construct()
+    protected function _construct(): void
     {
         $this->_init(
             Model::class,

--- a/AdobeStockAsset/Model/ResourceModel/Asset/Command/Save.php
+++ b/AdobeStockAsset/Model/ResourceModel/Asset/Command/Save.php
@@ -7,10 +7,10 @@ declare(strict_types=1);
 
 namespace Magento\AdobeStockAsset\Model\ResourceModel\Asset\Command;
 
+use Magento\AdobeMediaGalleryApi\Model\DataExtractorInterface;
 use Magento\Framework\App\ResourceConnection;
 use Magento\AdobeStockAssetApi\Api\Data\AssetInterface;
 use Magento\Framework\DB\Adapter\AdapterInterface;
-use Magento\Framework\EntityManager\Hydrator;
 
 /**
  * Save multiple asset service.
@@ -25,22 +25,20 @@ class Save
     private $resourceConnection;
 
     /**
-     * @var Hydrator $hydrator
+     * @var DataExtractorInterface
      */
-    private $hydrator;
+    private $dataExtractor;
 
     /**
-     * Save constructor.
-     *
      * @param ResourceConnection $resourceConnection
-     * @param Hydrator $hydrate
+     * @param DataExtractorInterface $dataExtractor
      */
     public function __construct(
         ResourceConnection $resourceConnection,
-        Hydrator $hydrate
+        DataExtractorInterface $dataExtractor
     ) {
         $this->resourceConnection = $resourceConnection;
-        $this->hydrator = $hydrate;
+        $this->dataExtractor = $dataExtractor;
     }
 
     /**
@@ -51,10 +49,8 @@ class Save
      */
     public function execute(AssetInterface $asset): void
     {
-        $data = $this->hydrator->extract($asset);
-        $tableName = $this->resourceConnection->getTableName(
-            self::ADOBE_STOCK_ASSET_TABLE_NAME
-        );
+        $data = $this->dataExtractor->extract($asset, AssetInterface::class);
+        $tableName = $this->resourceConnection->getTableName(self::ADOBE_STOCK_ASSET_TABLE_NAME);
 
         if (empty($data)) {
             return;
@@ -71,7 +67,7 @@ class Save
      * @param array $columns
      * @return array
      */
-    private function filterData(array $data, array $columns)
+    private function filterData(array $data, array $columns): array
     {
         return array_intersect_key($data, array_flip($columns));
     }

--- a/AdobeStockAsset/Model/ResourceModel/Asset/LoadByIds.php
+++ b/AdobeStockAsset/Model/ResourceModel/Asset/LoadByIds.php
@@ -44,14 +44,14 @@ class LoadByIds
     /**
      * Load assets by ids
      *
-     * @param \int[] $ids
+     * @param int[] $ids
      * @return AssetInterface[]
      */
     public function execute(array $ids): array
     {
         $connection = $this->resourceConnection->getConnection();
         $select = $connection->select()
-            ->from(self::ADOBE_STOCK_ASSET_TABLE_NAME)
+            ->from($this->resourceConnection->getTableName(self::ADOBE_STOCK_ASSET_TABLE_NAME))
             ->where('id in (?)', $ids);
         $data = $connection->fetchAssoc($select);
 

--- a/AdobeStockAsset/Model/ResourceModel/Category/Collection.php
+++ b/AdobeStockAsset/Model/ResourceModel/Category/Collection.php
@@ -20,7 +20,7 @@ class Collection extends AbstractCollection
     /**
      * Define model & resource model
      */
-    protected function _construct()
+    protected function _construct(): void
     {
         $this->_init(
             Model::class,

--- a/AdobeStockAsset/Model/ResourceModel/Category/Command/Save.php
+++ b/AdobeStockAsset/Model/ResourceModel/Category/Command/Save.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 
 namespace Magento\AdobeStockAsset\Model\ResourceModel\Category\Command;
 
+use Magento\AdobeMediaGalleryApi\Model\DataExtractorInterface;
 use Magento\AdobeStockAssetApi\Api\Data\CategoryInterface;
 use Magento\AdobeStockAsset\Model\ResourceModel\Command\InsertIgnore;
 
@@ -16,8 +17,6 @@ use Magento\AdobeStockAsset\Model\ResourceModel\Command\InsertIgnore;
 class Save
 {
     private const ADOBE_STOCK_ASSET_CATEGORY_TABLE_NAME = 'adobe_stock_category';
-    private const ID = 'id';
-    private const NAME = 'name';
 
     /**
      * @var InsertIgnore
@@ -25,12 +24,20 @@ class Save
     private $insertIgnore;
 
     /**
+     * @var DataExtractorInterface
+     */
+    private $dataExtractor;
+
+    /**
      * @param InsertIgnore $insertIgnore
+     * @param DataExtractorInterface $dataExtractor
      */
     public function __construct(
-        InsertIgnore $insertIgnore
+        InsertIgnore $insertIgnore,
+        DataExtractorInterface $dataExtractor
     ) {
         $this->insertIgnore = $insertIgnore;
+        $this->dataExtractor = $dataExtractor;
     }
 
     /**
@@ -41,13 +48,11 @@ class Save
      */
     public function execute(CategoryInterface $category): void
     {
+        $data = $this->dataExtractor->extract($category, CategoryInterface::class);
         $this->insertIgnore->execute(
-            $category,
+            $data,
             self::ADOBE_STOCK_ASSET_CATEGORY_TABLE_NAME,
-            [
-                self::ID,
-                self::NAME
-            ]
+            array_keys($data)
         );
     }
 }

--- a/AdobeStockAsset/Model/ResourceModel/Command/InsertIgnore.php
+++ b/AdobeStockAsset/Model/ResourceModel/Command/InsertIgnore.php
@@ -9,7 +9,6 @@ namespace Magento\AdobeStockAsset\Model\ResourceModel\Command;
 
 use Magento\Framework\App\ResourceConnection;
 use Magento\Framework\DB\Adapter\AdapterInterface;
-use Magento\Framework\EntityManager\Hydrator;
 
 /**
  * Universal insert ignore command
@@ -22,35 +21,23 @@ class InsertIgnore
     private $resourceConnection;
 
     /**
-     * @var Hydrator $hydrator
-     */
-    private $hydrator;
-
-    /**
-     * Save constructor.
-     *
      * @param ResourceConnection $resourceConnection
-     * @param Hydrator $hydrator
      */
     public function __construct(
-        ResourceConnection $resourceConnection,
-        Hydrator $hydrator
+        ResourceConnection $resourceConnection
     ) {
         $this->resourceConnection = $resourceConnection;
-        $this->hydrator = $hydrator;
     }
 
     /**
      * Extract data from object and insert to columns of table
      *
-     * @param object $object
+     * @param array $data
      * @param string $tableName
      * @param array $columns
      */
-    public function execute($object, string $tableName, array $columns): void
+    public function execute(array $data, string $tableName, array $columns): void
     {
-        $data = $this->hydrator->extract($object);
-
         $data = $this->filterData($data, $columns);
         if (empty($data)) {
             return;
@@ -72,7 +59,7 @@ class InsertIgnore
      * @param array $columns
      * @return array
      */
-    private function filterData(array $data, array $columns)
+    private function filterData(array $data, array $columns): array
     {
         return array_intersect_key($data, array_flip($columns));
     }

--- a/AdobeStockAsset/Model/ResourceModel/Creator.php
+++ b/AdobeStockAsset/Model/ResourceModel/Creator.php
@@ -29,7 +29,7 @@ class Creator extends AbstractDb
     /**
      * Initialize with table name and primary field
      */
-    protected function _construct()
+    protected function _construct(): void
     {
         $this->_init(self::ADOBE_STOCK_ASSET_CREATOR_TABLE_NAME, 'id');
     }

--- a/AdobeStockAsset/Model/ResourceModel/Creator/Collection.php
+++ b/AdobeStockAsset/Model/ResourceModel/Creator/Collection.php
@@ -20,7 +20,7 @@ class Collection extends AbstractCollection
     /**
      * Define model & resource model
      */
-    protected function _construct()
+    protected function _construct(): void
     {
         $this->_init(
             Model::class,

--- a/AdobeStockAsset/Model/ResourceModel/Creator/Command/Save.php
+++ b/AdobeStockAsset/Model/ResourceModel/Creator/Command/Save.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 
 namespace Magento\AdobeStockAsset\Model\ResourceModel\Creator\Command;
 
+use Magento\AdobeMediaGalleryApi\Model\DataExtractorInterface;
 use Magento\AdobeStockAssetApi\Api\Data\CreatorInterface;
 use Magento\AdobeStockAsset\Model\ResourceModel\Command\InsertIgnore;
 
@@ -16,8 +17,6 @@ use Magento\AdobeStockAsset\Model\ResourceModel\Command\InsertIgnore;
 class Save
 {
     private const ADOBE_STOCK_ASSET_CREATOR_TABLE_NAME = 'adobe_stock_creator';
-    private const ID = 'id';
-    private const NAME = 'name';
 
     /**
      * @var InsertIgnore
@@ -25,12 +24,20 @@ class Save
     private $insertIgnore;
 
     /**
+     * @var DataExtractorInterface
+     */
+    private $dataExtractor;
+
+    /**
      * @param InsertIgnore $insertIgnore
+     * @param DataExtractorInterface $dataExtractor
      */
     public function __construct(
-        InsertIgnore $insertIgnore
+        InsertIgnore $insertIgnore,
+        DataExtractorInterface $dataExtractor
     ) {
         $this->insertIgnore = $insertIgnore;
+        $this->dataExtractor = $dataExtractor;
     }
 
     /**
@@ -41,13 +48,11 @@ class Save
      */
     public function execute(CreatorInterface $creator): void
     {
+        $data = $this->dataExtractor->extract($creator, CreatorInterface::class);
         $this->insertIgnore->execute(
-            $creator,
+            $data,
             self::ADOBE_STOCK_ASSET_CREATOR_TABLE_NAME,
-            [
-                self::ID,
-                self::NAME
-            ]
+            array_keys($data)
         );
     }
 }

--- a/AdobeStockAsset/Model/SaveAsset.php
+++ b/AdobeStockAsset/Model/SaveAsset.php
@@ -7,10 +7,12 @@ declare(strict_types=1);
 
 namespace Magento\AdobeStockAsset\Model;
 
+use Magento\AdobeMediaGalleryApi\Model\DataExtractorInterface;
 use Magento\AdobeStockAssetApi\Api\AssetRepositoryInterface;
 use Magento\AdobeStockAssetApi\Api\CategoryRepositoryInterface;
 use Magento\AdobeStockAssetApi\Api\CreatorRepositoryInterface;
 use Magento\AdobeStockAssetApi\Api\Data\AssetInterface;
+use Magento\AdobeStockAssetApi\Api\Data\AssetInterfaceFactory;
 use Magento\AdobeStockAssetApi\Api\SaveAssetInterface;
 
 /**
@@ -20,6 +22,9 @@ use Magento\AdobeStockAssetApi\Api\SaveAssetInterface;
  */
 class SaveAsset implements SaveAssetInterface
 {
+    private const CATEGORY_ID = 'category_id';
+    private const CREATOR_ID = 'creator_id';
+
     /**
      * @var AssetRepositoryInterface
      */
@@ -36,20 +41,34 @@ class SaveAsset implements SaveAssetInterface
     private $creatorRepository;
 
     /**
-     * SaveAsset constructor.
-     *
+     * @var DataExtractorInterface
+     */
+    private $dataExtractor;
+
+    /**
+     * @var AssetInterfaceFactory
+     */
+    private $assetFactory;
+
+    /**
+     * @param AssetInterfaceFactory $assetFactory
      * @param AssetRepositoryInterface $assetRepository
      * @param CreatorRepositoryInterface $creatorRepository
      * @param CategoryRepositoryInterface $categoryRepository
+     * @param DataExtractorInterface $dataExtractor
      */
     public function __construct(
+        AssetInterfaceFactory $assetFactory,
         AssetRepositoryInterface $assetRepository,
         CreatorRepositoryInterface $creatorRepository,
-        CategoryRepositoryInterface $categoryRepository
+        CategoryRepositoryInterface $categoryRepository,
+        DataExtractorInterface $dataExtractor
     ) {
+        $this->assetFactory = $assetFactory;
         $this->assetRepository = $assetRepository;
         $this->creatorRepository = $creatorRepository;
         $this->categoryRepository = $categoryRepository;
+        $this->dataExtractor = $dataExtractor;
     }
 
     /**
@@ -57,18 +76,20 @@ class SaveAsset implements SaveAssetInterface
      */
     public function execute(AssetInterface $asset): void
     {
+        $data = $this->dataExtractor->extract($asset, AssetInterface::class);
+
         $category = $asset->getCategory();
         if ($category !== null) {
             $category = $this->categoryRepository->save($category);
         }
-        $asset->setCategoryId($category->getId());
+        $data[self::CATEGORY_ID] = $category->getId();
 
         $creator = $asset->getCreator();
         if ($creator !== null) {
             $creator = $this->creatorRepository->save($creator);
         }
-        $asset->setCreatorId($creator->getId());
+        $data[self::CREATOR_ID] = $creator->getId();
 
-        $this->assetRepository->save($asset);
+        $this->assetRepository->save($this->assetFactory->create(['data' => $data]));
     }
 }

--- a/AdobeStockAsset/Test/Api/AssetRepository/AssetListTest.php
+++ b/AdobeStockAsset/Test/Api/AssetRepository/AssetListTest.php
@@ -28,7 +28,7 @@ class AssetListTest extends WebapiAbstract
      *
      * @return void
      */
-    public function testGetList()
+    public function testGetList(): void
     {
         $searchCriteria = [
             'searchCriteria' => [
@@ -78,7 +78,7 @@ class AssetListTest extends WebapiAbstract
      *
      * @return void
      */
-    public static function assetFixtureProvider()
+    public static function assetFixtureProvider(): void
     {
         require __DIR__ . '/../../_files/asset.php';
     }

--- a/AdobeStockAsset/Test/Api/AssetRepository/DeleteTest.php
+++ b/AdobeStockAsset/Test/Api/AssetRepository/DeleteTest.php
@@ -44,7 +44,7 @@ class DeleteTest extends WebapiAbstract
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->objectManager = Bootstrap::getObjectManager();
         $this->assetCollectionFactory = $this->objectManager->get(CollectionFactory::class);
@@ -53,7 +53,7 @@ class DeleteTest extends WebapiAbstract
     /**
      * @magentoApiDataFixture assetFixtureProvider
      */
-    public function testDelete()
+    public function testDelete(): void
     {
         $response = $this->deleteAsset($this->getAssetId());
 
@@ -70,7 +70,7 @@ class DeleteTest extends WebapiAbstract
      * @return void
      * @throws \Exception
      */
-    public function testDeleteWithException()
+    public function testDeleteWithException(): void
     {
         try {
             $notExistedAssetId = -1;
@@ -119,7 +119,7 @@ class DeleteTest extends WebapiAbstract
      *
      * @return void
      */
-    public static function assetFixtureProvider()
+    public static function assetFixtureProvider(): void
     {
         require __DIR__ . '/../../_files/asset.php';
     }

--- a/AdobeStockAsset/Test/Api/AssetRepository/GetByIdTest.php
+++ b/AdobeStockAsset/Test/Api/AssetRepository/GetByIdTest.php
@@ -45,7 +45,7 @@ class GetByIdTest extends WebapiAbstract
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->objectManager = Bootstrap::getObjectManager();
         $this->assetCollectionFactory = $this->objectManager->get(CollectionFactory::class);
@@ -57,7 +57,7 @@ class GetByIdTest extends WebapiAbstract
      * @return void
      * @throws \Exception
      */
-    public function testGetNoSuchEntityException()
+    public function testGetNoSuchEntityException(): void
     {
         $notExistedAssetId = -1;
         $serviceInfo = [
@@ -103,7 +103,7 @@ class GetByIdTest extends WebapiAbstract
      *
      * @return void
      */
-    public function testGetAssetById()
+    public function testGetAssetById(): void
     {
         $assetId = $this->getAssetId();
         $serviceInfo = [
@@ -147,7 +147,7 @@ class GetByIdTest extends WebapiAbstract
      *
      * @return void
      */
-    public static function assetFixtureProvider()
+    public static function assetFixtureProvider(): void
     {
         require __DIR__ . '/../../_files/asset.php';
     }

--- a/AdobeStockAsset/Test/Api/AssetRepository/SaveTest.php
+++ b/AdobeStockAsset/Test/Api/AssetRepository/SaveTest.php
@@ -44,7 +44,7 @@ class SaveTest extends WebapiAbstract
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->objectManager = Bootstrap::getObjectManager();
         $this->assetCollectionFactory = $this->objectManager->get(CollectionFactory::class);
@@ -54,7 +54,7 @@ class SaveTest extends WebapiAbstract
      * @param array $data
      * @dataProvider assetDataProvider
      */
-    public function testSave(array $data)
+    public function testSave(array $data): void
     {
         $this->saveAsset($data);
         /** @var Asset $asset */

--- a/AdobeStockAsset/Test/Unit/Model/CreatorRepositoryTest.php
+++ b/AdobeStockAsset/Test/Unit/Model/CreatorRepositoryTest.php
@@ -7,16 +7,20 @@ declare(strict_types=1);
 
 namespace Magento\AdobeStockAsset\Test\Unit\Model;
 
+use Magento\AdobeStockAsset\Model\Creator;
 use Magento\AdobeStockAsset\Model\CreatorFactory;
 use Magento\AdobeStockAsset\Model\CreatorRepository;
+use Magento\AdobeStockAsset\Model\ResourceModel\Category\Collection;
 use Magento\AdobeStockAsset\Model\ResourceModel\Creator as ResourceModel;
 use Magento\AdobeStockAsset\Model\ResourceModel\Creator\CollectionFactory as CreatorCollectionFactory;
 use Magento\AdobeStockAsset\Model\ResourceModel\Creator\Command\Save;
 use Magento\AdobeStockAssetApi\Api\Data\CreatorInterface;
+use Magento\AdobeStockAssetApi\Api\Data\CreatorSearchResultsInterface;
 use Magento\AdobeStockAssetApi\Api\Data\CreatorSearchResultsInterfaceFactory;
 use Magento\Framework\Api\ExtensionAttribute\JoinProcessorInterface;
 use Magento\Framework\Api\SearchCriteria\CollectionProcessorInterface;
 use Magento\Framework\Api\SearchCriteriaInterface;
+use Magento\Framework\Exception\NoSuchEntityException;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -97,10 +101,10 @@ class CreatorRepositoryTest extends TestCase
     {
         /** @var MockObject|SearchCriteriaInterface $searchCriteria */
         $searchCriteria = $this->createMock(
-            \Magento\Framework\Api\SearchCriteriaInterface::class
+            SearchCriteriaInterface::class
         );
         $collection = $this->createMock(
-            \Magento\AdobeStockAsset\Model\ResourceModel\Category\Collection::class
+            Collection::class
         );
         $this->creatorCollectionFactory->expects($this->once())
             ->method('create')
@@ -115,7 +119,7 @@ class CreatorRepositoryTest extends TestCase
             ->with($searchCriteria, $collection)
             ->willReturn(null);
         $searchResults = $this->createMock(
-            \Magento\AdobeStockAssetApi\Api\Data\CreatorSearchResultsInterface::class
+            CreatorSearchResultsInterface::class
         );
         $this->creatorSearchResultInterfaceFactory->expects($this->once())
             ->method('create')
@@ -140,7 +144,7 @@ class CreatorRepositoryTest extends TestCase
      */
     public function testGetById(): void
     {
-        $creatorMock = $this->createMock(\Magento\AdobeStockAsset\Model\Creator::class);
+        $creatorMock = $this->createMock(Creator::class);
         $this->creatorFactory->expects($this->once())
             ->method('create')
             ->willReturn($creatorMock);
@@ -158,9 +162,9 @@ class CreatorRepositoryTest extends TestCase
      */
     public function testGetByIdWithException(): void
     {
-        $this->expectException(\Magento\Framework\Exception\NoSuchEntityException::class);
+        $this->expectException(NoSuchEntityException::class);
 
-        $creatorMock = $this->createMock(\Magento\AdobeStockAsset\Model\Creator::class);
+        $creatorMock = $this->createMock(Creator::class);
         $this->creatorFactory->expects($this->once())
             ->method('create')
             ->willReturn($creatorMock);

--- a/AdobeStockAsset/Test/Unit/Model/GetAssetByIdTest.php
+++ b/AdobeStockAsset/Test/Unit/Model/GetAssetByIdTest.php
@@ -8,6 +8,11 @@ namespace Magento\AdobeStockAsset\Test\Unit\Model;
 
 use Magento\AdobeStockAsset\Model\GetAssetById;
 use Magento\AdobeStockAssetApi\Api\GetAssetListInterface;
+use Magento\Framework\Api\AttributeValue;
+use Magento\Framework\Api\Filter;
+use Magento\Framework\Api\Search\Document;
+use Magento\Framework\Api\Search\SearchCriteria;
+use Magento\Framework\Api\Search\SearchResultInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Magento\Framework\Api\Search\SearchCriteriaBuilder;
@@ -41,7 +46,7 @@ class GetAssetByIdTest extends TestCase
     /**
      * @inheritdoc
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->filterBuilder = $this->createMock(FilterBuilder::class);
         $this->getAssetList = $this->createMock(GetAssetListInterface::class);
@@ -54,32 +59,32 @@ class GetAssetByIdTest extends TestCase
         );
     }
 
-    public function testExecute()
+    public function testExecute(): void
     {
         $this->filterBuilder->expects($this->once())->method('setField')->willReturnSelf();
         $this->filterBuilder->expects($this->once())->method('setValue')->willReturnSelf();
         $this->filterBuilder->expects($this->once())
             ->method('create')
-            ->willReturn($this->createMock(\Magento\Framework\Api\Filter::class));
+            ->willReturn($this->createMock(Filter::class));
         $this->searchCriteriaBuilder->expects($this->once())
             ->method('addFilter')
             ->willReturn($this->searchCriteriaBuilder);
         $this->searchCriteriaBuilder->expects($this->once())
             ->method('create')
             ->willReturn(
-                $this->createMock(\Magento\Framework\Api\Search\SearchCriteria::class)
+                $this->createMock(SearchCriteria::class)
             );
-        $searchResultMock = $this->createMock(\Magento\Framework\Api\Search\SearchResultInterface::class);
+        $searchResultMock = $this->createMock(SearchResultInterface::class);
         $this->getAssetList->expects($this->once())
             ->method('execute')
             ->willReturn($searchResultMock);
         $searchResultMock->expects($this->once())->method('getItems')->willReturn(
             [
-                new \Magento\Framework\Api\Search\Document(
+                new Document(
                     [
                         'id' => 123455678,
                         'custom_attributes' => [
-                            'id_field_name' => new \Magento\Framework\Api\AttributeValue(
+                            'id_field_name' => new AttributeValue(
                                 ['attribute_code' => 'id_field_name']
                             )
                         ]

--- a/AdobeStockAsset/Test/Unit/Model/GetAssetListTest.php
+++ b/AdobeStockAsset/Test/Unit/Model/GetAssetListTest.php
@@ -12,6 +12,7 @@ use Magento\AdobeStockAsset\Model\GetAssetList;
 use Magento\AdobeStockClientApi\Api\ClientInterface;
 use Magento\Framework\Api\Search\SearchResultInterface;
 use Magento\Framework\Api\Search\SearchCriteriaInterface;
+use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Magento\Framework\UrlInterface;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -40,7 +41,7 @@ class GetAssetListTest extends TestCase
     /**
      * @inheritdoc
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->clientMock = $this->createMock(ClientInterface::class);
         $this->urlMock = $this->createMock(UrlInterface::class);
@@ -56,9 +57,9 @@ class GetAssetListTest extends TestCase
 
     /**
      * Test execute method
-     * @throws \Magento\Framework\Exception\LocalizedException
+     * @throws LocalizedException
      */
-    public function testExecute()
+    public function testExecute(): void
     {
         $searchCriteriaMock = $this->createMock(SearchCriteriaInterface::class);
         $documentSearchResults = $this->createMock(SearchResultInterface::class);

--- a/AdobeStockAsset/Test/Unit/Model/SaveAssetTest.php
+++ b/AdobeStockAsset/Test/Unit/Model/SaveAssetTest.php
@@ -7,6 +7,9 @@
 namespace Magento\AdobeStockAsset\Test\Unit\Model;
 
 use Magento\AdobeStockAsset\Model\SaveAsset;
+use Magento\AdobeStockAssetApi\Api\Data\AssetInterface;
+use Magento\AdobeStockAssetApi\Api\Data\CategoryInterface;
+use Magento\AdobeStockAssetApi\Api\Data\CreatorInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Magento\AdobeStockAssetApi\Api\AssetRepositoryInterface;
@@ -41,7 +44,7 @@ class SaveAssetTest extends TestCase
     /**
      * @inheritdoc
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->assetRepository = $this->createMock(AssetRepositoryInterface::class);
         $this->creatorRepository = $this->createMock(CreatorRepositoryInterface::class);
@@ -54,13 +57,13 @@ class SaveAssetTest extends TestCase
         );
     }
 
-    public function testExecute()
+    public function testExecute(): void
     {
         $categoryId = 5;
         $creatorId = 5;
 
-        $asset = $this->createMock(\Magento\AdobeStockAssetApi\Api\Data\AssetInterface::class);
-        $categoryMock = $this->createMock(\Magento\AdobeStockAssetApi\Api\Data\CategoryInterface::class);
+        $asset = $this->createMock(AssetInterface::class);
+        $categoryMock = $this->createMock(CategoryInterface::class);
         $categoryMock->expects($this->once())->method('getId')
             ->willReturn($categoryId);
         $asset->expects($this->once())
@@ -69,7 +72,7 @@ class SaveAssetTest extends TestCase
         $asset->expects($this->once())
             ->method('setCategoryId')
             ->with($categoryId);
-        $creatorInterface = $this->createMock(\Magento\AdobeStockAssetApi\Api\Data\CreatorInterface::class);
+        $creatorInterface = $this->createMock(CreatorInterface::class);
         $this->categoryRepository->expects($this->once())->method('save')
             ->with($categoryMock)
             ->willReturn($categoryMock);

--- a/AdobeStockAsset/Test/Unit/Model/SaveAssetTest.php
+++ b/AdobeStockAsset/Test/Unit/Model/SaveAssetTest.php
@@ -6,10 +6,13 @@
 
 namespace Magento\AdobeStockAsset\Test\Unit\Model;
 
+use Magento\AdobeMediaGalleryApi\Model\DataExtractorInterface;
 use Magento\AdobeStockAsset\Model\SaveAsset;
 use Magento\AdobeStockAssetApi\Api\Data\AssetInterface;
+use Magento\AdobeStockAssetApi\Api\Data\AssetInterfaceFactory;
 use Magento\AdobeStockAssetApi\Api\Data\CategoryInterface;
 use Magento\AdobeStockAssetApi\Api\Data\CreatorInterface;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Magento\AdobeStockAssetApi\Api\AssetRepositoryInterface;
@@ -27,6 +30,11 @@ class SaveAssetTest extends TestCase
     private $assetRepository;
 
     /**
+     * @var MockObject|AssetInterfaceFactory
+     */
+    private $assetFactory;
+
+    /**
      * @var MockObject|CreatorRepositoryInterface
      */
     private $creatorRepository;
@@ -35,6 +43,11 @@ class SaveAssetTest extends TestCase
      * @var MockObject|CategoryRepositoryInterface
      */
     private $categoryRepository;
+
+    /**
+     * @var MockObject|DataExtractorInterface
+     */
+    private $dataExtractor;
 
     /**
      * @var SaveAsset
@@ -46,49 +59,91 @@ class SaveAssetTest extends TestCase
      */
     public function setUp(): void
     {
+        $this->assetFactory = $this->createMock(AssetInterfaceFactory::class);
         $this->assetRepository = $this->createMock(AssetRepositoryInterface::class);
         $this->creatorRepository = $this->createMock(CreatorRepositoryInterface::class);
         $this->categoryRepository = $this->createMock(CategoryRepositoryInterface::class);
+        $this->dataExtractor = $this->createMock(DataExtractorInterface::class);
 
-        $this->saveAsset = new SaveAsset(
-            $this->assetRepository,
-            $this->creatorRepository,
-            $this->categoryRepository
+        $this->saveAsset = (new ObjectManager($this))->getObject(
+            SaveAsset::class,
+            [
+                'assetFactory' => $this->assetFactory,
+                'assetRepository' => $this->assetRepository,
+                'creatorRepository' => $this->creatorRepository,
+                'categoryRepository' => $this->categoryRepository,
+                'dataExtractor' => $this->dataExtractor
+            ]
         );
     }
 
     public function testExecute(): void
     {
+        $data = [
+            'id' => 1,
+            'media_gallery_id' => 2
+        ];
         $categoryId = 5;
-        $creatorId = 5;
+        $creatorId = 6;
+        $finalData = [
+            'id' => 1,
+            'media_gallery_id' => 2,
+            'category_id' => $categoryId,
+            'creator_id' => $creatorId
+        ];
 
         $asset = $this->createMock(AssetInterface::class);
+
+        $this->dataExtractor->expects($this->once())
+            ->method('extract')
+            ->with($asset, AssetInterface::class)
+            ->willReturn($data);
+
         $categoryMock = $this->createMock(CategoryInterface::class);
         $categoryMock->expects($this->once())->method('getId')
             ->willReturn($categoryId);
         $asset->expects($this->once())
             ->method('getCategory')
             ->willReturn($categoryMock);
-        $asset->expects($this->once())
-            ->method('setCategoryId')
-            ->with($categoryId);
-        $creatorInterface = $this->createMock(CreatorInterface::class);
         $this->categoryRepository->expects($this->once())->method('save')
             ->with($categoryMock)
             ->willReturn($categoryMock);
-        $asset->expects($this->once())->method('getCreator')->willReturn($creatorInterface);
+
+        $creatorInterface = $this->createMock(CreatorInterface::class);
         $creatorInterface->expects($this->once())
             ->method('getId')
             ->willReturn($creatorId);
+        $asset->expects($this->once())
+            ->method('getCreator')
+            ->willReturn($creatorInterface);
         $this->creatorRepository->expects($this->once())
             ->method('save')
             ->with($creatorInterface)
             ->willReturn($creatorInterface);
-        $asset->expects($this->once())
-            ->method('setCreatorId')
-            ->with($creatorId);
+
+        $finalAsset = $this->createMock(AssetInterface::class);
+
+        $this->assetFactory->expects($this->once())
+            ->method('create')
+            ->with(['data' => $finalData])
+            ->willReturn($finalAsset);
+
         $this->assetRepository->expects($this->once())->method('save')
-            ->with($asset);
+            ->with($finalAsset);
+
         $this->saveAsset->execute($asset);
+    }
+
+    public function assetDataProvider()
+    {
+        return [
+            [
+                [
+                    'id' => 1,
+                    'media_gallery_id' => 2,
+                    'creator'
+                ]
+            ]
+        ];
     }
 }

--- a/AdobeStockAsset/etc/di.xml
+++ b/AdobeStockAsset/etc/di.xml
@@ -31,15 +31,4 @@
             </argument>
         </arguments>
     </type>
-
-    <type name="Magento\Framework\EntityManager\MetadataPool">
-        <arguments>
-            <argument name="metadata" xsi:type="array">
-                <item name="Magento\AdobeStockAssetApi\Api\Data\AssetInterface" xsi:type="array">
-                    <item name="entityTableName" xsi:type="string">adobe_stock_asset</item>
-                    <item name="identifierField" xsi:type="string">id</item>
-                </item>
-            </argument>
-        </arguments>
-    </type>
 </config>

--- a/AdobeStockAssetApi/Api/Data/AssetInterface.php
+++ b/AdobeStockAssetApi/Api/Data/AssetInterface.php
@@ -39,14 +39,6 @@ interface AssetInterface extends ExtensibleDataInterface
     public function getCategoryId(): ?int;
 
     /**
-     * Set category
-     *
-     * @param int $categoryId
-     * @return void
-     */
-    public function setCategoryId(int $categoryId): void;
-
-    /**
      * Get category
      *
      * @return \Magento\AdobeStockAssetApi\Api\Data\CategoryInterface|null
@@ -59,14 +51,6 @@ interface AssetInterface extends ExtensibleDataInterface
      * @return int|null
      */
     public function getCreatorId(): ?int;
-
-    /**
-     * Set the creator
-     *
-     * @param int $creatorId
-     * @return void
-     */
-    public function setCreatorId(int $creatorId): void;
 
     /**
      * Return the creator

--- a/AdobeStockAssetApi/Api/Data/CategorySearchResultsInterface.php
+++ b/AdobeStockAssetApi/Api/Data/CategorySearchResultsInterface.php
@@ -8,11 +8,13 @@ declare(strict_types=1);
 
 namespace Magento\AdobeStockAssetApi\Api\Data;
 
+use Magento\Framework\Api\SearchResultsInterface;
+
 /**
  * Interface CategorySearchResultsInterface
  * @api
  */
-interface CategorySearchResultsInterface extends \Magento\Framework\Api\SearchResultsInterface
+interface CategorySearchResultsInterface extends SearchResultsInterface
 {
     /**
      * Get category list.

--- a/AdobeStockAssetApi/Api/Data/CreatorInterface.php
+++ b/AdobeStockAssetApi/Api/Data/CreatorInterface.php
@@ -9,12 +9,13 @@ declare(strict_types=1);
 namespace Magento\AdobeStockAssetApi\Api\Data;
 
 use Magento\AdobeStockAssetApi\Api\Data\CreatorExtensionInterface;
+use Magento\Framework\Api\ExtensibleDataInterface;
 
 /**
  * Interface CreatorInterface
  * @api
  */
-interface CreatorInterface extends \Magento\Framework\Api\ExtensibleDataInterface
+interface CreatorInterface extends ExtensibleDataInterface
 {
     /**
      * Get the id

--- a/AdobeStockAssetApi/Api/Data/CreatorSearchResultsInterface.php
+++ b/AdobeStockAssetApi/Api/Data/CreatorSearchResultsInterface.php
@@ -8,11 +8,13 @@ declare(strict_types=1);
 
 namespace Magento\AdobeStockAssetApi\Api\Data;
 
+use Magento\Framework\Api\SearchResultsInterface;
+
 /**
  * Interface CreatorSearchResultsInterface
  * @api
  */
-interface CreatorSearchResultsInterface extends \Magento\Framework\Api\SearchResultsInterface
+interface CreatorSearchResultsInterface extends SearchResultsInterface
 {
     /**
      * Get category list.

--- a/AdobeStockClient/Model/Client.php
+++ b/AdobeStockClient/Model/Client.php
@@ -163,7 +163,7 @@ class Client implements ClientInterface
      *
      * @param int $contentId
      * @return LicenseRequest
-     * @throws \AdobeStock\Api\Exception\StockApi
+     * @throws StockApi
      */
     private function getLicenseRequest(int $contentId): LicenseRequest
     {

--- a/AdobeStockClient/Model/SearchParameterProviderInterface.php
+++ b/AdobeStockClient/Model/SearchParameterProviderInterface.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace Magento\AdobeStockClient\Model;
 
+use AdobeStock\Api\Exception\StockApi as StockApiException;
 use AdobeStock\Api\Models\SearchParameters;
 use Magento\Framework\Api\SearchCriteriaInterface;
 
@@ -22,6 +23,7 @@ interface SearchParameterProviderInterface
      * @param SearchCriteriaInterface $searchCriteria
      * @param SearchParameters $searchParams
      * @return SearchParameters
+     * @throws StockApiException
      */
     public function apply(
         SearchCriteriaInterface $searchCriteria,

--- a/AdobeStockClient/Model/SearchParametersProvider/ContentType.php
+++ b/AdobeStockClient/Model/SearchParametersProvider/ContentType.php
@@ -8,7 +8,6 @@ declare(strict_types=1);
 
 namespace Magento\AdobeStockClient\Model\SearchParametersProvider;
 
-use AdobeStock\Api\Exception\StockApi;
 use AdobeStock\Api\Models\SearchParameters;
 use Magento\AdobeStockClient\Model\SearchParameterProviderInterface;
 use Magento\Framework\Api\SearchCriteriaInterface;
@@ -20,7 +19,6 @@ class ContentType implements SearchParameterProviderInterface
 {
     /**
      * @inheritdoc
-     * @throws StockApi
      */
     public function apply(SearchCriteriaInterface $searchCriteria, SearchParameters $searchParams): SearchParameters
     {

--- a/AdobeStockClient/Model/SearchParametersProvider/ContentType.php
+++ b/AdobeStockClient/Model/SearchParametersProvider/ContentType.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace Magento\AdobeStockClient\Model\SearchParametersProvider;
 
+use AdobeStock\Api\Exception\StockApi;
 use AdobeStock\Api\Models\SearchParameters;
 use Magento\AdobeStockClient\Model\SearchParameterProviderInterface;
 use Magento\Framework\Api\SearchCriteriaInterface;
@@ -19,7 +20,7 @@ class ContentType implements SearchParameterProviderInterface
 {
     /**
      * @inheritdoc
-     * @throws \AdobeStock\Api\Exception\StockApi
+     * @throws StockApi
      */
     public function apply(SearchCriteriaInterface $searchCriteria, SearchParameters $searchParams): SearchParameters
     {

--- a/AdobeStockClient/Model/SearchParametersProvider/Isolated.php
+++ b/AdobeStockClient/Model/SearchParametersProvider/Isolated.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace Magento\AdobeStockClient\Model\SearchParametersProvider;
 
+use AdobeStock\Api\Exception\StockApi;
 use AdobeStock\Api\Models\SearchParameters;
 use Magento\AdobeStockClient\Model\SearchParameterProviderInterface;
 use Magento\Framework\Api\SearchCriteriaInterface;
@@ -19,7 +20,7 @@ class Isolated implements SearchParameterProviderInterface
 {
     /**
      * @inheritdoc
-     * @throws \AdobeStock\Api\Exception\StockApi
+     * @throws StockApi
      */
     public function apply(SearchCriteriaInterface $searchCriteria, SearchParameters $searchParams): SearchParameters
     {

--- a/AdobeStockClient/Model/SearchParametersProvider/Isolated.php
+++ b/AdobeStockClient/Model/SearchParametersProvider/Isolated.php
@@ -8,7 +8,6 @@ declare(strict_types=1);
 
 namespace Magento\AdobeStockClient\Model\SearchParametersProvider;
 
-use AdobeStock\Api\Exception\StockApi;
 use AdobeStock\Api\Models\SearchParameters;
 use Magento\AdobeStockClient\Model\SearchParameterProviderInterface;
 use Magento\Framework\Api\SearchCriteriaInterface;
@@ -20,7 +19,6 @@ class Isolated implements SearchParameterProviderInterface
 {
     /**
      * @inheritdoc
-     * @throws StockApi
      */
     public function apply(SearchCriteriaInterface $searchCriteria, SearchParameters $searchParams): SearchParameters
     {

--- a/AdobeStockClient/Model/SearchParametersProvider/MediaId.php
+++ b/AdobeStockClient/Model/SearchParametersProvider/MediaId.php
@@ -8,7 +8,6 @@ declare(strict_types=1);
 
 namespace Magento\AdobeStockClient\Model\SearchParametersProvider;
 
-use AdobeStock\Api\Exception\StockApi;
 use AdobeStock\Api\Models\SearchParameters;
 use Magento\AdobeStockClient\Model\SearchParameterProviderInterface;
 use Magento\Framework\Api\SearchCriteriaInterface;
@@ -20,7 +19,6 @@ class MediaId implements SearchParameterProviderInterface
 {
     /**
      * @inheritdoc
-     * @throws StockApi
      */
     public function apply(SearchCriteriaInterface $searchCriteria, SearchParameters $searchParams): SearchParameters
     {

--- a/AdobeStockClient/Model/SearchParametersProvider/MediaId.php
+++ b/AdobeStockClient/Model/SearchParametersProvider/MediaId.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace Magento\AdobeStockClient\Model\SearchParametersProvider;
 
+use AdobeStock\Api\Exception\StockApi;
 use AdobeStock\Api\Models\SearchParameters;
 use Magento\AdobeStockClient\Model\SearchParameterProviderInterface;
 use Magento\Framework\Api\SearchCriteriaInterface;
@@ -19,7 +20,7 @@ class MediaId implements SearchParameterProviderInterface
 {
     /**
      * @inheritdoc
-     * @throws \AdobeStock\Api\Exception\StockApi
+     * @throws StockApi
      */
     public function apply(SearchCriteriaInterface $searchCriteria, SearchParameters $searchParams): SearchParameters
     {

--- a/AdobeStockClient/Model/SearchParametersProvider/Offensive.php
+++ b/AdobeStockClient/Model/SearchParametersProvider/Offensive.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace Magento\AdobeStockClient\Model\SearchParametersProvider;
 
+use AdobeStock\Api\Exception\StockApi;
 use AdobeStock\Api\Models\SearchParameters;
 use Magento\AdobeStockClient\Model\SearchParameterProviderInterface;
 use Magento\Framework\Api\SearchCriteriaInterface;
@@ -19,7 +20,7 @@ class Offensive implements SearchParameterProviderInterface
 {
     /**
      * @inheritdoc
-     * @throws \AdobeStock\Api\Exception\StockApi
+     * @throws StockApi
      */
     public function apply(SearchCriteriaInterface $searchCriteria, SearchParameters $searchParams): SearchParameters
     {

--- a/AdobeStockClient/Model/SearchParametersProvider/Offensive.php
+++ b/AdobeStockClient/Model/SearchParametersProvider/Offensive.php
@@ -8,7 +8,6 @@ declare(strict_types=1);
 
 namespace Magento\AdobeStockClient\Model\SearchParametersProvider;
 
-use AdobeStock\Api\Exception\StockApi;
 use AdobeStock\Api\Models\SearchParameters;
 use Magento\AdobeStockClient\Model\SearchParameterProviderInterface;
 use Magento\Framework\Api\SearchCriteriaInterface;
@@ -20,7 +19,6 @@ class Offensive implements SearchParameterProviderInterface
 {
     /**
      * @inheritdoc
-     * @throws StockApi
      */
     public function apply(SearchCriteriaInterface $searchCriteria, SearchParameters $searchParams): SearchParameters
     {

--- a/AdobeStockClient/Model/SearchParametersProvider/Orientation.php
+++ b/AdobeStockClient/Model/SearchParametersProvider/Orientation.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace Magento\AdobeStockClient\Model\SearchParametersProvider;
 
+use AdobeStock\Api\Exception\StockApi;
 use AdobeStock\Api\Models\SearchParameters;
 use Magento\AdobeStockClient\Model\SearchParameterProviderInterface;
 use Magento\Framework\Api\SearchCriteriaInterface;
@@ -19,7 +20,7 @@ class Orientation implements SearchParameterProviderInterface
 {
     /**
      * @inheritdoc
-     * @throws \AdobeStock\Api\Exception\StockApi
+     * @throws StockApi
      */
     public function apply(SearchCriteriaInterface $searchCriteria, SearchParameters $searchParams): SearchParameters
     {

--- a/AdobeStockClient/Model/SearchParametersProvider/Orientation.php
+++ b/AdobeStockClient/Model/SearchParametersProvider/Orientation.php
@@ -8,7 +8,6 @@ declare(strict_types=1);
 
 namespace Magento\AdobeStockClient\Model\SearchParametersProvider;
 
-use AdobeStock\Api\Exception\StockApi;
 use AdobeStock\Api\Models\SearchParameters;
 use Magento\AdobeStockClient\Model\SearchParameterProviderInterface;
 use Magento\Framework\Api\SearchCriteriaInterface;
@@ -20,7 +19,6 @@ class Orientation implements SearchParameterProviderInterface
 {
     /**
      * @inheritdoc
-     * @throws StockApi
      */
     public function apply(SearchCriteriaInterface $searchCriteria, SearchParameters $searchParams): SearchParameters
     {

--- a/AdobeStockClient/Model/SearchParametersProvider/Pagination.php
+++ b/AdobeStockClient/Model/SearchParametersProvider/Pagination.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace Magento\AdobeStockClient\Model\SearchParametersProvider;
 
+use AdobeStock\Api\Exception\StockApi;
 use AdobeStock\Api\Models\SearchParameters;
 use Magento\AdobeStockClient\Model\SearchParameterProviderInterface;
 use Magento\Framework\Api\SearchCriteriaInterface;
@@ -19,7 +20,7 @@ class Pagination implements SearchParameterProviderInterface
 {
     /**
      * @inheritdoc
-     * @throws \AdobeStock\Api\Exception\StockApi
+     * @throws StockApi
      */
     public function apply(SearchCriteriaInterface $searchCriteria, SearchParameters $searchParams): SearchParameters
     {

--- a/AdobeStockClient/Model/SearchParametersProvider/Pagination.php
+++ b/AdobeStockClient/Model/SearchParametersProvider/Pagination.php
@@ -8,7 +8,6 @@ declare(strict_types=1);
 
 namespace Magento\AdobeStockClient\Model\SearchParametersProvider;
 
-use AdobeStock\Api\Exception\StockApi;
 use AdobeStock\Api\Models\SearchParameters;
 use Magento\AdobeStockClient\Model\SearchParameterProviderInterface;
 use Magento\Framework\Api\SearchCriteriaInterface;
@@ -20,7 +19,6 @@ class Pagination implements SearchParameterProviderInterface
 {
     /**
      * @inheritdoc
-     * @throws StockApi
      */
     public function apply(SearchCriteriaInterface $searchCriteria, SearchParameters $searchParams): SearchParameters
     {

--- a/AdobeStockClient/Model/SearchParametersProvider/Similar.php
+++ b/AdobeStockClient/Model/SearchParametersProvider/Similar.php
@@ -8,7 +8,6 @@ declare(strict_types=1);
 
 namespace Magento\AdobeStockClient\Model\SearchParametersProvider;
 
-use AdobeStock\Api\Exception\StockApi;
 use AdobeStock\Api\Models\SearchParameters;
 use Magento\AdobeStockClient\Model\SearchParameterProviderInterface;
 use Magento\Framework\Api\SearchCriteriaInterface;
@@ -20,7 +19,6 @@ class Similar implements SearchParameterProviderInterface
 {
     /**
      * @inheritdoc
-     * @throws StockApi
      */
     public function apply(SearchCriteriaInterface $searchCriteria, SearchParameters $searchParams): SearchParameters
     {

--- a/AdobeStockClient/Model/SearchParametersProvider/Similar.php
+++ b/AdobeStockClient/Model/SearchParametersProvider/Similar.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace Magento\AdobeStockClient\Model\SearchParametersProvider;
 
+use AdobeStock\Api\Exception\StockApi;
 use AdobeStock\Api\Models\SearchParameters;
 use Magento\AdobeStockClient\Model\SearchParameterProviderInterface;
 use Magento\Framework\Api\SearchCriteriaInterface;
@@ -19,7 +20,7 @@ class Similar implements SearchParameterProviderInterface
 {
     /**
      * @inheritdoc
-     * @throws \AdobeStock\Api\Exception\StockApi
+     * @throws StockApi
      */
     public function apply(SearchCriteriaInterface $searchCriteria, SearchParameters $searchParams): SearchParameters
     {

--- a/AdobeStockClient/Model/SearchParametersProvider/Sorting.php
+++ b/AdobeStockClient/Model/SearchParametersProvider/Sorting.php
@@ -19,11 +19,7 @@ use Magento\Framework\Api\SearchCriteriaInterface;
 class Sorting implements SearchParameterProviderInterface
 {
     /**
-     * Apply sorting
-     *
-     * @param SearchCriteriaInterface $searchCriteria
-     * @param SearchParameters $searchParams
-     * @return SearchParameters
+     * @inheritdoc
      */
     public function apply(SearchCriteriaInterface $searchCriteria, SearchParameters $searchParams): SearchParameters
     {

--- a/AdobeStockClient/Model/StockFileToDocument.php
+++ b/AdobeStockClient/Model/StockFileToDocument.php
@@ -84,9 +84,9 @@ class StockFileToDocument
      * Convert data to an associate array
      *
      * @param object|array $data
-     * @return array
+     * @return mixed
      */
-    private function toArray($data): array
+    private function toArray($data)
     {
         if (is_object($data) || is_array($data)) {
             $array = [];

--- a/AdobeStockClient/Model/StockFileToDocument.php
+++ b/AdobeStockClient/Model/StockFileToDocument.php
@@ -83,10 +83,10 @@ class StockFileToDocument
     /**
      * Convert data to an associate array
      *
-     * @param mixed $data
+     * @param object|array $data
      * @return array
      */
-    private function toArray($data)
+    private function toArray($data): array
     {
         if (is_object($data) || is_array($data)) {
             $array = [];
@@ -147,7 +147,7 @@ class StockFileToDocument
      * @param Exception $exception
      * @throws IntegrationException
      */
-    private function processException(Phrase $message, Exception $exception)
+    private function processException(Phrase $message, Exception $exception): void
     {
         $this->logger->critical($message->render());
         throw new IntegrationException($message, $exception, $exception->getCode());

--- a/AdobeStockClient/Test/Unit/Model/ClientTest.php
+++ b/AdobeStockClient/Test/Unit/Model/ClientTest.php
@@ -101,7 +101,7 @@ class ClientTest extends TestCase
     private $connectionWrapper;
 
     /**
-     * @var \AdobeStock\Api\Response\License|MockObject $licenseResponse
+     * @var ResponseLicense|MockObject $licenseResponse
      */
     private $licenseResponse;
 

--- a/AdobeStockClient/Test/Unit/Model/ConnectionWrapperTest.php
+++ b/AdobeStockClient/Test/Unit/Model/ConnectionWrapperTest.php
@@ -107,7 +107,7 @@ class ConnectionWrapperTest extends TestCase
     public function testApiKey(): void
     {
         $this->adobeStockMock->expects($this->once())->method('searchFilesInitialize')->willReturnSelf();
-        $nextResponse = new\AdobeStock\Api\Response\SearchFiles();
+        $nextResponse = newSearchFiles();
         $nextResponse->setNbResults(12);
         $this->adobeStockMock->expects($this->exactly(1))
             ->method('getNextResponse')

--- a/AdobeStockClient/Test/Unit/Model/ConnectionWrapperTest.php
+++ b/AdobeStockClient/Test/Unit/Model/ConnectionWrapperTest.php
@@ -107,7 +107,7 @@ class ConnectionWrapperTest extends TestCase
     public function testApiKey(): void
     {
         $this->adobeStockMock->expects($this->once())->method('searchFilesInitialize')->willReturnSelf();
-        $nextResponse = newSearchFiles();
+        $nextResponse = new SearchFiles();
         $nextResponse->setNbResults(12);
         $this->adobeStockMock->expects($this->exactly(1))
             ->method('getNextResponse')

--- a/AdobeStockClient/Test/Unit/Model/SearchParametersProvider/PremiumTest.php
+++ b/AdobeStockClient/Test/Unit/Model/SearchParametersProvider/PremiumTest.php
@@ -21,7 +21,7 @@ use PHPUnit\Framework\TestCase;
  */
 class PremiumTest extends TestCase
 {
-    const FILTER_TYPE = 'premium_price_filter';
+    public const FILTER_TYPE = 'premium_price_filter';
 
     /**
      * @var ObjectManager

--- a/AdobeStockImage/Model/GetImageList.php
+++ b/AdobeStockImage/Model/GetImageList.php
@@ -75,7 +75,7 @@ class GetImageList implements GetImageListInterface
      * @param SearchCriteriaInterface $searchCriteria
      * @return SearchCriteriaInterface
      */
-    private function setDefaultFilters(SearchCriteriaInterface $searchCriteria)
+    private function setDefaultFilters(SearchCriteriaInterface $searchCriteria): SearchCriteriaInterface
     {
         $filterGroups = $searchCriteria->getFilterGroups();
         $appliedFilters = $this->getAppliedFilters($filterGroups);

--- a/AdobeStockImage/Model/GetRelatedImages.php
+++ b/AdobeStockImage/Model/GetRelatedImages.php
@@ -10,6 +10,7 @@ namespace Magento\AdobeStockImage\Model;
 
 use Magento\AdobeStockImageApi\Api\GetImageListInterface;
 use Magento\AdobeStockImageApi\Api\GetRelatedImagesInterface;
+use Magento\Framework\Api\AttributeInterface;
 use Magento\Framework\Api\Search\Document;
 use Magento\Framework\Api\Search\SearchCriteriaBuilder;
 use Magento\Framework\Api\FilterBuilder;
@@ -106,7 +107,7 @@ class GetRelatedImages implements GetRelatedImagesInterface
             /** @var Document $image */
             foreach ($images as $image) {
                 $itemData = [];
-                /** @var \Magento\Framework\Api\AttributeInterface $attribute */
+                /** @var AttributeInterface $attribute */
                 foreach ($image->getCustomAttributes() as $attribute) {
                     if ($attribute->getAttributeCode() === 'thumbnail_240_url') {
                         $itemData['thumbnail_url'] = $attribute->getValue();

--- a/AdobeStockImage/Test/Api/SearchExecuteTest.php
+++ b/AdobeStockImage/Test/Api/SearchExecuteTest.php
@@ -5,6 +5,8 @@
  */
 namespace Magento\AdobeStockImage\Test\Api;
 
+use Magento\Framework\ObjectManagerInterface;
+use Magento\Framework\Webapi\Rest\Request;
 use Magento\TestFramework\TestCase\WebapiAbstract;
 
 /**
@@ -20,19 +22,18 @@ class SearchExecuteTest extends WebapiAbstract
     private const SERVICE_VERSION = 'V1';
 
     /**
-     * @var \Magento\Framework\ObjectManagerInterface
+     * @var ObjectManagerInterface
      */
     protected $objectManager;
 
-    public function testSearchExecute()
+    public function testSearchExecute(): void
     {
-
         $searchCriteria = $this->getSearchData();
 
         $serviceInfo = [
             'rest' => [
                 'resourcePath' => self::RESOURCE_PATH . '?' . http_build_query($searchCriteria),
-                'httpMethod' => \Magento\Framework\Webapi\Rest\Request::HTTP_METHOD_GET,
+                'httpMethod' => Request::HTTP_METHOD_GET,
             ],
             'soap' => [
                 'service' => self::SERVICE_READ_NAME,
@@ -52,7 +53,10 @@ class SearchExecuteTest extends WebapiAbstract
         $this->assertNotNull($response['items'][0]['id']);
     }
 
-    private function getSearchData()
+    /**
+     * @return array
+     */
+    private function getSearchData(): array
     {
         $searchCriteria = [
             'searchCriteria' => [

--- a/AdobeStockImage/Test/Unit/Model/Extract/DocumentToAssetTest.php
+++ b/AdobeStockImage/Test/Unit/Model/Extract/DocumentToAssetTest.php
@@ -141,7 +141,11 @@ class DocumentToAssetTest extends TestCase
         ];
     }
 
-    private function getDocument(array $attributes)
+    /**
+     * @param array $attributes
+     * @return Document|MockObject
+     */
+    private function getDocument(array $attributes): Document
     {
         $document = $this->createMock(Document::class);
 

--- a/AdobeStockImage/Test/Unit/Model/GetImageListTest.php
+++ b/AdobeStockImage/Test/Unit/Model/GetImageListTest.php
@@ -66,7 +66,7 @@ class GetImageListTest extends TestCase
     /**
      * @inheritdoc
      */
-    public function setUp()
+    public function setUp(): void
     {
         $objectManager = new ObjectManager($this);
         $this->getAssetListMock = $this->createMock(GetAssetListInterface::class);
@@ -91,7 +91,7 @@ class GetImageListTest extends TestCase
      * @dataProvider appliedFilterNamesProvider
      * @throws LocalizedException
      */
-    public function testWithDefaultFilters(array $appliedFilterNames)
+    public function testWithDefaultFilters(array $appliedFilterNames): void
     {
         $appliedFilterGroup = $this->getAppliedFilterGroup($appliedFilterNames);
 
@@ -119,7 +119,7 @@ class GetImageListTest extends TestCase
      *
      * @return array
      */
-    public function appliedFilterNamesProvider()
+    public function appliedFilterNamesProvider(): array
     {
         return [
             [
@@ -148,7 +148,7 @@ class GetImageListTest extends TestCase
         $filters = [];
 
         foreach ($appliedFilterNames as $field) {
-            /** @var \Magento\Framework\Api\Filter|MockObject $filter */
+            /** @var Filter|MockObject $filter */
             $filter = $this->createMock(Filter::class);
             $filter->expects($this->once())
                 ->method('getField')

--- a/AdobeStockImage/Test/Unit/Model/GetRelatedImagesTest.php
+++ b/AdobeStockImage/Test/Unit/Model/GetRelatedImagesTest.php
@@ -6,6 +6,10 @@
 
 namespace Magento\AdobeStockImage\Test\Unit\Model;
 
+use Magento\Framework\Api\Filter;
+use Magento\Framework\Api\Search\Document;
+use Magento\Framework\Api\Search\SearchCriteria;
+use Magento\Framework\Api\Search\SearchResultInterface;
 use Magento\Framework\Exception\IntegrationException;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -54,7 +58,7 @@ class GetRelatedImagesTest extends TestCase
     /**
      * @inheritdoc
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->filterBuilder = $this->createMock(FilterBuilder::class);
         $this->logger = $this->createMock(LoggerInterface::class);
@@ -78,7 +82,7 @@ class GetRelatedImagesTest extends TestCase
      * @throws IntegrationException
      * @dataProvider relatedImagesDataProvider
      */
-    public function testExecute($relatedImagesProvider, $expectedResult)
+    public function testExecute($relatedImagesProvider, $expectedResult): void
     {
         $this->filterBuilder->expects($this->any())
             ->method('setField')
@@ -89,7 +93,7 @@ class GetRelatedImagesTest extends TestCase
         $this->filterBuilder->expects($this->any())
             ->method('create')
             ->willReturn(
-                $this->createMock(\Magento\Framework\Api\Filter::class)
+                $this->createMock(Filter::class)
             );
         $this->searchCriteriaBuilder->expects($this->any())
             ->method('addFilter')
@@ -100,9 +104,9 @@ class GetRelatedImagesTest extends TestCase
         $this->searchCriteriaBuilder->expects($this->any())
             ->method('create')
             ->willReturn(
-                $this->createMock(\Magento\Framework\Api\Search\SearchCriteria::class)
+                $this->createMock(SearchCriteria::class)
             );
-        $searchCriteriaMock = $this->createMock(\Magento\Framework\Api\Search\SearchResultInterface::class);
+        $searchCriteriaMock = $this->createMock(SearchResultInterface::class);
         $this->getImageListInterface->expects($this->any())
             ->method('execute')
             ->willReturn($searchCriteriaMock);
@@ -123,7 +127,7 @@ class GetRelatedImagesTest extends TestCase
         return [
             [
                 'relatedImagesProvider' => [
-                    new \Magento\Framework\Api\Search\Document(
+                    new Document(
                         [
                             'id' => 2,
                             'custom_attributes' => [

--- a/AdobeStockImage/Test/Unit/Model/SaveImageTest.php
+++ b/AdobeStockImage/Test/Unit/Model/SaveImageTest.php
@@ -17,6 +17,7 @@ use Magento\AdobeStockImage\Model\Storage\Save as StorageSave;
 use Magento\AdobeStockImage\Model\Storage\Delete as StorageDelete;
 use Magento\Framework\Api\AttributeInterface;
 use Magento\Framework\Api\Search\Document;
+use Magento\Framework\Exception\CouldNotSaveException;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -80,7 +81,7 @@ class SaveImageTest extends TestCase
     /**
      * @inheritdoc
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->storageSave = $this->createMock(StorageSave::class);
         $this->storageDelete = $this->createMock(StorageDelete::class);
@@ -113,10 +114,10 @@ class SaveImageTest extends TestCase
      *
      * @param Document $document
      * @param bool $delete
-     * @throws \Magento\Framework\Exception\CouldNotSaveException
+     * @throws CouldNotSaveException
      * @dataProvider assetProvider
      */
-    public function testExecute(Document $document, bool $delete)
+    public function testExecute(Document $document, bool $delete): void
     {
         if ($delete) {
             $this->storageDelete->expects($this->once())

--- a/AdobeStockImage/Test/Unit/Model/Storage/DeleteTest.php
+++ b/AdobeStockImage/Test/Unit/Model/Storage/DeleteTest.php
@@ -6,12 +6,16 @@
 
 namespace Magento\AdobeStockImage\Test\Unit\Model\Storage;
 
+use Exception;
 use Magento\Framework\App\Filesystem\DirectoryList;
 use Magento\Framework\Exception\CouldNotDeleteException;
+use Magento\Framework\Filesystem;
+use Magento\Framework\Filesystem\Directory\Write;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Magento\AdobeStockImage\Model\Storage\Delete;
+use Psr\Log\LoggerInterface;
 
 /**
  * Test for the storage delete functionality
@@ -19,7 +23,7 @@ use Magento\AdobeStockImage\Model\Storage\Delete;
 class DeleteTest extends TestCase
 {
     /**
-     * @var MockObject | \Magento\Framework\Filesystem\Directory\Write
+     * @var MockObject | Write
      */
     private $mediaDirectoryMock;
 
@@ -29,24 +33,23 @@ class DeleteTest extends TestCase
     private $delete;
 
     /**
-     * @var MockObject | \Magento\Framework\Filesystem
+     * @var MockObject | Filesystem
      */
     public $fileSystemMock;
 
     /**
-     * @var MockObject | \Psr\Log\LoggerInterface
+     * @var MockObject | LoggerInterface
      */
     private $logger;
 
     /**
      * Initialize basic test object
      */
-    public function setUp()
+    public function setUp(): void
     {
-
-        $this->fileSystemMock = $this->createMock(\Magento\Framework\Filesystem::class);
-        $this->logger = $this->createMock(\Psr\Log\LoggerInterface::class);
-        $this->mediaDirectoryMock = $this->createMock(\Magento\Framework\Filesystem\Directory\Write::class);
+        $this->fileSystemMock = $this->createMock(Filesystem::class);
+        $this->logger = $this->createMock(LoggerInterface::class);
+        $this->mediaDirectoryMock = $this->createMock(Write::class);
 
         $this->delete = (new ObjectManager($this))->getObject(
             Delete::class,
@@ -60,7 +63,7 @@ class DeleteTest extends TestCase
     /**
      * Test storage delete action
      */
-    public function testExecute()
+    public function testExecute(): void
     {
         $path = 'path';
 
@@ -85,7 +88,7 @@ class DeleteTest extends TestCase
     /**
      * Assume that delete action will thrown an Exception
      */
-    public function testExceptionOnDeleteExecution()
+    public function testExceptionOnDeleteExecution(): void
     {
         $path = 'path';
 
@@ -102,7 +105,7 @@ class DeleteTest extends TestCase
         $this->mediaDirectoryMock->expects($this->once())
             ->method('delete')
             ->with($path)
-            ->willThrowException(new \Exception());
+            ->willThrowException(new Exception());
 
         $this->expectException(CouldNotDeleteException::class);
         $this->logger->expects($this->once())

--- a/AdobeStockImage/Test/Unit/Model/Storage/SaveTest.php
+++ b/AdobeStockImage/Test/Unit/Model/Storage/SaveTest.php
@@ -6,12 +6,19 @@
 
 namespace Magento\AdobeStockImage\Test\Unit\Model\Storage;
 
+use Exception;
 use Magento\Framework\App\Filesystem\DirectoryList;
 use Magento\Framework\Exception\CouldNotSaveException;
+use Magento\Framework\Filesystem;
+use Magento\Framework\Filesystem\Directory\Write;
+use Magento\Framework\Filesystem\Driver\Https;
+use Magento\Framework\Filesystem\DriverInterface;
+use Magento\Framework\Filesystem\Io\File;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Magento\AdobeStockImage\Model\Storage\Save;
+use Psr\Log\LoggerInterface;
 
 /**
  * Test for the storage save functionality
@@ -19,7 +26,7 @@ use Magento\AdobeStockImage\Model\Storage\Save;
 class SaveTest extends TestCase
 {
     /**
-     * @var MockObject | \Magento\Framework\Filesystem\Directory\Write
+     * @var MockObject | Write
      */
     private $mediaDirectoryMock;
 
@@ -29,36 +36,35 @@ class SaveTest extends TestCase
     private $save;
 
     /**
-     * @var MockObject | \Magento\Framework\Filesystem
+     * @var MockObject | Filesystem
      */
     public $fileSystemMock;
 
     /**
-     * @var MockObject | \Magento\Framework\Filesystem\DriverInterface
+     * @var MockObject | DriverInterface
      */
     private $httpsDriverMock;
 
     /**
-     * @var MockObject | \Magento\Framework\Filesystem\Io\File
+     * @var MockObject | File
      */
     private $fileSystemIoMock;
 
     /**
-     * @var MockObject | \Psr\Log\LoggerInterface
+     * @var MockObject | LoggerInterface
      */
     private $logger;
 
     /**
      * Initialize base test objects
      */
-    public function setUp()
+    public function setUp(): void
     {
-
-        $this->fileSystemMock = $this->createMock(\Magento\Framework\Filesystem::class);
-        $this->httpsDriverMock = $this->createMock(\Magento\Framework\Filesystem\Driver\Https::class);
-        $this->fileSystemIoMock = $this->createMock(\Magento\Framework\Filesystem\Io\File::class);
-        $this->logger = $this->createMock(\Psr\Log\LoggerInterface::class);
-        $this->mediaDirectoryMock = $this->createMock(\Magento\Framework\Filesystem\Directory\Write::class);
+        $this->fileSystemMock = $this->createMock(Filesystem::class);
+        $this->httpsDriverMock = $this->createMock(Https::class);
+        $this->fileSystemIoMock = $this->createMock(File::class);
+        $this->logger = $this->createMock(LoggerInterface::class);
+        $this->mediaDirectoryMock = $this->createMock(Write::class);
 
         $this->save = (new ObjectManager($this))->getObject(
             Save::class,
@@ -74,7 +80,7 @@ class SaveTest extends TestCase
     /**
      * Test image preview save
      */
-    public function testSavePreview()
+    public function testSavePreview(): void
     {
         $imageUrl = 'https://t4.ftcdn.net/jpg/02/72/29/99/240_F_272299924_HjNOJkyyhzFVKRcSQ2TaArR7Ka6nTXRa.jpg';
 
@@ -102,7 +108,7 @@ class SaveTest extends TestCase
     /**
      * Assume that save action will thrown an Exception
      */
-    public function testExceptionOnSaveExecution()
+    public function testExceptionOnSaveExecution(): void
     {
         $imageUrl = 'https://t4.ftcdn.net/jpg/02/72/29/99/240_F_272299924_HjNOJkyyhzFVKRcSQ2TaArR7Ka6nTXRa.jpg';
 
@@ -119,7 +125,7 @@ class SaveTest extends TestCase
         $this->mediaDirectoryMock->expects($this->once())
             ->method('writeFile')
             ->withAnyParameters()
-            ->willThrowException(new \Exception());
+            ->willThrowException(new Exception());
 
         $this->expectException(CouldNotSaveException::class);
         $this->logger->expects($this->once())

--- a/AdobeStockImageAdminUi/Controller/Adminhtml/License/Confirmation.php
+++ b/AdobeStockImageAdminUi/Controller/Adminhtml/License/Confirmation.php
@@ -10,6 +10,7 @@ namespace Magento\AdobeStockImageAdminUi\Controller\Adminhtml\License;
 
 use Magento\AdobeStockClientApi\Api\ClientInterface;
 use Magento\Backend\App\Action;
+use Magento\Framework\Controller\Result\Json;
 use Magento\Framework\Controller\ResultFactory;
 use Psr\Log\LoggerInterface;
 
@@ -31,7 +32,7 @@ class Confirmation extends Action
     /**
      * @see _isAllowed()
      */
-    const ADMIN_RESOURCE = 'Magento_AdobeStockImageAdminUi::license_images';
+    public const ADMIN_RESOURCE = 'Magento_AdobeStockImageAdminUi::license_images';
 
     /**
      * @var ClientInterface
@@ -89,7 +90,7 @@ class Confirmation extends Action
             ];
         }
 
-        /** @var \Magento\Framework\Controller\Result\Json $resultJson */
+        /** @var Json $resultJson */
         $resultJson = $this->resultFactory->create(ResultFactory::TYPE_JSON);
         $resultJson->setHttpResponseCode($responseCode);
         $resultJson->setData($responseContent);

--- a/AdobeStockImageAdminUi/Controller/Adminhtml/License/License.php
+++ b/AdobeStockImageAdminUi/Controller/Adminhtml/License/License.php
@@ -13,6 +13,7 @@ use Magento\AdobeStockClientApi\Api\ClientInterface;
 use Magento\AdobeStockImageApi\Api\SaveImageInterface;
 use Magento\Backend\App\Action;
 use Magento\Framework\Api\AttributeInterface;
+use Magento\Framework\Controller\Result\Json;
 use Magento\Framework\Controller\ResultFactory;
 use Magento\Framework\Exception\NotFoundException;
 use Psr\Log\LoggerInterface;
@@ -41,7 +42,7 @@ class License extends Action
     /**
      * @see _isAllowed()
      */
-    const ADMIN_RESOURCE = 'Magento_AdobeStockImageAdminUi::license_images';
+    public const ADMIN_RESOURCE = 'Magento_AdobeStockImageAdminUi::license_images';
 
     /**
      * @var GetAssetByIdInterface
@@ -146,7 +147,7 @@ class License extends Action
             ];
         }
 
-        /** @var \Magento\Framework\Controller\Result\Json $resultJson */
+        /** @var Json $resultJson */
         $resultJson = $this->resultFactory->create(ResultFactory::TYPE_JSON);
         $resultJson->setHttpResponseCode($responseCode);
         $resultJson->setData($responseContent);

--- a/AdobeStockImageAdminUi/Controller/Adminhtml/License/Quota.php
+++ b/AdobeStockImageAdminUi/Controller/Adminhtml/License/Quota.php
@@ -31,7 +31,7 @@ class Quota extends Action
     /**
      * @see _isAllowed()
      */
-    const ADMIN_RESOURCE = 'Magento_AdobeStockImageAdminUi::license_images';
+    public const ADMIN_RESOURCE = 'Magento_AdobeStockImageAdminUi::license_images';
 
     /**
      * @var ClientInterface

--- a/AdobeStockImageAdminUi/Controller/Adminhtml/Preview/Download.php
+++ b/AdobeStockImageAdminUi/Controller/Adminhtml/Preview/Download.php
@@ -11,6 +11,7 @@ namespace Magento\AdobeStockImageAdminUi\Controller\Adminhtml\Preview;
 use Magento\AdobeStockAssetApi\Api\GetAssetByIdInterface;
 use Magento\AdobeStockImageApi\Api\SaveImageInterface;
 use Magento\Backend\App\Action;
+use Magento\Framework\Controller\Result\Json;
 use Magento\Framework\Controller\ResultFactory;
 use Magento\Framework\Exception\NotFoundException;
 use Psr\Log\LoggerInterface;
@@ -31,7 +32,7 @@ class Download extends Action
     /**
      * @see _isAllowed()
      */
-    const ADMIN_RESOURCE = 'Magento_AdobeStockImageAdminUi::save_preview_images';
+    public const ADMIN_RESOURCE = 'Magento_AdobeStockImageAdminUi::save_preview_images';
 
     /**
      * @var GetAssetByIdInterface
@@ -104,7 +105,7 @@ class Download extends Action
             ];
         }
 
-        /** @var \Magento\Framework\Controller\Result\Json $resultJson */
+        /** @var Json $resultJson */
         $resultJson = $this->resultFactory->create(ResultFactory::TYPE_JSON);
         $resultJson->setHttpResponseCode($responseCode);
         $resultJson->setData($responseContent);

--- a/AdobeStockImageAdminUi/Controller/Adminhtml/Preview/RelatedImages.php
+++ b/AdobeStockImageAdminUi/Controller/Adminhtml/Preview/RelatedImages.php
@@ -21,7 +21,7 @@ class RelatedImages extends Action
     /**
      * @see _isAllowed()
      */
-    const ADMIN_RESOURCE = 'Magento_AdobeStockImageAdminUi::save_preview_images';
+    public const ADMIN_RESOURCE = 'Magento_AdobeStockImageAdminUi::save_preview_images';
 
     /**
      * Successful get related image result code.

--- a/AdobeStockImageAdminUi/Model/Listing/DataProvider.php
+++ b/AdobeStockImageAdminUi/Model/Listing/DataProvider.php
@@ -11,6 +11,7 @@ namespace Magento\AdobeStockImageAdminUi\Model\Listing;
 use Magento\Framework\Api\FilterBuilder;
 use Magento\Framework\Api\Search\ReportingInterface;
 use Magento\Framework\Api\Search\SearchCriteriaBuilder;
+use Magento\Framework\Api\Search\SearchResultInterface;
 use Magento\Framework\App\RequestInterface;
 use Magento\AdobeStockImageApi\Api\GetImageListInterface;
 use Magento\Framework\Exception\LocalizedException;
@@ -69,7 +70,7 @@ class DataProvider extends \Magento\Framework\View\Element\UiComponent\DataProvi
      *
      * @throws LocalizedException
      */
-    public function getSearchResult()
+    public function getSearchResult(): SearchResultInterface
     {
         return $this->getImageList->execute($this->getSearchCriteria());
     }

--- a/AdobeStockImageAdminUi/Model/SignInConfigProvider.php
+++ b/AdobeStockImageAdminUi/Model/SignInConfigProvider.php
@@ -12,6 +12,7 @@ use Magento\AdobeImsApi\Api\UserAuthorizedInterface;
 use Magento\AdobeStockClientApi\Api\ClientInterface;
 use Magento\Framework\Exception\AuthenticationException;
 use Magento\Framework\Exception\AuthorizationException;
+use Magento\Framework\Exception\IntegrationException;
 use Magento\Framework\UrlInterface;
 
 /**
@@ -67,7 +68,7 @@ class SignInConfigProvider implements ConfigProviderInterface
      * Get user quota information
      *
      * @return array
-     * @throws \Magento\Framework\Exception\IntegrationException
+     * @throws IntegrationException
      */
     private function getUserQuota(): array
     {

--- a/AdobeStockImageAdminUi/Plugin/AddSearchButton.php
+++ b/AdobeStockImageAdminUi/Plugin/AddSearchButton.php
@@ -6,7 +6,7 @@
 
 declare(strict_types=1);
 
-namespace Magento\AdobeStockImageAdminUi\Model\Block\Wysiwyg\Images\Content\Plugin;
+namespace Magento\AdobeStockImageAdminUi\Plugin;
 
 use Magento\AdobeStockAssetApi\Api\ConfigInterface;
 use Magento\Backend\Block\Widget\Container;

--- a/AdobeStockImageAdminUi/Test/Unit/Controller/Adminhtml/License/ConfirmationTest.php
+++ b/AdobeStockImageAdminUi/Test/Unit/Controller/Adminhtml/License/ConfirmationTest.php
@@ -8,8 +8,11 @@ declare(strict_types=1);
 
 namespace Magento\AdobeStockImageAdminUi\Test\Unit\Controller\Adminhtml\License;
 
+use Exception;
 use Magento\AdobeStockClientApi\Api\Data\LicenseConfirmationInterface;
 use Magento\AdobeStockImageAdminUi\Controller\Adminhtml\License\Confirmation;
+use Magento\Framework\App\RequestInterface;
+use Magento\Framework\Controller\ResultFactory;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Magento\AdobeStockClientApi\Api\ClientInterface;
@@ -61,16 +64,16 @@ class ConfirmationTest extends TestCase
     /**
      * @inheritdoc
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->clientInterfaceMock = $this->createMock(ClientInterface::class);
         $this->logger = $this->createMock(LoggerInterface::class);
-        $this->context = $this->createMock(\Magento\Backend\App\Action\Context::class);
-        $this->request = $this->createMock(\Magento\Framework\App\RequestInterface::class);
+        $this->context = $this->createMock(ActionContext::class);
+        $this->request = $this->createMock(RequestInterface::class);
         $this->context->expects($this->once())
             ->method('getRequest')
             ->will($this->returnValue($this->request));
-        $this->resultFactory = $this->createMock(\Magento\Framework\Controller\ResultFactory::class);
+        $this->resultFactory = $this->createMock(ResultFactory::class);
         $this->context->expects($this->once())
             ->method('getResultFactory')
             ->willReturn($this->resultFactory);
@@ -97,7 +100,7 @@ class ConfirmationTest extends TestCase
     /**
      * Verify that Quota can be retrieved
      */
-    public function testExecute()
+    public function testExecute(): void
     {
         /** @var LicenseConfirmationInterface|MockObject $confirmation */
         $confirmation = $this->createMock(LicenseConfirmationInterface::class);
@@ -123,7 +126,7 @@ class ConfirmationTest extends TestCase
     /**
      * Verify that exception will throw if quota not available.
      */
-    public function testExecuteWithException()
+    public function testExecuteWithException(): void
     {
         $result = [
             'success' => false,
@@ -131,7 +134,7 @@ class ConfirmationTest extends TestCase
         ];
         $this->clientInterfaceMock->expects($this->once())
             ->method('getLicenseConfirmation')
-            ->willThrowException(new \Exception());
+            ->willThrowException(new Exception());
         $this->jsonObject->expects($this->once())->method('setHttpResponseCode')->with(500);
         $this->jsonObject->expects($this->once())->method('setData')
             ->with($this->equalTo($result));

--- a/AdobeStockImageAdminUi/Test/Unit/Controller/Adminhtml/License/LicenseTest.php
+++ b/AdobeStockImageAdminUi/Test/Unit/Controller/Adminhtml/License/LicenseTest.php
@@ -83,7 +83,7 @@ class LicenseTest extends TestCase
     /**
      * @inheritdoc
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->clientInterfaceMock = $this->createMock(ClientInterface::class);
         $this->loggerMock = $this->createMock(LoggerInterface::class);
@@ -127,7 +127,7 @@ class LicenseTest extends TestCase
     /**
      * Test if the image is licensed and downloaded successfully
      */
-    public function testExecute()
+    public function testExecute(): void
     {
         $result = [
             'success' => true,
@@ -172,7 +172,7 @@ class LicenseTest extends TestCase
      * @param int $responseCode
      * @param array $result
      */
-    public function testNotFoundAsset($exception, int $responseCode, array $result)
+    public function testNotFoundAsset($exception, int $responseCode, array $result): void
     {
         $mediaId = 283415387;
 

--- a/AdobeStockImageAdminUi/Test/Unit/Controller/Adminhtml/License/QuotaTest.php
+++ b/AdobeStockImageAdminUi/Test/Unit/Controller/Adminhtml/License/QuotaTest.php
@@ -60,7 +60,7 @@ class QuotaTest extends TestCase
     {
         $this->clientInterfaceMock = $this->createMock(ClientInterface::class);
         $this->logger = $this->createMock(LoggerInterface::class);
-        $this->context = $this->createMock(\Magento\Backend\App\Action\Context::class);
+        $this->context = $this->createMock(ActionContext::class);
         $this->resultFactory = $this->createMock(\Magento\Framework\Controller\ResultFactory::class);
         $this->context->expects($this->once())
             ->method('getResultFactory')

--- a/AdobeStockImageAdminUi/Test/Unit/Controller/Adminhtml/Preview/DownloadTest.php
+++ b/AdobeStockImageAdminUi/Test/Unit/Controller/Adminhtml/Preview/DownloadTest.php
@@ -16,6 +16,7 @@ use Magento\Framework\Api\AttributeInterface;
 use Magento\Framework\Api\Search\Document;
 use Magento\Framework\App\RequestInterface;
 use Magento\Framework\Controller\Result\Json;
+use Magento\Framework\Controller\ResultFactory;
 use Magento\Framework\Exception\CouldNotSaveException;
 use Magento\Framework\Phrase;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -75,11 +76,11 @@ class DownloadTest extends TestCase
     /**
      * @inheritdoc
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->saveImage = $this->createMock(SaveImageInterface::class);
         $this->logger = $this->createMock(LoggerInterface::class);
-        $this->context = $this->createMock(\Magento\Backend\App\Action\Context::class);
+        $this->context = $this->createMock(ActionContext::class);
         $this->getAssetById = $this->createMock(GetAssetByIdInterface::class);
         $this->document = $this->createMock(Document::class);
 
@@ -109,7 +110,7 @@ class DownloadTest extends TestCase
         $this->context->expects($this->once())
             ->method('getRequest')
             ->willReturn($this->request);
-        $this->resultFactory = $this->createMock(\Magento\Framework\Controller\ResultFactory::class);
+        $this->resultFactory = $this->createMock(ResultFactory::class);
         $this->context->expects($this->once())
             ->method('getResultFactory')
             ->willReturn($this->resultFactory);
@@ -128,7 +129,7 @@ class DownloadTest extends TestCase
     /**
      * Verify that image can be downloaded
      */
-    public function testExecute()
+    public function testExecute(): void
     {
         $result = ['success' => true, 'message' => new Phrase('You have successfully downloaded the image.')];
         $this->jsonObject->expects($this->once())->method('setHttpResponseCode')->with(200);
@@ -140,7 +141,7 @@ class DownloadTest extends TestCase
     /**
      * Verify that exception will throw is image not available.
      */
-    public function testExecuteWithException()
+    public function testExecuteWithException(): void
     {
         $result = ['success' => false, 'message' => new Phrase('An error occurred while image download.')];
         $this->saveImage->method('execute')->willThrowException(new CouldNotSaveException(new Phrase('Error')));

--- a/AdobeStockImageAdminUi/Test/Unit/Controller/Adminhtml/Preview/RelatedImagesTest.php
+++ b/AdobeStockImageAdminUi/Test/Unit/Controller/Adminhtml/Preview/RelatedImagesTest.php
@@ -11,7 +11,9 @@ namespace Magento\AdobeStockImageAdminUi\Test\Unit\Controller\Adminhtml\Preview;
 use Magento\AdobeStockImageAdminUi\Controller\Adminhtml\Preview\RelatedImages;
 use Magento\AdobeStockImageApi\Api\GetRelatedImagesInterface;
 use Magento\Backend\App\Action\Context as ActionContext;
+use Magento\Framework\App\RequestInterface;
 use Magento\Framework\Controller\Result\Json;
+use Magento\Framework\Controller\ResultFactory;
 use Magento\Framework\Exception\IntegrationException;
 use Magento\Framework\Phrase;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -61,16 +63,16 @@ class RelatedImagesTest extends TestCase
     /**
      * @inheritdoc
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->logger = $this->createMock(LoggerInterface::class);
         $this->getRelatedImages = $this->createMock(GetRelatedImagesInterface::class);
-        $this->context = $this->createMock(\Magento\Backend\App\Action\Context::class);
-        $this->request = $this->createMock(\Magento\Framework\App\RequestInterface::class);
+        $this->context = $this->createMock(ActionContext::class);
+        $this->request = $this->createMock(RequestInterface::class);
         $this->context->expects($this->once())
             ->method('getRequest')
             ->will($this->returnValue($this->request));
-        $this->resultFactory = $this->createMock(\Magento\Framework\Controller\ResultFactory::class);
+        $this->resultFactory = $this->createMock(ResultFactory::class);
         $this->context->expects($this->once())
             ->method('getResultFactory')
             ->willReturn($this->resultFactory);
@@ -96,7 +98,7 @@ class RelatedImagesTest extends TestCase
     /**
      * Verify that image relatedImages loaded.
      */
-    public function testExecute()
+    public function testExecute(): void
     {
         $relatedImages = [
             'same_model' => [
@@ -129,7 +131,7 @@ class RelatedImagesTest extends TestCase
     /**
      * Verify that image relatedImages with exception
      */
-    public function testExecuteWithException()
+    public function testExecuteWithException(): void
     {
         $result = [
             'success' => false,

--- a/AdobeStockImageAdminUi/Test/Unit/Model/Block/Wysiwyg/Images/Content/Plugin/AddSearchButtonTest.php
+++ b/AdobeStockImageAdminUi/Test/Unit/Model/Block/Wysiwyg/Images/Content/Plugin/AddSearchButtonTest.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 namespace Magento\AdobeStockImageAdminUi\Test\Unit\Model\Block\Wysiwyg\Images\Content\Plugin;
 
 use Magento\AdobeStockAssetApi\Api\ConfigInterface;
-use Magento\AdobeStockImageAdminUi\Model\Block\Wysiwyg\Images\Content\Plugin\AddSearchButton;
+use Magento\AdobeStockImageAdminUi\Plugin\AddSearchButton;
 use Magento\Backend\Block\Widget\Container;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Magento\Framework\View\LayoutInterface;

--- a/AdobeStockImageAdminUi/Test/Unit/Model/SignInConfigProviderTest.php
+++ b/AdobeStockImageAdminUi/Test/Unit/Model/SignInConfigProviderTest.php
@@ -52,7 +52,7 @@ class SignInConfigProviderTest extends TestCase
     /**
      * Set Up
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->clientInterfaceMock = $this->createMock(ClientInterface::class);
         $this->userAuthorizedMock = $this->createMock(UserAuthorizedInterface::class);
@@ -74,7 +74,7 @@ class SignInConfigProviderTest extends TestCase
      * @param bool $userIsAuthorized
      * @param array $userQuota
      */
-    public function testGettingUserQuota(bool $userIsAuthorized, array $userQuota)
+    public function testGettingUserQuota(bool $userIsAuthorized, array $userQuota): void
     {
         $quotaUrl = 'http://site.com/adobe_stock/license/quota';
         $expectedResult = [
@@ -106,7 +106,7 @@ class SignInConfigProviderTest extends TestCase
      * @param $exception
      * @param array $userQuota
      */
-    public function testGettingUserQuotaOnExceptions($exception, array $userQuota)
+    public function testGettingUserQuotaOnExceptions($exception, array $userQuota): void
     {
         $userIsAuthorized = true;
         $quotaUrl = 'http://site.com/adobe_stock/license/quota';

--- a/AdobeStockImageAdminUi/Test/Unit/Ui/Component/Listing/Filter/ColorTest.php
+++ b/AdobeStockImageAdminUi/Test/Unit/Ui/Component/Listing/Filter/ColorTest.php
@@ -10,6 +10,7 @@ namespace Magento\AdobeStockImageAdminUi\Test\Unit\Ui\Component\Listing\Filter;
 use Magento\AdobeStockImageAdminUi\Ui\Component\Listing\Filter\Color;
 use Magento\Framework\Api\Filter;
 use Magento\Framework\Api\FilterBuilder;
+use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\View\Element\UiComponent\ContextInterface;
 use Magento\Framework\View\Element\UiComponentFactory;
 use Magento\Framework\View\Element\UiComponentInterface;
@@ -137,7 +138,7 @@ class ColorTest extends TestCase
      * @dataProvider colorPickerModeProvider
      * @param string|null $colorPickerMode
      * @param string $appliedValue
-     * @throws \Magento\Framework\Exception\LocalizedException
+     * @throws LocalizedException
      */
     public function testPrepare(?string $colorPickerMode, string $appliedValue): void
     {

--- a/AdobeStockImageAdminUi/Ui/Component/Listing/Columns/ContentType/Options.php
+++ b/AdobeStockImageAdminUi/Ui/Component/Listing/Columns/ContentType/Options.php
@@ -8,10 +8,12 @@ declare(strict_types=1);
 
 namespace Magento\AdobeStockImageAdminUi\Ui\Component\Listing\Columns\ContentType;
 
+use Magento\Framework\Data\OptionSourceInterface;
+
 /**
  * Content Type Photo filter options provider
  */
-class Options implements \Magento\Framework\Data\OptionSourceInterface
+class Options implements OptionSourceInterface
 {
     /**
      * Get options

--- a/AdobeStockImageAdminUi/Ui/Component/Listing/Columns/Image.php
+++ b/AdobeStockImageAdminUi/Ui/Component/Listing/Columns/Image.php
@@ -46,7 +46,7 @@ class Image extends Column
     /**
      * @inheritdoc
      */
-    public function prepare()
+    public function prepare(): void
     {
         parent::prepare();
         $this->setData(

--- a/AdobeStockImageAdminUi/Ui/Component/Listing/Columns/ImagePreview.php
+++ b/AdobeStockImageAdminUi/Ui/Component/Listing/Columns/ImagePreview.php
@@ -43,7 +43,7 @@ class ImagePreview extends Column
     /**
      * @inheritdoc
      */
-    public function prepare()
+    public function prepare(): void
     {
         parent::prepare();
         $this->setData(

--- a/AdobeStockImageAdminUi/Ui/Component/Listing/Columns/Isolated/Options.php
+++ b/AdobeStockImageAdminUi/Ui/Component/Listing/Columns/Isolated/Options.php
@@ -8,10 +8,12 @@ declare(strict_types=1);
 
 namespace Magento\AdobeStockImageAdminUi\Ui\Component\Listing\Columns\Isolated;
 
+use Magento\Framework\Data\OptionSourceInterface;
+
 /**
  * Isolated filter options provider
  */
-class Options implements \Magento\Framework\Data\OptionSourceInterface
+class Options implements OptionSourceInterface
 {
     /**
      * Get options

--- a/AdobeStockImageAdminUi/Ui/Component/Listing/Columns/LicensedOverlay.php
+++ b/AdobeStockImageAdminUi/Ui/Component/Listing/Columns/LicensedOverlay.php
@@ -20,7 +20,7 @@ class LicensedOverlay extends Column
      * @param array $dataSource
      * @return array
      */
-    public function prepareDataSource(array $dataSource)
+    public function prepareDataSource(array $dataSource): array
     {
         if (isset($dataSource['data']['items'])) {
             foreach ($dataSource['data']['items'] as & $item) {

--- a/AdobeStockImageAdminUi/Ui/Component/Listing/Columns/Offensive/Options.php
+++ b/AdobeStockImageAdminUi/Ui/Component/Listing/Columns/Offensive/Options.php
@@ -8,10 +8,12 @@ declare(strict_types=1);
 
 namespace Magento\AdobeStockImageAdminUi\Ui\Component\Listing\Columns\Offensive;
 
+use Magento\Framework\Data\OptionSourceInterface;
+
 /**
  * Offensive filter options provider
  */
-class Options implements \Magento\Framework\Data\OptionSourceInterface
+class Options implements OptionSourceInterface
 {
     /**
      * Get options

--- a/AdobeStockImageAdminUi/Ui/Component/Listing/Columns/Orientation/Options.php
+++ b/AdobeStockImageAdminUi/Ui/Component/Listing/Columns/Orientation/Options.php
@@ -8,17 +8,19 @@ declare(strict_types=1);
 
 namespace Magento\AdobeStockImageAdminUi\Ui\Component\Listing\Columns\Orientation;
 
+use Magento\Framework\Data\OptionSourceInterface;
+
 /**
  * Orientation filter options provider
  */
-class Options implements \Magento\Framework\Data\OptionSourceInterface
+class Options implements OptionSourceInterface
 {
     /**
      * Get options
      *
      * @return array
      */
-    public function toOptionArray()
+    public function toOptionArray(): array
     {
         return [
             [

--- a/AdobeStockImageAdminUi/Ui/Component/Listing/Columns/PremiumPrice/Options.php
+++ b/AdobeStockImageAdminUi/Ui/Component/Listing/Columns/PremiumPrice/Options.php
@@ -8,10 +8,12 @@ declare(strict_types=1);
 
 namespace Magento\AdobeStockImageAdminUi\Ui\Component\Listing\Columns\PremiumPrice;
 
+use Magento\Framework\Data\OptionSourceInterface;
+
 /**
  * Pricing filter options provider
  */
-class Options implements \Magento\Framework\Data\OptionSourceInterface
+class Options implements OptionSourceInterface
 {
     /**
      * Get options

--- a/AdobeStockImageAdminUi/Ui/Component/Listing/Filter/Checkbox.php
+++ b/AdobeStockImageAdminUi/Ui/Component/Listing/Filter/Checkbox.php
@@ -15,7 +15,7 @@ use Magento\Ui\Component\Filters\Type\AbstractFilter;
  */
 class Checkbox extends AbstractFilter
 {
-    const NAME = 'filter_input';
+    public const NAME = 'filter_input';
 
     /**
      * Prepare component configuration

--- a/AdobeStockImageAdminUi/Ui/Component/Listing/Filter/Color.php
+++ b/AdobeStockImageAdminUi/Ui/Component/Listing/Filter/Color.php
@@ -24,7 +24,7 @@ use Magento\Ui\Component\Filters\Type\Input;
  */
 class Color extends AbstractFilter
 {
-    const NAME = 'filter_input';
+    public const NAME = 'filter_input';
 
     /**
      * Wrapped component

--- a/AdobeStockImageAdminUi/etc/adminhtml/di.xml
+++ b/AdobeStockImageAdminUi/etc/adminhtml/di.xml
@@ -7,6 +7,6 @@
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
     <type name="Magento\Cms\Block\Adminhtml\Wysiwyg\Images\Content">
-        <plugin name="add_search_button" type="Magento\AdobeStockImageAdminUi\Model\Block\Wysiwyg\Images\Content\Plugin\AddSearchButton"/>
+        <plugin name="add_search_button" type="Magento\AdobeStockImageAdminUi\Plugin\AddSearchButton"/>
     </type>
 </config>


### PR DESCRIPTION
Code adjustments after architecture review

- \Magento\AdobeIms\Model\UserProfileRepository::ADMIN_USER_ID and \Magento\AdobeIms\Model\UserProfileRepository::ID are the same
- \Magento\AdobeMediaGallery\Model\Asset\Command\GetById::execute doesn’t take into account that table `media_gallery_asset` might have prefix
- The same in \Magento\AdobeMediaGallery\Model\Keyword\Command\GetAssetKeywords::execute, \Magento\AdobeMediaGallery\Model\Keyword\Command\SaveAssetKeywords::execute, \Magento\AdobeMediaGallery\Model\Keyword\Command\SaveAssetLinks::execute, \Magento\AdobeStockAsset\Model\ResourceModel\Asset\LoadByIds::execute
- AdobeStockAsset/Model/AssetRepository.php:124 what the reason to iterate over collection’s items. Why just don’t call $searchResults->setItems($collection->getItems())
- \Magento\AdobeImsApi\Api\Data\UserProfileInterface::setId does it really needed?
- FQCN usage in interfaces and classes
- All constants should have visibility scope
- Plugin \Magento\AdobeStockImageAdminUi\Model\Block\Wysiwyg\Images\Content\Plugin\AddSearchButton doesn’t follow plugins location convention
- Eliminated setters from interfaces
- Eliminated dependency on entity manager
- Added strict types for all methods