### PR TITLE
Resolved issue 641

### DIFF
--- a/AdobeStockImageAdminUi/view/adminhtml/web/css/source/_module.less
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/css/source/_module.less
@@ -18,7 +18,7 @@
             }
 
             &-overlay {
-                top: 110px;
+                bottom: 14px;
                 right: 0;
                 background-color: #507DC8;
                 opacity: 1;


### PR DESCRIPTION
### Description

- Used `bottom` instead of `top` CSS property, to always position image with respect to the bottom since the label should appear on the **bottom** right.

### Fixed Issues
-  magento/adobe-stock-integration#641: The licensed label is shown under the image if the row of images has small height

### Manual testing scenarios
-  Open a wide image in the Adobe Stock grid (292736798 is the ID of the pumpkin image used in the issue page)