### PR TITLE
Resolved issue #623

### DIFF
--- a/AdobeStockImageAdminUi/Test/Mftf/Section/AdobeStockImagePreviewSection.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Section/AdobeStockImagePreviewSection.xml
@@ -18,7 +18,7 @@
         <element name="keywordsTitle" type="text" selector="//*[@id='adobe-stock-images-search-modal']//div[text()='Similar Keywords']"/>
         <element name="keyword" type="block" selector="//div[@class='keyword']//span[text()='{{keyword}}']" parameterized="true"/>
         <element name="confirm" selector="//*[@class='action-primary action-accept']" type="button"/>
-        <element name="generatedImageName" selector="//*[@data-role='promptField']" type="input"/>
+        <element name="generatedImageName" selector="input[data-role='adobe-stock-image-name-field']" type="input"/>
         <element name="moreFromThisModel" selector="//*[@id='model_tab']" type="block"/>
         <element name="moreFromThisModelImages" selector="//div[@aria-labelledby='model_tab']//div[@class='thumbnail']" type="block"/>
         <element name="moreFromThisSeries" selector="//*[@id='series_tab']" type="block"/>

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/actions.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/actions.js
@@ -301,6 +301,8 @@ define([
          * Return configured  prompt with input field.
          */
         getPrompt: function (data) {
+            var regex = new RegExp('[a-zA-Z0-9_-]');
+
             prompt({
                 title: data.title,
                 content:  data.content,
@@ -325,6 +327,17 @@ define([
                 context: this,
                 actions: data.actions,
                 buttons: data.buttons
+            });
+
+            /* Allow only alphanumeric, dash, and underscore on filename input keypress */
+            $('input[data-role="promptField"]').bind('keypress', function (event) {
+                var key = String.fromCharCode(!event.charCode ? event.which : event.charCode);
+
+                if (!regex.test(key)) {
+                    event.preventDefault();
+
+                    return false;
+                }
             });
         },
 

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/actions.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/actions.js
@@ -312,7 +312,7 @@ define([
                 promptContentTmpl: adobePromptContentTmpl,
                 modalClass: 'adobe-stock-save-preview-prompt',
                 validation: true,
-                promptField: '[data-role="promptField"]',
+                promptField: '[data-role="adobe-stock-image-name-field"]',
                 validationRules: ['required-entry'],
                 attributesForm: {
                     novalidate: 'novalidate',
@@ -330,7 +330,7 @@ define([
             });
 
             /* Allow only alphanumeric, dash, and underscore on filename input keypress */
-            $('input[data-role="promptField"]').bind('keypress', function (event) {
+            $('input[data-role="adobe-stock-image-name-field"]').bind('keypress', function (event) {
                 var key = String.fromCharCode(!event.charCode ? event.which : event.charCode);
 
                 if (!regex.test(key)) {

--- a/AdobeStockImageAdminUi/view/adminhtml/web/template/modal/adobe-modal-prompt-content.html
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/template/modal/adobe-modal-prompt-content.html
@@ -14,7 +14,7 @@
             </label>
             <% } %>
             <div class="admin__field-control admin__field-with-image-ext">
-                <input type="text" data-role="promptField" id="prompt-field-<%- data.id %>" class="admin__control-text" <%= inputAttr %>/>
+                <input type="text" data-role="promptField" id="prompt-field-<%- data.id %>" placeholder="Enter the filename (no special characters)" class="admin__control-text" <%= inputAttr %>/>
                 <span class="image-ext">.<%= data.imageExtension %></span>
             </div>
         </div>

--- a/AdobeStockImageAdminUi/view/adminhtml/web/template/modal/adobe-modal-prompt-content.html
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/template/modal/adobe-modal-prompt-content.html
@@ -14,7 +14,7 @@
             </label>
             <% } %>
             <div class="admin__field-control admin__field-with-image-ext">
-                <input type="text" data-role="promptField" id="prompt-field-<%- data.id %>" placeholder="Enter the filename (no special characters)" class="admin__control-text" <%= inputAttr %>/>
+                <input type="text" data-role="adobe-stock-image-name-field" id="prompt-field-<%- data.id %>" placeholder="Enter the filename (no special characters)" class="admin__control-text" <%= inputAttr %>/>
                 <span class="image-ext">.<%= data.imageExtension %></span>
             </div>
         </div>


### PR DESCRIPTION
### Description

- Added a regex check on input keypress and only allow alphanumerics, dashes, and underscores
- Added a placeholder for input field indicating no special characters

### Fixed Issues
-  magento/adobe-stock-integration#623: Disallow entering special characters for image file name

### Manual testing scenarios
1. Login to admin panel
2. Open Magento Media Gallery (i.e. go to Cms -> Pages, edit the page and insert image)
3. Click "Search Adobe Stock" button to open images grid
4. Click on an image to expand the preview
5. Click on "Save Preview" button
6. Enter image file name containing special characters in the opened popup