### PR TITLE
Added image preview responsiveness

### DIFF
--- a/AdobeStockImageAdminUi/view/adminhtml/web/css/source/_module.less
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/css/source/_module.less
@@ -1,7 +1,7 @@
-// /**
-//  * Copyright © Magento, Inc. All rights reserved.
-//  * See COPYING.txt for license details.
-//  */
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
 
 & when (@media-common = true) {
     .adobe-stock-images-search-modal-content {
@@ -30,6 +30,12 @@
 
                 .container {
                     padding-top: 0;
+                    .preview-buttons {
+                        /* Align image preview actions uniformly to the right edge */
+                        .action-previous, .action-next, .action-close {
+                            padding: 30px 0 30px 30px;
+                        }
+                    }
                 }
             }
         }
@@ -302,6 +308,25 @@
 
             .admin__field-tooltip {
                 margin: -5px 0 0 5px;
+            }
+        }
+    }
+}
+
+@media (max-width: 1024px) {
+    .adobe-stock-images-search-modal-content {
+        .masonry-image-preview {
+            .container {
+                margin: 0 60px;
+                .preview-row-content {
+                    .info {
+                        .actions {
+                            .action-secondary {
+                                margin-bottom: 8px;
+                            }
+                        }
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
### Description

-  Added responsiveness for image preview section although less media query doesn't work for `adminhtml`; hence, reverted back to CSS. It works properly on iPad view. Do let me know if any change is required.

### Fixed Issues
1. magento/adobe-stock-integration#658: [CSS] Image preview is overflowing the slide panel at the left side on iPad

### Manual testing scenarios
1. Open image preview section in iPad or browser width less than 1024px