### PR TITLE
Made test's <after/> node stateless

### DIFF
--- a/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockSignedInCreditsVisibleTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockSignedInCreditsVisibleTest.xml
@@ -28,10 +28,12 @@
             <actionGroup ref="AdminAdobeStockAssertUserLoggedActionGroup" stepKey="assertUserLoggedIn"/>
         </before>
         <after>
-            <actionGroup ref="AdminAdobeStockUserSignOutActionGroup" stepKey="LogOut"/>
+            <actionGroup ref="AdminOpenMediaGalleryForPageNoEditorActionGroup" stepKey="openMediaGalleryForPage"/>
+            <actionGroup ref="AdminAdobeStockOpenPanelFromMediaGalleryActionGroup" stepKey="openAdobeStockPanel"/>
+            <actionGroup ref="AdminAdobeStockUserSignOutActionGroup" stepKey="adobeLogout"/>
             <actionGroup ref="AdminAdobeStockAssertUserNotLoggedActionGroup" stepKey="assertUserNotLogged"/>
             <actionGroup ref="resetAdminDataGridToDefaultView" stepKey="resetAdminDataGridToDefaultView"/>
-            <actionGroup ref="logout" stepKey="logout"/>
+            <actionGroup ref="logout" stepKey="adminLogout"/>
         </after>
         <actionGroup ref="AdminAdobeStockSignedInViewCreditsActionGroup" stepKey="viewCreditsInfo"/>
     </test>


### PR DESCRIPTION
### Description

Made `<after/>` node stateless 

### Manual testing scenarios

No matter where `AdminAdobeStockSignedInCreditsVisibleTest` fails, the `<after/>` node won't fail as it doesn't depend on where the test failed.