### PR TITLE
making mftf test annotations consistent

### DIFF
--- a/AdobeStockAdminUi/Test/Mftf/Test/AdminAdobeStockConfigTest.xml
+++ b/AdobeStockAdminUi/Test/Mftf/Test/AdminAdobeStockConfigTest.xml
@@ -11,8 +11,10 @@
     <test name="AdminAdobeStockConfigTest">
         <annotations>
             <features value="AdobeStockConfiguration"/>
-            <stories value="Configure Adobe Stock Integration via the Admin"/>
-            <title value="Admin should be able to configure Adobe Stock Integration"/>
+            <stories value="[Story #6] User configures Adobe Stock integration"/>
+            <useCaseId value="https://github.com/magento/adobe-stock-integration/issues/29"/>
+            <title value="User configures Adobe Stock Integration"/>
+            <testCaseId value="https://app.hiptest.com/projects/131313/test-plan/folders/943908/scenarios/3216034"/>
             <description value="Admin should be able to configure Adobe Stock Integration"/>
             <severity value="CRITICAL"/>
             <group value="adobe_stock_integration_general"/>

--- a/AdobeStockAdminUi/Test/Mftf/Test/AdminCannotAccessStockImagesWithWrongCredentialsTest.xml
+++ b/AdobeStockAdminUi/Test/Mftf/Test/AdminCannotAccessStockImagesWithWrongCredentialsTest.xml
@@ -11,11 +11,13 @@
     <test name="AdminCannotAccessStockImagesWithWrongCredentialsTest">
         <annotations>
             <features value="AdobeStockConfiguration"/>
-            <stories value="Verify Adobe Stock Integration accessibility with wrong credentials"/>
-            <title value="Admin should see the authentication message error if provided Adobe credentials are wrong"/>
+            <stories value="[Story #6] User configures Adobe Stock integration"/>
+            <useCaseId value="https://github.com/magento/adobe-stock-integration/issues/29"/>
+            <title value="User sees error if configures Adobe Stock Integration with wrong keys"/>
+            <testCaseId value="https://app.hiptest.com/projects/131313/test-plan/folders/943908/scenarios/3819049"/>
             <description value="Admin should see the authentication message error if provided Adobe credentials are wrong"/>
-            <severity value="CRITICAL"/>
-            <group value="adobe_stock_integration_general"/>
+            <severity value="MAJOR"/>
+            <group value="adobe_stock_integration"/>
         </annotations>
         <before>
             <actionGroup ref="LoginActionGroup" stepKey="login"/>

--- a/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockACLTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockACLTest.xml
@@ -10,10 +10,13 @@
        xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
     <test name="AdminAdobeStockACLTest">
         <annotations>
-            <stories value="Controls access to Adobe Stock images from Admin Panel in ACL"/>
-            <title value="Admin should be able to controls access to Adobe Stock images from Admin Panel in ACL"/>
+            <features value="AdobeStockImagePanel"/>
+            <stories value="[Story #19] User controls access to Adobe Stock images from Admin Panel in ACL"/>
+            <useCaseId value="https://github.com/magento/adobe-stock-integration/issues/42"/>
+            <title value="User controls access to Adobe Stock images from Admin Panel in ACL"/>
             <description value="Test to cover scenario: User controls access to Adobe Stock images from Admin Panel in ACL"/>
-            <severity value="CRITICAL"/>
+            <testCaseId value="https://app.hiptest.com/projects/131313/test-plan/folders/943908/scenarios/3218882"/>
+            <severity value="MAJOR"/>
             <group value="adobe_stock_integration_general"/>
             <group value="adobe_stock_integration"/>
         </annotations>

--- a/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockColorFilterTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockColorFilterTest.xml
@@ -11,10 +11,12 @@
     <test name="AdminAdobeStockColorFilterTest">
         <annotations>
             <features value="AdobeStockImagePanel"/>
-            <stories value="User filters images by image color"/>
-            <title value="Admin should be able to filters images by image color"/>
-            <description value="Admin should be able to filters images by image color"/>
-            <severity value="CRITICAL"/>
+            <stories value="[Story #14] User filters images by image color"/>
+            <useCaseId value="https://github.com/magento/adobe-stock-integration/issues/37"/>
+            <title value="User filters images by image color"/>
+            <description value="Admin should be able to filter images by image color"/>
+            <testCaseId value="https://app.hiptest.com/projects/131313/test-plan/folders/943908/scenarios/3218841"/>
+            <severity value="MAJOR"/>
             <group value="adobe_stock_integration_filters"/>
             <group value="adobe_stock_integration"/>
         </annotations>

--- a/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockGridFiltersTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockGridFiltersTest.xml
@@ -11,10 +11,12 @@
     <test name="AdminAdobeStockGridFiltersTest">
         <annotations>
             <features value="AdobeStockImagePanel"/>
-            <stories value="User has access to Adobe Stock Images filters"/>
-            <title value="User has access to Adobe Stock Images filters"/>
-            <description value="User is able to see the available adobe images filters"/>
-            <severity value="CRITICAL"/>
+            <stories value="[Story #1] User accesses stock images from Magento Admin"/>
+            <useCaseId value="https://github.com/magento/adobe-stock-integration/issues/22"/>
+            <title value="User has access to filters"/>
+            <description value="User is able to see the available Adobe Stock images filters"/>
+            <testCaseId value="https://app.hiptest.com/projects/131313/test-plan/folders/943908/scenarios/3222613"/>
+            <severity value="BLOCKER"/>
             <group value="adobe_stock_integration_filters"/>
             <group value="adobe_stock_integration"/>
         </annotations>

--- a/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockGridSortTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockGridSortTest.xml
@@ -11,10 +11,12 @@
     <test name="AdminAdobeStockGridSortTest">
         <annotations>
             <features value="AdobeStockImagePanel"/>
-            <stories value="User is able to sort Adobe Stock Images"/>
-            <title value="User is able to sort Adobe Stock Images"/>
-            <description value="User is able to sort Adobe Stock Images"/>
-            <severity value="CRITICAL"/>
+            <stories value="[Story #16] User sorts the order of images in the grid"/>
+            <useCaseId value="https://github.com/magento/adobe-stock-integration/issues/39"/>
+            <title value="User sorts the order of images in the grid"/>
+            <description value="User is able to sort Adobe Stock images"/>
+            <testCaseId value="https://app.hiptest.com/projects/131313/test-plan/folders/943908/scenarios/3218851"/>
+            <severity value="MAJOR"/>
             <group value="adobe_stock_integration_sort"/>
             <group value="adobe_stock_integration"/>
         </annotations>

--- a/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockGridTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockGridTest.xml
@@ -10,10 +10,12 @@
     <test name="AdminAdobeStockGridTest">
         <annotations>
             <features value="AdobeStockImagePanel"/>
-            <stories value="Basic Adobe Stock grid controls"/>
-            <title value="Basic Adobe Stock grid controls"/>
-            <description value="Basic Adobe Stock grid controls"/>
-            <severity value="CRITICAL"/>
+            <stories value="[Story #2] User searches Adobe Stock images by keywords"/>
+            <useCaseId value="https://github.com/magento/adobe-stock-integration/issues/23"/>
+            <title value="User pages through Stock image results"/>
+            <testCaseId value="https://app.hiptest.com/projects/131313/test-plan/folders/943908/scenarios/3819033"/>
+            <description value="User can use pagination controls to page to the next page of results"/>
+            <severity value="BLOCKER"/>
             <group value="adobe_stock_integration_grid"/>
             <group value="adobe_stock_integration"/>
         </annotations>

--- a/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockImagePreviewAttributesTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockImagePreviewAttributesTest.xml
@@ -10,10 +10,12 @@
        xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
     <test name="AdminAdobeStockImagePreviewAttributesTest">
         <annotations>
-            <stories value="Admin User see images preview attributes"/>
-            <title value="Admin should be able to see images attributes in the image preview"/>
+            <features value="AdobeStockImagePanel"/>
+            <stories value="[Story #3] User views the image details"/>
+            <useCaseId value="https://github.com/magento/adobe-stock-integration/issues/24"/>
+            <title value="User views the image details"/>
             <description value="Admin should be able to see images attributes in the image preview"/>
-            <severity value="CRITICAL"/>
+            <severity value="BLOCKER"/>
             <group value="adobe_stock_integration_preview"/>
             <group value="adobe_stock_integration"/>
         </annotations>

--- a/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockImagePreviewKeywordsSearchTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockImagePreviewKeywordsSearchTest.xml
@@ -9,8 +9,10 @@
 <tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
     <test name="AdminAdobeStockImagePreviewKeywordsSearchTest">
         <annotations>
-            <stories value="Cover scenario: User searches images by keywords in image preview"/>
-            <title value="Admin should be able to searches images by keywords in image preview"/>
+            <features value="AdobeStockImagePanel"/>
+            <stories value="[Story #33] User searches for an image by its keyword tag"/>
+            <useCaseId value="https://github.com/magento/adobe-stock-integration/issues/348"/>
+            <title value="User searches for an image by its keyword tag"/>
             <description value="User searches images by clicking on keywords in image preview"/>
             <severity value="CRITICAL"/>
             <group value="adobe_stock_integration_filters"/>

--- a/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockImagePreviewKeywordsTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockImagePreviewKeywordsTest.xml
@@ -10,10 +10,13 @@
        xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
     <test name="AdminAdobeStockImagePreviewKeywordsTest">
         <annotations>
-            <stories value="Admin User Sees keywords in the image preview "/>
-            <title value="Admin should be able to see keywords in the image preview"/>
+            <features value="AdobeStockImagePanel"/>
+            <stories value="[Story #34] User sees current image tags"/>
+            <useCaseId value="https://github.com/magento/adobe-stock-integration/issues/349"/>
+            <title value="User sees current image tags"/>
+            <testCaseId value="https://app.hiptest.com/projects/131313/test-plan/folders/1051731/scenarios/3579522"/>
             <description value="Admin should be able to able to see keywords in the image preview"/>
-            <severity value="CRITICAL"/>
+            <severity value="MAJOR"/>
             <group value="adobe_stock_integration_preview"/>
             <group value="adobe_stock_integration"/>
         </annotations>

--- a/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockImagePreviewSameModelSeeMoreTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockImagePreviewSameModelSeeMoreTest.xml
@@ -9,8 +9,10 @@
 <tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
     <test name="AdminAdobeStockImagePreviewSameModelSeeMoreTest">
         <annotations>
-            <stories value="Cover scenario: User sees images with the same model as the currently viewed one, then clicks the see more button to filter images"/>
-            <title value="Admin should be able to see grid filtered by images with the same model"/>
+            <features value="AdobeStockImagePanel"/>
+            <stories value="[Story #32] User searches for images with the same model as the currently viewed one"/>
+            <useCaseId value="https://github.com/magento/adobe-stock-integration/issues/347"/>
+            <title value="User searches for images from the same model as the currently viewed one"/>
             <description value="User sees images with the same model filtered grid"/>
             <severity value="CRITICAL"/>
             <group value="adobe_stock_integration_preview"/>

--- a/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockImagePreviewSameModelTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockImagePreviewSameModelTest.xml
@@ -9,8 +9,11 @@
 <tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
     <test name="AdminAdobeStockImagePreviewSameModelTest">
         <annotations>
-            <stories value="Cover scenario: User sees images with the same model as the currently viewed one"/>
-            <title value="Admin should be able to see images with same model"/>
+            <features value="AdobeStockImagePanel"/>
+            <stories value="[Story #30] User sees images with the same model as the currently viewed one"/>
+            <useCaseId value="https://github.com/magento/adobe-stock-integration/issues/345"/>
+            <title value="User sees images with the same model as the currently viewed one"/>
+            <testCaseId value="https://app.hiptest.com/projects/131313/test-plan/folders/1051731/scenarios/3579511"/>
             <description value="User sees images with the same model"/>
             <severity value="CRITICAL"/>
             <group value="adobe_stock_integration_preview"/>

--- a/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockImagePreviewSameSeriesTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockImagePreviewSameSeriesTest.xml
@@ -9,8 +9,11 @@
 <tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
     <test name="AdminAdobeStockImagePreviewSameSeriesTest">
         <annotations>
-            <stories value="Cover scenario: User sees images with the same series as the currently viewed one"/>
-            <title value="Admin should be able to see images with same series"/>
+            <features value="AdobeStockImagePanel"/>
+            <stories value="[Story #29] User sees images from the same series as the currently viewed image"/>
+            <useCaseId value="https://github.com/magento/adobe-stock-integration/issues/324"/>
+            <title value="User sees images from the same series as the currently viewed image"/>
+            <testCaseId value="https://app.hiptest.com/projects/131313/test-plan/folders/1051731/scenarios/3579509"/>
             <description value="User sees images with the same series"/>
             <severity value="CRITICAL"/>
             <group value="adobe_stock_integration_preview"/>

--- a/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockImagesPreviewNavigationTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockImagesPreviewNavigationTest.xml
@@ -10,10 +10,13 @@
        xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
     <test name="AdminAdobeStockImagesPreviewNavigationTest">
         <annotations>
-            <stories value="User navigates to next previous image"/>
-            <title value="Admin should be able to navigates to next previous image from the currently viewed"/>
-            <description value="Admin should be able to navigates to next previous image from the currently viewed"/>
-            <severity value="CRITICAL"/>
+            <features value="AdobeStockImagePanel"/>
+            <stories value="[Story #17] User navigates to next previous image from the currently viewed"/>
+            <useCaseId value="https://github.com/magento/adobe-stock-integration/issues/40"/>
+            <title value="User navigates to next previous image from the currently viewed"/>
+            <testCaseId value="https://app.hiptest.com/projects/131313/test-plan/folders/943908/scenarios/3218871"/>
+            <description value="Admin should be able to navigate to next / previous image from the currently viewed preview image"/>
+            <severity value="BLOCKER"/>
             <group value="adobe_stock_integration_preview"/>
             <group value="adobe_stock_integration"/>
         </annotations>

--- a/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockIsolatedFilterTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockIsolatedFilterTest.xml
@@ -9,9 +9,11 @@
 <tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
     <test name="AdminAdobeStockIsolatedFilterTest">
         <annotations>
-            <title value="Isolated Images Filter Test"/>
-            <stories value="User filters images in Adobe Stock image grid by isolated images"/>
             <features value="AdobeStockImagePanel"/>
+            <title value="[Story #13] User filters isolated image only"/>
+            <useCaseId value="https://github.com/magento/adobe-stock-integration/issues/36"/>
+            <stories value="User filters isolated image only"/>
+            <testCaseId value="https://app.hiptest.com/projects/131313/test-plan/folders/943908/scenarios/3218832"/>
             <description value="Admin should be able to filter images by Isolated images"/>
             <severity value="CRITICAL"/>
             <group value="adobe_stock_integration_filters"/>

--- a/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockListingStateTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockListingStateTest.xml
@@ -10,10 +10,13 @@
        xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
     <test name="AdminAdobeStockListingStateTest">
         <annotations>
+            <features value="AdobeStockImagePanel"/>
             <stories value="Admin user should be able return to the same state of image grid "/>
-            <title value="Admin user should be able return to the same state of image grid after saving image preview"/>
-            <description value="User returns to the same state of image grid after saving image preview. "/>
-            <severity value="CRITICAL"/>
+            <useCaseId value="https://github.com/magento/adobe-stock-integration/issues/31"/>
+            <title value="User returns to the same state of image grid after saving image preview"/>
+            <testCaseId value="https://app.hiptest.com/projects/131313/test-plan/folders/943908/scenarios/3578627"/>
+            <description value="User returns to the same state of image grid after saving image preview"/>
+            <severity value="MAJOR"/>
             <group value="adobe_stock_integration_filters"/>
             <group value="adobe_stock_integration"/>
         </annotations>

--- a/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockLocalizationTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockLocalizationTest.xml
@@ -10,10 +10,13 @@
        xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
     <test name="AdminAdobeStockLocalizationTest">
         <annotations>
-            <stories value="User sees stock image attributes localized"/>
-            <title value="Admin should be able to sees stock image attributes localized"/>
+            <features value="AdobeStockImagePanel"/>
+            <stories value="[Story #18] User sees stock image attributes localized"/>
+            <useCaseId value="https://github.com/magento/adobe-stock-integration/issues/41"/>
+            <title value="User sees stock image attributes localized"/>
+            <testCaseId value="https://app.hiptest.com/projects/131313/test-plan/folders/943908/scenarios/3218880"/>
             <description value="Admin should be able to sees stock image attributes localized"/>
-            <severity value="CRITICAL"/>
+            <severity value="MAJOR"/>
             <group value="adobe_stock_integration_general"/>
             <group value="adobe_stock_integration"/>
         </annotations>

--- a/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockOrientationFilterTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockOrientationFilterTest.xml
@@ -10,10 +10,13 @@
        xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
     <test name="AdminAdobeStockOrientationFilterTest">
         <annotations>
-            <stories value="Cover scenario: User filters images by orientation"/>
-            <title value="Admin should be able to filters images by orientation"/>
+            <features value="AdobeStockImagePanel"/>
+            <stories value="[Story #10] User filters images by orientation"/>
+            <useCaseId value="https://github.com/magento/adobe-stock-integration/issues/33"/>
+            <title value="User filters images by orientation"/>
+            <testCaseId value="https://app.hiptest.com/projects/131313/test-plan/folders/943908/scenarios/3217694"/>
             <description value="Admin should be able to filters images by orientation"/>
-            <severity value="CRITICAL"/>
+            <severity value="MAJOR"/>
             <group value="adobe_stock_integration_filters"/>
             <group value="adobe_stock_integration"/>
         </annotations>

--- a/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockPageNumberTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockPageNumberTest.xml
@@ -10,10 +10,12 @@
     <test name="AdminAdobeStockPageNumberTest">
         <annotations>
             <features value="AdobeStockImagePanel"/>
-            <stories value="Access Adobe Stock Image panel via the Admin"/>
-            <title value="Admin should be able to chooses the number of images to display on the page"/>
+            <stories value="[Story #15] User chooses the number of images to display on the page"/>
+            <useCaseId value="https://github.com/magento/adobe-stock-integration/issues/38"/>
+            <title value="User chooses the number of images to display on the page"/>
+            <testCaseId value="https://app.hiptest.com/projects/131313/test-plan/folders/943908/scenarios/3218849"/>
             <description value="Admin should be able to chooses the number of images to display on the page"/>
-            <severity value="CRITICAL"/>
+            <severity value="MAJOR"/>
             <group value="adobe_stock_integration_grid"/>
             <group value="adobe_stock_integration"/>
         </annotations>

--- a/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockPanelTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockPanelTest.xml
@@ -10,8 +10,10 @@
     <test name="AdminAdobeStockPanelTest">
         <annotations>
             <features value="AdobeStockImagePanel"/>
-            <stories value="Access Adobe Stock Image panel via the Admin"/>
-            <title value="Admin should be able to access Adobe Stock Image panel"/>
+            <stories value="[Story #1] User accesses stock images from Magento Admin"/>
+            <useCaseId value="https://github.com/magento/adobe-stock-integration/issues/22"/>
+            <title value="User accesses Stock images from Magento"/>
+            <testCaseId value="https://app.hiptest.com/projects/131313/test-plan/folders/943908/scenarios/3198694"/>
             <description value="Admin should be able to access Adobe Stock Image panel"/>
             <severity value="CRITICAL"/>
             <group value="adobe_stock_integration_general"/>

--- a/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockPriceFilterTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockPriceFilterTest.xml
@@ -10,10 +10,13 @@
        xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
     <test name="AdminAdobeStockPriceFilterTest">
         <annotations>
-            <stories value="Cover scenario: User filters images by price"/>
-            <title value="Admin should be able to filters images by price"/>
+            <features value="AdobeStockImagePanel"/>
+            <stories value="[Story #11] User filters images by price"/>
+            <useCaseId value="https://github.com/magento/adobe-stock-integration/issues/34"/>
+            <title value="User filters images by price"/>
+            <testCaseId value="https://app.hiptest.com/projects/131313/test-plan/folders/943908/scenarios/3217868"/>
             <description value="Admin should be able to filters images by price"/>
-            <severity value="CRITICAL"/>
+            <severity value="MAJOR"/>
             <group value="adobe_stock_integration_filters"/>
             <group value="adobe_stock_integration"/>
         </annotations>

--- a/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockSafeContentFilterTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockSafeContentFilterTest.xml
@@ -10,10 +10,12 @@
     <test name="AdminAdobeStockSafeContentFilterTest">
         <annotations>
             <features value="AdobeStockImagePanel"/>
-            <stories value="Filter safe content images via Admin"/>
-            <title value="Admin should be able to filters safe content images"/>
+            <stories value="[Story #12] User filters safe content images"/>
+            <useCaseId value="https://github.com/magento/adobe-stock-integration/issues/35"/>
+            <title value="User filters safe content images"/>
+            <testCaseId value="https://app.hiptest.com/projects/131313/test-plan/folders/943908/scenarios/3218324"/>
             <description value="Admin should be able to filters safe content images"/>
-            <severity value="CRITICAL"/>
+            <severity value="MAJOR"/>
             <group value="adobe_stock_integration_filters"/>
             <group value="adobe_stock_integration"/>
         </annotations>

--- a/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockSavePreviewTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockSavePreviewTest.xml
@@ -9,8 +9,11 @@
 <tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
     <test name="AdminAdobeStockSavePreviewTest">
         <annotations>
-            <stories value="Admin User can saves image preview"/>
-            <title value="Admin should be able to saves image preview"/>
+            <features value="AdobeStockImagePanel"/>
+            <stories value="[Story #4] User saves image preview"/>
+            <useCaseId value="https://github.com/magento/adobe-stock-integration/issues/26"/>
+            <title value="User saves image preview"/>
+            <testCaseId value="https://app.hiptest.com/projects/131313/test-plan/folders/943908/scenarios/3210330"/>
             <description value="Admin should be able to saves image preview "/>
             <severity value="CRITICAL"/>
             <group value="adobe_stock_integration_general"/>

--- a/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockSearchTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockSearchTest.xml
@@ -11,8 +11,10 @@
     <test name="AdminAdobeStockSearchTest">
         <annotations>
             <features value="AdobeStockImagePanel"/>
-            <stories value="Access Adobe Stock Image panel via the Admin"/>
+            <stories value="[Story #2] User searches Adobe Stock images by keywords"/>
+            <useCaseId value="https://github.com/magento/adobe-stock-integration/issues/23"/>
             <title value="User searches stock images by keywords"/>
+            <testCaseId value="https://app.hiptest.com/projects/131313/test-plan/folders/943908/scenarios/3199830"/>
             <description value="User searches stock images by keywords"/>
             <severity value="CRITICAL"/>
             <group value="adobe_stock_integration_grid"/>

--- a/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockSeeMoreSeriesFilterTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockSeeMoreSeriesFilterTest.xml
@@ -10,8 +10,11 @@
        xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
     <test name="AdminAdobeStockSeeMoreSeriesFilterTest">
         <annotations>
-            <stories value="Admin User see more images from series filter"/>
-            <title value="Admin should be able to see more images from series filter"/>
+            <features value="AdobeStockImagePanel"/>
+            <stories value="[Story #31] User searches for images from the same series as the currently viewed one"/>
+            <useCaseId value="https://github.com/magento/adobe-stock-integration/issues/346"/>
+            <title value="User searches for images from the same series as the currently viewed one"/>
+            <testCaseId value="https://app.hiptest.com/projects/131313/test-plan/folders/1051731/scenarios/3579513"/>
             <description value="Admin should be able to see more images from series filter"/>
             <severity value="CRITICAL"/>
             <group value="adobe_stock_integration_filters"/>

--- a/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockSignInSignOutTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockSignInSignOutTest.xml
@@ -11,9 +11,13 @@
     <test name="AdminAdobeStockSignInSignOutTest">
         <annotations>
             <features value="AdobeStockImagePanel"/>
-            <stories value="Admin User is logged into Admin Panel and User signs out from Stock"/>
-            <title value="Admin User is logged into Admin Panel and User signs out from Stock"/>
-            <description value="Admin User is logged into Admin Panel and User signs out from Stock"/>
+            <stories value="[Story #21] Adobe Sign-in"/>
+            <stories value="[Story #36] User signs out from Stock"/>
+            <useCaseId value="https://github.com/magento/adobe-stock-integration/issues/308"/>
+            <useCaseId value="https://github.com/magento/adobe-stock-integration/issues/389"/>
+            <title value="Admin User is logged into Admin Panel and User signs in and out from Stock"/>
+            <testCaseId value="https://app.hiptest.com/projects/131313/test-plan/folders/1051731/scenarios/3579351"/>
+            <description value="Admin User is logged into Admin Panel and User signs in and out from Stock"/>
             <severity value="CRITICAL"/>
             <group value="adobe_stock_integration_grid"/>
             <group value="adobe_stock_integration"/>

--- a/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockSignedInCreditsVisibleTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockSignedInCreditsVisibleTest.xml
@@ -11,8 +11,10 @@
     <test name="AdminAdobeStockSignedInCreditsVisibleTest">
         <annotations>
             <features value="AdobeStockImagePanel"/>
-            <stories value="Admin user can view credits and images available when signed in to Adobe Stock"/>
-            <title value="Admin user can view credits and images available when signed in to Adobe Stock"/>
+            <stories value="[Story #35] User sees credits available on their account"/>
+            <useCaseId value="https://github.com/magento/adobe-stock-integration/issues/356"/>
+            <title value="User sees credits available on their account"/>
+            <testCaseId value="https://app.hiptest.com/projects/131313/test-plan/folders/1051731/scenarios/3579523"/>
             <description value="Admin user can view credits and images available when signed in to Adobe Stock"/>
             <severity value="CRITICAL"/>
             <group value="adobe_stock_integration_grid"/>

--- a/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockTypeFilterTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockTypeFilterTest.xml
@@ -9,10 +9,13 @@
 <tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
     <test name="AdminAdobeStockTypeFilterTest">
         <annotations>
-            <stories value="Cover scenario: User filters images by type"/>
-            <title value="Admin should be able to filters images by type"/>
+            <features value="AdobeStockImagePanel"/>
+            <stories value="[Story #9] User filters images by type"/>
+            <useCaseId value="https://github.com/magento/adobe-stock-integration/issues/32"/>
+            <title value="User filters images by type"/>
+            <testCaseId value="https://app.hiptest.com/projects/131313/test-plan/folders/943908/scenarios/3216729"/>
             <description value="Admin should be able to filters images by type"/>
-            <severity value="CRITICAL"/>
+            <severity value="MAJOR"/>
             <group value="adobe_stock_integration_filters"/>
             <group value="adobe_stock_integration"/>
         </annotations>


### PR DESCRIPTION
- using consistent `group` and `features` properties
- linking to github issues via `useCaseId`
- linking to hiptest cases via `testCaseId`
- matching `title` to hiptest case title
- matching story title to github issue story title
- making consistent the `severity` by assigning S0=CRITICAL, S1=BLOCKER, S2=MAJOR
- where applicable, ensure that the one `group` that _must_ be assigned to each test is `adobe_stock_integration` - others are optional and can be added additionally