### PR TITLE
Close image preview on pagination change

### DIFF
--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/images-grid-sizes.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/images-grid-sizes.js
@@ -14,6 +14,11 @@ define([
             maxSize: 64
         },
 
+        exports: {
+            value: '${ $.provider }:params.paging.page',
+            options: '${ $.provider }:params.paging.options'
+        },
+
         sizes: {
             '32': {
                 value: 32,

--- a/AdobeUi/view/adminhtml/web/js/components/grid/column/image-preview.js
+++ b/AdobeUi/view/adminhtml/web/js/components/grid/column/image-preview.js
@@ -27,7 +27,8 @@ define([
             },
             listens: {
                 '${ $.provider }:params.filters': 'hide',
-                '${ $.provider }:params.search': 'hide'
+                '${ $.provider }:params.search': 'hide',
+                '${ $.provider }:params.paging': 'hide'
             },
             exports: {
                 height: '${ $.parentName }.thumbnail_url:previewHeight'


### PR DESCRIPTION
### Description (*)
This PR fixes an issue when user tries to change the grid's page or number of items per page with the image preview opened.

### Fixed Issues (if relevant)
1. #642 : Error when switching to the next listing page with preview opened

### Manual testing scenarios (*)
1. Login to admin panel
2. Open Magento Media Gallery (i.e. go to Cms -> Pages, edit the page and insert image)
3. Click "Search Adobe Stock" button to open images grid
4. Click on an image to expand the preview
5. Switch listing page (Next, previous or manual entry)

The image preview should be closed and the page change is being performed without errors