### PR TITLE
#675 : Remove First Image from the related images (More from model and More from series) 

### DIFF
--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/image-preview.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/image-preview.js
@@ -19,7 +19,7 @@ define([
             buyCreditsUrl: 'https://stock.adobe.com/',
             mediaGallerySelector: '.media-gallery-modal:has(#search_adobe_stock)',
             adobeStockModalSelector: '#adobe-stock-images-search-modal',
-            tabImagesLimit: 5,
+            tabImagesLimit: 4,
             modules: {
                 keywords: '${ $.name }_keywords',
                 related: '${ $.name }_related',
@@ -152,7 +152,7 @@ define([
                 showLoader: true,
                 data: {
                     'image_id': record.id,
-                    'limit': this.tabImagesLimit
+                    'limit': this.tabImagesLimit + 1
                 }
             }).done(function (data) {
                 record.series(data.result['same_series'].splice(1));

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/image-preview.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/image-preview.js
@@ -19,7 +19,7 @@ define([
             buyCreditsUrl: 'https://stock.adobe.com/',
             mediaGallerySelector: '.media-gallery-modal:has(#search_adobe_stock)',
             adobeStockModalSelector: '#adobe-stock-images-search-modal',
-            tabImagesLimit: 4,
+            tabImagesLimit: 5,
             modules: {
                 keywords: '${ $.name }_keywords',
                 related: '${ $.name }_related',
@@ -155,8 +155,8 @@ define([
                     'limit': this.tabImagesLimit
                 }
             }).done(function (data) {
-                record.series(data.result['same_series']);
-                record.model(data.result['same_model']);
+                record.series(data.result['same_series'].splice(1));
+                record.model(data.result['same_model'].splice(1));
                 this.updateHeight();
             }.bind(this));
         },

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/related.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/related.js
@@ -17,7 +17,6 @@ define([
             filterChipsProvider: 'componentType = filters, ns = ${ $.ns }',
             serieFilterValue: '',
             modelFilterValue: '',
-            relatedPreviewLimit: 4,
             selectedTab: null,
             statefull: {
                 serieFilterValue: true,
@@ -76,7 +75,7 @@ define([
          * @returns boolean
          */
         canShowMoreSeriesImages: function (record) {
-            return parseInt(record.series().length, 10) >= this.relatedPreviewLimit;
+            return parseInt(record.series().length, 10) >= this.preview().tabImagesLimit;
         },
 
         /**
@@ -96,7 +95,7 @@ define([
          * @returns boolean
          */
         canShowMoreModelImages: function (record) {
-            return parseInt(record.model().length, 10) >= this.relatedPreviewLimit;
+            return parseInt(record.model().length, 10) >= this.preview().tabImagesLimit;
         },
 
         /**

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/related.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/related.js
@@ -17,6 +17,7 @@ define([
             filterChipsProvider: 'componentType = filters, ns = ${ $.ns }',
             serieFilterValue: '',
             modelFilterValue: '',
+            relatedPreviewLimit: 4,
             selectedTab: null,
             statefull: {
                 serieFilterValue: true,
@@ -75,7 +76,7 @@ define([
          * @returns boolean
          */
         canShowMoreSeriesImages: function (record) {
-            return parseInt(record.series().length, 10) >= this.preview().tabImagesLimit;
+            return parseInt(record.series().length) >= this.relatedPreviewLimit;
         },
 
         /**
@@ -95,7 +96,7 @@ define([
          * @returns boolean
          */
         canShowMoreModelImages: function (record) {
-            return parseInt(record.model().length, 10) >= this.preview().tabImagesLimit;
+            return parseInt(record.model().length) >= this.relatedPreviewLimit;
         },
 
         /**

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/related.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/related.js
@@ -76,7 +76,7 @@ define([
          * @returns boolean
          */
         canShowMoreSeriesImages: function (record) {
-            return parseInt(record.series().length) >= this.relatedPreviewLimit;
+            return parseInt(record.series().length, 10) >= this.relatedPreviewLimit;
         },
 
         /**
@@ -96,7 +96,7 @@ define([
          * @returns boolean
          */
         canShowMoreModelImages: function (record) {
-            return parseInt(record.model().length) >= this.relatedPreviewLimit;
+            return parseInt(record.model().length, 10) >= this.relatedPreviewLimit;
         },
 
         /**


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/adobe-stock-integration#675: Remove First Image from the related images (More from model and More from series) 

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Login to admin panel
2. Open Magento Media Gallery (i.e. go to Cms -> Pages, edit the page and insert image)
3. Click "Search Adobe Stock" button to open images grid
4. Click on any image to open the image preview

### Expected result
The image shown in the image preview should not be visible in the More from series and More from Model Tab