### PR TITLE
#669 : Licensed overlay label is missing for just licensed images

### DIFF
--- a/AdobeStockImageAdminUi/view/adminhtml/web/css/source/_module.less
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/css/source/_module.less
@@ -153,9 +153,7 @@
                     letter-spacing: -1px;
 
                     button {
-                        & + button {
-                            margin-right: 15px;
-                        }
+                        margin-right: 15px;
                     }
                 }
 

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/image-preview.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/image-preview.js
@@ -19,7 +19,6 @@ define([
             buyCreditsUrl: 'https://stock.adobe.com/',
             mediaGallerySelector: '.media-gallery-modal:has(#search_adobe_stock)',
             adobeStockModalSelector: '#adobe-stock-images-search-modal',
-            tabImagesLimit: 4,
             modules: {
                 keywords: '${ $.name }_keywords',
                 related: '${ $.name }_related',
@@ -117,11 +116,10 @@ define([
          */
         show: function (record) {
             this.related().selectedTab(null);
-            this.related().initRecord(record);
             this.keywords().hideAllKeywords();
             this.displayedRecord(record);
             this._super(record);
-            this.loadRelatedImages(record);
+            this.related().loadRelatedImages(record);
         },
 
         /**
@@ -136,38 +134,15 @@ define([
         },
 
         /**
-         * Get image related image series.
-         *
-         * @param {Object} record
-         */
-        loadRelatedImages: function (record) {
-            if (record.series && record.model &&
-                record.series() && record.model() &&
-                record.series().length && record.model().length) {
-                return;
-            }
-            $.ajax({
-                type: 'GET',
-                url: this.relatedImagesUrl,
-                dataType: 'json',
-                showLoader: true,
-                data: {
-                    'image_id': record.id,
-                    'limit': this.tabImagesLimit
-                }
-            }).done(function (data) {
-                record.series(data.result['same_series']);
-                record.model(data.result['same_model']);
-                this.updateHeight();
-            }.bind(this));
-        },
-
-        /**
          * Returns attributes to display under the preview image
          *
          * @returns {*[]}
          */
         getDisplayAttributes: function () {
+            if (!this.displayedRecord()) {
+                return [];
+            }
+
             return [
                 {
                     name: 'Dimensions',

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/image-preview.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/image-preview.js
@@ -36,7 +36,8 @@ define([
                 },
                 {
                     component: 'Magento_AdobeStockImageAdminUi/js/components/grid/column/preview/actions',
-                    name: '${ $.name }_actions'
+                    name: '${ $.name }_actions',
+                    provider: '${ $.provider }'
                 }
             ]
         },

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/actions.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/actions.js
@@ -29,7 +29,8 @@ define([
             messageDelay: 5,
             modules: {
                 login: '${ $.loginProvider }',
-                preview: '${ $.parentName }.preview'
+                preview: '${ $.parentName }.preview',
+                source: '${ $.provider }'
             }
         },
 
@@ -114,7 +115,7 @@ define([
                 requestUrl = isLicensed ? this.preview().saveLicensedAndDownloadUrl :
                     license ? this.preview().licenseAndDownloadUrl : this.preview().downloadImagePreviewUrl,
                 destinationPath = (mediaBrowser.activeNode.path || '') + '/' + fileName + '.' +
-                                  this.getImageExtension(record);
+                    this.getImageExtension(record);
 
             $.ajax({
                 type: 'POST',
@@ -142,7 +143,8 @@ define([
                         displayedRecord['is_licensed'] = 1;
                         displayedRecord['is_licensed_locally'] = 1;
                     }
-
+                    this.source().set('params.t ', Date.now());
+                    this.preview().hide();
                     this.preview().displayedRecord(displayedRecord);
                     $(this.preview().adobeStockModalSelector).trigger('closeModal');
                     mediaBrowser.reload(true);

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/actions.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/actions.js
@@ -144,7 +144,6 @@ define([
                         displayedRecord['is_licensed_locally'] = 1;
                     }
                     this.source().set('params.t ', Date.now());
-                    this.preview().hide();
                     this.preview().displayedRecord(displayedRecord);
                     $(this.preview().adobeStockModalSelector).trigger('closeModal');
                     mediaBrowser.reload(true);

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/actions.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/actions.js
@@ -134,17 +134,15 @@ define([
                  *
                  */
                 success: function () {
-                    var displayedRecord = this.preview().displayedRecord();
-
-                    displayedRecord['is_downloaded'] = 1;
-                    displayedRecord.path = destinationPath;
+                    record['is_downloaded'] = 1;
+                    record.path = destinationPath;
 
                     if (license || isLicensed) {
-                        displayedRecord['is_licensed'] = 1;
-                        displayedRecord['is_licensed_locally'] = 1;
+                        record['is_licensed'] = 1;
+                        record['is_licensed_locally'] = 1;
                     }
+                    this.preview().displayedRecord(record);
                     this.source().set('params.t ', Date.now());
-                    this.preview().displayedRecord(displayedRecord);
                     $(this.preview().adobeStockModalSelector).trigger('closeModal');
                     mediaBrowser.reload(true);
                 },

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/related.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/related.js
@@ -87,7 +87,7 @@ define([
                 }
             }).done(function (data) {
                 var relatedImages = this.relatedImages();
-                
+
                 relatedImages.series[record.id] = data.result['same_series'];
                 relatedImages.model[record.id] = data.result['same_model'];
                 this.relatedImages(relatedImages);

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/related.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/related.js
@@ -65,7 +65,12 @@ define([
          * @returns {*[]}
          */
         getSeries: function (record) {
-            return record.series;
+            if (this.preview().displayedRecord().series) {
+                return this.preview().displayedRecord().series();
+            }
+            else {
+                return record.series;
+            }
         },
 
         /**
@@ -75,7 +80,12 @@ define([
          * @returns boolean
          */
         canShowMoreSeriesImages: function (record) {
-            return parseInt(record.series().length, 10) >= this.preview().tabImagesLimit;
+            if (this.preview().displayedRecord().series) {
+                return parseInt(this.preview().displayedRecord().series().length, 10) >= this.preview().tabImagesLimit;
+            }
+            else {
+                return parseInt(record.series().length, 10) >= this.preview().tabImagesLimit;
+            }
         },
 
         /**
@@ -85,7 +95,12 @@ define([
          * @returns {*[]}
          */
         getModel: function (record) {
-            return record.model;
+            if (this.preview().displayedRecord().model) {
+                return this.preview().displayedRecord().model();
+            }
+            else {
+                return record.model;
+            }
         },
 
         /**
@@ -95,7 +110,12 @@ define([
          * @returns boolean
          */
         canShowMoreModelImages: function (record) {
-            return parseInt(record.model().length, 10) >= this.preview().tabImagesLimit;
+            if (this.preview().displayedRecord().model) {
+                return parseInt(this.preview().displayedRecord().model().length, 10) >= this.preview().tabImagesLimit;
+            }
+            else {
+                return parseInt(record.model().length, 10) >= this.preview().tabImagesLimit;
+            }
         },
 
         /**

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/related.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/related.js
@@ -87,6 +87,7 @@ define([
                 }
             }).done(function (data) {
                 var relatedImages = this.relatedImages();
+                
                 relatedImages.series[record.id] = data.result['same_series'];
                 relatedImages.model[record.id] = data.result['same_model'];
                 this.relatedImages(relatedImages);

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/signIn.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/signIn.js
@@ -47,7 +47,6 @@ define([
                 }
                 auth(self.loginConfig)
                     .then(function (response) {
-                        self.preview().hide();
                         self.source().set('params.t ', Date.now());
                         self.loadUserProfile();
                         resolve(response);
@@ -72,7 +71,6 @@ define([
                 context: this,
                 showLoader: true,
                 success: function () {
-                    this.preview().hide();
                     this.source().set('params.t ', Date.now());
                     this.user({
                         isAuthorized: false,

--- a/AdobeStockImageAdminUi/view/adminhtml/web/template/grid/column/preview/related.html
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/template/grid/column/preview/related.html
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 -->
-<div if="getSeries($row()).length || getModel($row()).length"
+<div if="isLoaded($row())"
      id="adobe-stock-tabs"
      class="adobe-stock-tabs"
      data-bind="mageInit: {
@@ -27,7 +27,7 @@
         </li>
     </ul>
 </div>
-<div if="getSeries($row()).length || getModel($row()).length"
+<div if="isLoaded($row())"
      id="adobe-stock-tabs-content"
      class="adobe-stock-related-images-tab-content">
     <div attr="'id': 'series_content_' + $row().id">

--- a/AdobeStockImageAdminUi/view/adminhtml/web/template/grid/column/preview/related.html
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/template/grid/column/preview/related.html
@@ -4,7 +4,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<div id="adobe-stock-tabs"
+<div if="getSeries($row()).length || getModel($row()).length"
+     id="adobe-stock-tabs"
      class="adobe-stock-tabs"
      data-bind="mageInit: {
                     'mage/backend/tabs': {
@@ -26,7 +27,9 @@
         </li>
     </ul>
 </div>
-<div id="adobe-stock-tabs-content" class="adobe-stock-related-images-tab-content">
+<div if="getSeries($row()).length || getModel($row()).length"
+     id="adobe-stock-tabs-content"
+     class="adobe-stock-related-images-tab-content">
     <div attr="'id': 'series_content_' + $row().id">
         <!-- ko foreach: getSeries($row()) -->
             <div class="thumbnail" data-bind="click: function(){ $parent.switchImagePreviewToSeriesImage($data) }">


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR will update the license label if the image is just licensed and also fixed small css issue with save preview button
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/adobe-stock-integration#669: Licensed overlay label is missing for just licensed images

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Login to admin panel
2. Open Magento Media Gallery (i.e. go to Cms -> Pages, edit the page and insert image)
3. Click "Search Adobe Stock" button to open images grid
4. License an Image
5. Reopen the grid
### Expected Result
License label will be visible for the recently licensed label