### PR TITLE
Resolved issue 641

### DIFF
--- a/AdobeStockImageAdminUi/etc/module.xml
+++ b/AdobeStockImageAdminUi/etc/module.xml
@@ -6,5 +6,9 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Magento_AdobeStockImageAdminUi" />
+    <module name="Magento_AdobeStockImageAdminUi">
+        <sequence>
+            <module name="Magento_Ui"/>
+        </sequence>
+    </module>
 </config>

--- a/AdobeStockImageAdminUi/etc/module.xml
+++ b/AdobeStockImageAdminUi/etc/module.xml
@@ -6,9 +6,5 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Magento_AdobeStockImageAdminUi">
-        <sequence>
-            <module name="Magento_Ui"/>
-        </sequence>
-    </module>
+    <module name="Magento_AdobeStockImageAdminUi" />
 </config>

--- a/AdobeStockImageAdminUi/view/adminhtml/ui_component/adobe_stock_images_listing.xml
+++ b/AdobeStockImageAdminUi/view/adminhtml/ui_component/adobe_stock_images_listing.xml
@@ -177,10 +177,10 @@
                 <item name="containerId" xsi:type="string">adobe-stock-images-masonry-grid</item>
             </item>
         </argument>
-        <column name="overlay" component="Magento_Ui/js/grid/columns/overlay" class="Magento\AdobeStockImageAdminUi\Ui\Component\Listing\Columns\LicensedOverlay">
+        <column name="overlay" component="Magento_AdobeStockImageAdminUi/js/components/grid/column/overlay" class="Magento\AdobeStockImageAdminUi\Ui\Component\Listing\Columns\LicensedOverlay">
             <settings>
                 <label translate="true">Overlay</label>
-                <bodyTmpl>ui/grid/columns/overlay</bodyTmpl>
+                <bodyTmpl>Magento_AdobeStockImageAdminUi/grid/column/overlay</bodyTmpl>
                 <visible>true</visible>
                 <sortable>false</sortable>
             </settings>

--- a/AdobeStockImageAdminUi/view/adminhtml/web/css/source/_module.less
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/css/source/_module.less
@@ -18,7 +18,6 @@
             }
 
             &-overlay {
-                top: 110px;
                 right: 0;
                 background-color: #507DC8;
                 opacity: 1;

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/overlay.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/overlay.js
@@ -1,0 +1,23 @@
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+define([
+    'Magento_Ui/js/grid/columns/overlay'
+], function (overlay) {
+    'use strict';
+
+    return overlay.extend({
+
+        /**
+         * Returns top displacement of overlay according to image height
+         *
+         * @param {Object} record - Data to be preprocessed.
+         * @returns {Object}
+         */
+        getStyles: function (record) {
+            var height = record.styles()['height'].replace('px', '');
+            return {top: (height - 50) + 'px'};
+        }
+    });
+});

--- a/AdobeStockImageAdminUi/view/adminhtml/web/template/grid/column/overlay.html
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/template/grid/column/overlay.html
@@ -1,0 +1,9 @@
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<div if="$col.isVisible($row())" ko-style="$col.getStyles($row())" class="masonry-image-overlay">
+    <span text="$col.getLabel($row())"/>
+</div>


### PR DESCRIPTION
### Description 
This PR solves the below mentioned issue by programmatically calculating the top displacement from the respective image height. Prevents the previously caused bug by using `top` instead of `bottom` as image container height increases to accommodate opened preview. Also, inspect overlay label container to notice `top` displacement vary according to respective image height.

Two more required files are present in magento/magento2 repository's PR: https://github.com/magento/magento2/pull/25525

### Fixed Issues
1. magento/adobe-stock-integration#641: The licensed label is shown under the image if the row of images has small height

### Manual testing scenarios
1. Open wide licensed images in Adobe Stock grid