### PR TITLE
MFTF test tweaks, part two

### DIFF
--- a/AdobeStockImageAdminUi/Test/Mftf/Section/AdobeStockImagePreviewSection.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Section/AdobeStockImagePreviewSection.xml
@@ -10,7 +10,7 @@
     <section name="AdobeStockImagePreviewSection">
         <element name="save" type="block" selector="//button[@class='action-secondary']/span[contains(.,'Save Preview')]"/>
         <element name="image" type="block" selector="//div[@class='masonry-image-preview']//img"/>
-        <element name="navigation" type="block" selector="//div[@class='masonry-image-preview']//div[contains(@class, 'action-buttons')]/button[@class='action-{{type}}']" parameterized="true"/>
+        <element name="navigation" type="button" selector="//div[@class='masonry-image-preview']//div[contains(@class, 'action-buttons')]/button[@class='action-{{type}}']" parameterized="true"/>
         <element name="attribute" type="block" selector="//*[@id='adobe-stock-images-search-modal']//div[@data-role='image-attributes-value']//span[text()='{{type}}']/parent::div//div[@class='value']//span" parameterized="true"/>
         <element name="attributeTitle" type="block" selector="//*[@id='adobe-stock-images-search-modal']//div[@data-role='image-attributes-value']//span[text()='{{title}}']" parameterized="true"/>
         <element name="viewAllKeywords" type="button" selector="//*[@id='adobe-stock-images-search-modal']//span[text()='View all']"/>

--- a/AdobeStockImageAdminUi/Test/Mftf/Section/AdobeStockImagePreviewSection.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Section/AdobeStockImagePreviewSection.xml
@@ -10,7 +10,7 @@
     <section name="AdobeStockImagePreviewSection">
         <element name="save" type="block" selector="//button[@class='action-secondary']/span[contains(.,'Save Preview')]"/>
         <element name="image" type="block" selector="//div[@class='masonry-image-preview']//img"/>
-        <element name="navigation" type="block" selector="//div[@class='masonry-image-preview']//div[@class='action-buttons']/button[@class='action-{{type}}']" parameterized="true"/>
+        <element name="navigation" type="block" selector="//div[@class='masonry-image-preview']//div[contains(@class, 'action-buttons')]/button[@class='action-{{type}}']" parameterized="true"/>
         <element name="attribute" type="block" selector="//*[@id='adobe-stock-images-search-modal']//div[@data-role='image-attributes-value']//span[text()='{{type}}']/parent::div//div[@class='value']//span" parameterized="true"/>
         <element name="attributeTitle" type="block" selector="//*[@id='adobe-stock-images-search-modal']//div[@data-role='image-attributes-value']//span[text()='{{title}}']" parameterized="true"/>
         <element name="viewAllKeywords" type="button" selector="//*[@id='adobe-stock-images-search-modal']//span[text()='View all']"/>

--- a/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockImagePreviewAttributesTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockImagePreviewAttributesTest.xml
@@ -41,20 +41,12 @@
         <actionGroup ref="AssertVisibleImagePreviewAttributesActionGroup" stepKey="verifyAttributeFile">
             <argument name="attributeName" value="File #"/>
         </actionGroup>
-        <grabTextFrom selector="{{AdobeStockImagePreviewSection.attribute('Dimensions')}}" stepKey="getDimensionAttributeValue"/>
-        <grabTextFrom selector="{{AdobeStockImagePreviewSection.attribute('File type')}}" stepKey="getFileTypeAttributeValue"/>
-        <grabTextFrom selector="{{AdobeStockImagePreviewSection.attribute('Category')}}" stepKey="getCategoryAttributeValue"/>
         <grabTextFrom selector="{{AdobeStockImagePreviewSection.attribute('File #')}}" stepKey="getFileAttributeValue"/>
         <click selector="{{AdobeStockImagePreviewSection.navigation('next')}}" stepKey="navigateToNextImage"/>
+        <waitForPageLoad stepKey="waitForNextImageLoad"/>
 
-        <!-- Assert that image attributes changed "-->
-        <assertNotContains actual="$getDimensionAttributeValue"
-                           expected="AdobeStockImagePreviewSection.attribute('Dimensions')" expectedType="string"
-                           stepKey="assertAttributeDimensionChanged"/>
-        <assertNotContains actual="$getDimensionAttributeValue"
-                           expected="AdobeStockImagePreviewSection.attribute('Category')" expectedType="string"
-                           stepKey="assertAttributeCategoryChanged"/>
-        <assertNotContains actual="$getDimensionAttributeValue"
+        <!-- Assert that file # attribute changed "-->
+        <assertNotContains actual="$getFileAttributeValue"
                            expected="AdobeStockImagePreviewSection.attribute('File #')" expectedType="string"
                            stepKey="assertAttributeFileChanged"/>
     </test>

--- a/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockImagePreviewAttributesTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockImagePreviewAttributesTest.xml
@@ -43,7 +43,7 @@
         </actionGroup>
         <grabTextFrom selector="{{AdobeStockImagePreviewSection.attribute('File #')}}" stepKey="getFileAttributeValue"/>
         <click selector="{{AdobeStockImagePreviewSection.navigation('next')}}" stepKey="navigateToNextImage"/>
-        <waitForPageLoad stepKey="waitForNextImageLoad"/>
+        <waitForLoadingMaskToDisappear stepKey="waitForNextImageToLoad"/>
 
         <!-- Assert that file # attribute changed "-->
         <assertNotContains actual="$getFileAttributeValue"

--- a/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockImagePreviewKeywordsSearchTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockImagePreviewKeywordsSearchTest.xml
@@ -26,7 +26,7 @@
             <actionGroup ref="logout" stepKey="logout"/>
         </after>
 
-        <actionGroup ref="AdminSearchImagesOnModalActionGroup" stepKey="searchForPear">
+        <actionGroup ref="AdminSearchImagesOnModalActionGroup" stepKey="searchForInterior">
             <argument name="query" value="Interior"/>
         </actionGroup>
         <actionGroup ref="AdminAdobeStockExpandImagePreviewActionGroup" stepKey="expandImagePreview"/>

--- a/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockImagePreviewKeywordsTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockImagePreviewKeywordsTest.xml
@@ -42,7 +42,9 @@
         <dontSeeElement selector="{{AdobeStockImagePreviewSection.viewAllKeywords}}" stepKey="VerifyViewAllButtonDisappears"/>
         <!-- Verify that keywords closed after navigate to next image -->
         <click selector="{{AdobeStockImagePreviewSection.navigation('next')}}" stepKey="navigateToNextImage"/>
+        <waitForLoadingMaskToDisappear stepKey="waitForNextImageToLoad"/>
         <click selector="{{AdobeStockImagePreviewSection.navigation('previous')}}" stepKey="navigateToPreviousImage"/>
+        <waitForLoadingMaskToDisappear stepKey="waitForPreviousImageToLoad"/>
         <actionGroup ref="AssertNumberOfKeywordsInImagePreviewActionGroup" stepKey="verifyKeywordsCountAfterHide">
             <argument name="keywordsNumber" value="5"/>
         </actionGroup>

--- a/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockImagesPreviewNavigationTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockImagesPreviewNavigationTest.xml
@@ -29,13 +29,15 @@
         <actionGroup ref="AdminAdobeStockExpandImagePreviewActionGroup" stepKey="expandImagePreview"/>
         <grabAttributeFrom selector="{{AdobeStockImagePreviewSection.image}}" userInput="src" stepKey="getCurrentImageUrl"/>
         <click selector="{{AdobeStockImagePreviewSection.navigation('next')}}" stepKey="NavigateToNextImage"/>
+        <waitForLoadingMaskToDisappear stepKey="waitForNextImageToLoad"/>
         <!-- Assert that User switched to the next image "-->
         <dontSeeElement selector="{{AdobeStockSection.imageSrc($getCurrentImageUrl)}}"
                         stepKey="checkImageNotSameAfterWeSwitchToNextImage"/>
         <grabAttributeFrom selector="{{AdobeStockImagePreviewSection.image}}" userInput="src"
                            stepKey="getImageUrlAfterSwitchedToNextImage"/>
-        <!-- Assert that User switched to the previous image "-->
         <click selector="{{AdobeStockImagePreviewSection.navigation('previous')}}" stepKey="NavigateToPreviousImage"/>
+        <waitForLoadingMaskToDisappear stepKey="waitForPreviousImageToLoad"/>
+        <!-- Assert that User switched to the previous image "-->
         <dontSeeElement selector="{{AdobeStockSection.imageSrc($getImageUrlAfterSwitchedToNextImage)}}"
                         stepKey="checkImageNotSameAfterWeSwitchToPreviousImage"/>
         <!-- Assert that User can close preview "-->


### PR DESCRIPTION
### Description (*)

- Fixing up ImagePreviewAttributesTest: fixed xpath selector for image preview navigation buttons, removed inspecting dimensions and category from test (as consecutive images may actually end up being same size and category). Instead only assert on File #, which is guaranteed to be unique. Also added a wait for load after using navigation element.
- update stepkey to reflect actual search term used
- fixing AdminAdobeStockImagesPreviewNavigationTest: the image preview navigation controls are buttons, so the elements should be defined as buttons. also wait for the loading mask to disappear after using next/previous navigation in image preview section.
- while were at it, might as well ensure we wait for the loading mask to disappear every time we interact with image preview navigation controls