### PR TITLE
Resolved issue 200

### DIFF
--- a/AdobeStockAdminUi/Test/Mftf/Test/AdminCannotAccessStockImagesWithWrongCredentialsTest.xml
+++ b/AdobeStockAdminUi/Test/Mftf/Test/AdminCannotAccessStockImagesWithWrongCredentialsTest.xml
@@ -31,6 +31,6 @@
         </after>
         <actionGroup ref="AdminOpenMediaGalleryForPageNoEditorActionGroup" stepKey="openMediaGalleryForPage"/>
         <actionGroup ref="AdminAdobeStockOpenPanelFromMediaGalleryActionGroup" stepKey="openAdobeStockPopup"/>
-        <actionGroup ref="AdminAssertFailedAuthenticationMessageActionGroup" stepKey="assertFailedAuthenticationMessage"/>
+        <actionGroup ref="AssertAdminFailedAuthenticationMessageActionGroup" stepKey="assertFailedAuthenticationMessage"/>
     </test>
 </tests>

--- a/AdobeStockImageAdminUi/Test/Mftf/ActionGroup/AdminAdobeStockClickSortActionGroup.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/ActionGroup/AdminAdobeStockClickSortActionGroup.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+<actionGroup name="AdminAdobeStockClickSortActionGroup">
+    <arguments>
+        <argument name="sortName" type="string"/>
+    </arguments>
+    <click selector="{{AdobeStockSection.sortDropdown}}" stepKey="clickOnSortDropdown"/>
+    <click selector="{{AdobeStockSection.sortOption(sortName)}}" stepKey="clickOnSortOption"/>
+    <waitForPageLoad stepKey="waitForLoad"/>
+</actionGroup>
+</actionGroups>

--- a/AdobeStockImageAdminUi/Test/Mftf/Section/AdobeStockSection.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Section/AdobeStockSection.xml
@@ -30,5 +30,7 @@
         <element name="userImageSmall" type="text" selector=".adobe-profile-image-small"/>
         <element name="userNameButton" type="button" selector=".adobe-user-name"/>
         <element name="userSignOut" type="button" selector=".adobe-sign-out-button"/>
+        <element name="sortDropdown" type="button" selector="div[class='masonry-sorting'] select"/>
+        <element name="sortOption" type="button" selector="//div[@class='masonry-sorting'] //option[@value='{{sortOption}}']" parameterized="true"/>
     </section>
 </sections>

--- a/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockGridSortTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockGridSortTest.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+    <test name="AdminAdobeStockGridSortTest">
+        <annotations>
+            <features value="AdobeStockImagePanel"/>
+            <stories value="User is able to sort Adobe Stock Images"/>
+            <title value="User is able to sort Adobe Stock Images"/>
+            <description value="User is able to sort Adobe Stock Images"/>
+            <severity value="CRITICAL"/>
+            <group value="adobe_stock_integration_sort"/>
+            <group value="adobe_stock_integration"/>
+        </annotations>
+        <before>
+            <actionGroup ref="LoginAsAdmin" stepKey="loginAsAdmin"/>
+            <actionGroup ref="AdminOpenMediaGalleryForPageNoEditorActionGroup" stepKey="openMediaGalleryForPage"/>
+            <actionGroup ref="AdminAdobeStockOpenPanelFromMediaGalleryActionGroup" stepKey="openAdobeStockPanel"/>
+        </before>
+        <after>
+            <actionGroup ref="resetAdminDataGridToDefaultView" stepKey="resetAdminDataGridToDefaultView"/>
+            <actionGroup ref="logout" stepKey="logout"/>
+        </after>
+        <actionGroup ref="AdminAdobeStockClickSortActionGroup" stepKey="sortByCreation">
+            <argument name="sortName" value="creation"/>
+        </actionGroup>
+        <grabAttributeFrom selector="{{AdobeStockSection.firstImageInGrid}}" userInput="src"
+                           stepKey="getImageSrcAfterFirstSort"/>
+        <actionGroup ref="AdminAdobeStockClickSortActionGroup" stepKey="sortByPopularity">
+            <argument name="sortName" value="popularity"/>
+        </actionGroup>
+        <grabAttributeFrom selector="{{AdobeStockSection.firstImageInGrid}}" userInput="src"
+                           stepKey="getImageSrcAfterSecondSort"/>
+        <assertNotEquals expected="{$getImageSrcAfterFirstSort}" expectedType="string"
+                         actual="{$getImageSrcAfterSecondSort}" actualType="string"
+                         stepKey="assertImagesDifferentAfterSort"/>
+    </test>
+</tests>


### PR DESCRIPTION
### Description

- Developed an MFTF test to check if sorting works on Adobe Stock Image Grid
- Fixed an issue in a recently merged PR which was throwing an error
  - https://github.com/magento/adobe-stock-integration/pull/607 ActionGroup filename is different from where it is used as `ref`

### Fixed Issues
-  magento/adobe-stock-integration#200: [MFTF]: User sorts the order of images in the grid

### Manual testing scenarios
- `vendor/bin/mftf run:test AdminAdobeStockGridSortTest --remove`