### PR TITLE
Revert "Resolved issue 641"

### DIFF
--- a/AdobeStockImageAdminUi/view/adminhtml/web/css/source/_module.less
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/css/source/_module.less
@@ -18,7 +18,7 @@
             }
 
             &-overlay {
-                bottom: 14px;
+                top: 110px;
                 right: 0;
                 background-color: #507DC8;
                 opacity: 1;


### PR DESCRIPTION
Reverts magento/adobe-stock-integration#663

The solution causes a bug that makes license labels for the row to disappear when image preview is opened