### PR TITLE
Improving the performance for saving the asset links.

### DIFF
--- a/AdobeMediaGallery/Model/Keyword/Command/SaveAssetLinks.php
+++ b/AdobeMediaGallery/Model/Keyword/Command/SaveAssetLinks.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 
 namespace Magento\AdobeMediaGallery\Model\Keyword\Command;
 
+use Exception;
 use Magento\AdobeMediaGalleryApi\Api\Data\KeywordInterface;
 use Magento\AdobeMediaGalleryApi\Model\Keyword\Command\SaveAssetLinksInterface;
 use Magento\Framework\App\ResourceConnection;
@@ -55,15 +56,17 @@ class SaveAssetLinks
                 $values[] = [$assetId, $keywordId];
             }
 
-            /** @var Mysql $connection */
-            $connection = $this->resourceConnection->getConnection();
-            $connection->insertArray(
-                $this->resourceConnection->getTableName(self::TABLE_ASSET_KEYWORD),
-                [self::FIELD_ASSET_ID, self::FIELD_KEYWORD_ID],
-                $values,
-                AdapterInterface::INSERT_IGNORE
-            );
-        } catch (\Exception $exception) {
+            if (!empty($values)) {
+                /** @var Mysql $connection */
+                $connection = $this->resourceConnection->getConnection();
+                $connection->insertArray(
+                    $this->resourceConnection->getTableName(self::TABLE_ASSET_KEYWORD),
+                    [self::FIELD_ASSET_ID, self::FIELD_KEYWORD_ID],
+                    $values,
+                    AdapterInterface::INSERT_IGNORE
+                );
+            }
+        } catch (Exception $exception) {
             $message = __('An error occurred during save asset keyword links: %1', $exception->getMessage());
             throw new CouldNotSaveException($message, $exception);
         }


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
This PR improves the performance for saving the Assert Links, if there are no keywords for that asset. So `insertArray` shouldn't be triggered if no records have to be inserted.

### Fixed Issues (if relevant)

N/A

### Manual testing scenarios (*)
N/A