### PR TITLE
Enhancement for AdobeStockImage tests

### DIFF
--- a/AdobeStockImage/Test/Api/SearchExecuteTest.php
+++ b/AdobeStockImage/Test/Api/SearchExecuteTest.php
@@ -47,8 +47,8 @@ class SearchExecuteTest extends WebapiAbstract
         $this->assertArrayHasKey('total_count', $response);
         $this->assertArrayHasKey('items', $response);
 
-        $this->assertTrue($response['total_count'] > 0);
-        $this->assertTrue(count($response['items']) > 0);
+        $this->assertGreaterThan(0, $response['total_count']);
+        $this->assertGreaterThan(0, count($response['items']));
 
         $this->assertNotNull($response['items'][0]['id']);
     }

--- a/AdobeStockImage/Test/Unit/Model/Extract/DocumentToAssetTest.php
+++ b/AdobeStockImage/Test/Unit/Model/Extract/DocumentToAssetTest.php
@@ -48,7 +48,7 @@ class DocumentToAssetTest extends TestCase
     /**
      * Prepare test objects.
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->assetFactory = $this->createMock(AssetInterfaceFactory::class);
         $this->creatorFactory = $this->createMock(CreatorInterfaceFactory::class);

--- a/AdobeStockImage/Test/Unit/Model/GetImageListTest.php
+++ b/AdobeStockImage/Test/Unit/Model/GetImageListTest.php
@@ -66,7 +66,7 @@ class GetImageListTest extends TestCase
     /**
      * @inheritdoc
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         $objectManager = new ObjectManager($this);
         $this->getAssetListMock = $this->createMock(GetAssetListInterface::class);

--- a/AdobeStockImage/Test/Unit/Model/GetRelatedImagesTest.php
+++ b/AdobeStockImage/Test/Unit/Model/GetRelatedImagesTest.php
@@ -58,7 +58,7 @@ class GetRelatedImagesTest extends TestCase
     /**
      * @inheritdoc
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->filterBuilder = $this->createMock(FilterBuilder::class);
         $this->logger = $this->createMock(LoggerInterface::class);

--- a/AdobeStockImage/Test/Unit/Model/SaveImageTest.php
+++ b/AdobeStockImage/Test/Unit/Model/SaveImageTest.php
@@ -81,7 +81,7 @@ class SaveImageTest extends TestCase
     /**
      * @inheritdoc
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->storageSave = $this->createMock(StorageSave::class);
         $this->storageDelete = $this->createMock(StorageDelete::class);
@@ -179,10 +179,10 @@ class SaveImageTest extends TestCase
     /**
      * Get document
      *
-     * @param string $path
+     * @param string|null $path
      * @return Document|MockObject
      */
-    private function getDocument(string $path = null): Document
+    private function getDocument(?string $path = null): Document
     {
         $document = $this->createMock(Document::class);
         $pathAttribute = $this->createMock(AttributeInterface::class);

--- a/AdobeStockImage/Test/Unit/Model/Storage/DeleteTest.php
+++ b/AdobeStockImage/Test/Unit/Model/Storage/DeleteTest.php
@@ -45,7 +45,7 @@ class DeleteTest extends TestCase
     /**
      * Initialize basic test object
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->fileSystemMock = $this->createMock(Filesystem::class);
         $this->logger = $this->createMock(LoggerInterface::class);

--- a/AdobeStockImage/Test/Unit/Model/Storage/SaveTest.php
+++ b/AdobeStockImage/Test/Unit/Model/Storage/SaveTest.php
@@ -58,7 +58,7 @@ class SaveTest extends TestCase
     /**
      * Initialize base test objects
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->fileSystemMock = $this->createMock(Filesystem::class);
         $this->httpsDriverMock = $this->createMock(Https::class);


### PR DESCRIPTION
### Description (*)
Enhance enhance_AdobeStockImage tests.

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios (*)
The Travis CI will be passed.

# Changed log
- The PHPUnit fixtures are about the `protected` `setUp` method, not `public`.
- Using the `assertGreaterThan` to assert the expected value is same as result.