### PR TITLE
Fixed issue found by PHPStan level 1

### DIFF
--- a/AdobeStockAsset/Test/Api/AssetRepository/DeleteTest.php
+++ b/AdobeStockAsset/Test/Api/AssetRepository/DeleteTest.php
@@ -52,7 +52,7 @@ class DeleteTest extends WebapiAbstract
     {
         $response = $this->deleteAsset($this->getAssetId());
 
-        if (TESTS_WEB_API_ADAPTER === self::ADAPTER_REST) {
+        if (constant('TESTS_WEB_API_ADAPTER') === self::ADAPTER_REST) {
             $this->assertSame([], $response);
         } else {
             $this->assertNull($response);
@@ -72,11 +72,11 @@ class DeleteTest extends WebapiAbstract
             $this->deleteAsset($notExistedAssetId);
             $this->fail('Expected throwing exception');
         } catch (\Exception $e) {
-            if (TESTS_WEB_API_ADAPTER === self::ADAPTER_REST) {
+            if (constant('TESTS_WEB_API_ADAPTER') === self::ADAPTER_REST) {
                 $errorData = $this->processRestExceptionResult($e);
                 self::assertEquals($notExistedAssetId, $errorData['parameters'][0]);
                 self::assertEquals(Exception::HTTP_NOT_FOUND, $e->getCode());
-            } elseif (TESTS_WEB_API_ADAPTER === self::ADAPTER_SOAP) {
+            } elseif (constant('TESTS_WEB_API_ADAPTER') === self::ADAPTER_SOAP) {
                 $this->assertInstanceOf('SoapFault', $e);
             } else {
                 throw $e;
@@ -103,7 +103,7 @@ class DeleteTest extends WebapiAbstract
             ],
         ];
 
-        return (TESTS_WEB_API_ADAPTER === self::ADAPTER_SOAP)
+        return (constant('TESTS_WEB_API_ADAPTER') === self::ADAPTER_SOAP)
             ? $this->_webApiCall($serviceInfo, ['id' => $assetId])
             : $this->_webApiCall($serviceInfo);
     }

--- a/AdobeStockAsset/Test/Api/AssetRepository/DeleteTest.php
+++ b/AdobeStockAsset/Test/Api/AssetRepository/DeleteTest.php
@@ -67,8 +67,8 @@ class DeleteTest extends WebapiAbstract
      */
     public function testDeleteWithException(): void
     {
+        $notExistedAssetId = -1;
         try {
-            $notExistedAssetId = -1;
             $this->deleteAsset($notExistedAssetId);
             $this->fail('Expected throwing exception');
         } catch (\Exception $e) {

--- a/AdobeStockAsset/Test/Api/AssetRepository/GetByIdTest.php
+++ b/AdobeStockAsset/Test/Api/AssetRepository/GetByIdTest.php
@@ -70,19 +70,19 @@ class GetByIdTest extends WebapiAbstract
         $expectedMessage = 'Object with id "%1" does not exist.';
 
         try {
-            if (TESTS_WEB_API_ADAPTER === self::ADAPTER_REST) {
+            if (constant('TESTS_WEB_API_ADAPTER') === self::ADAPTER_REST) {
                 $this->_webApiCall($serviceInfo);
             } else {
                 $this->_webApiCall($serviceInfo, ['id' => $notExistedAssetId]);
             }
             $this->fail('Expected throwing exception');
         } catch (\Exception $e) {
-            if (TESTS_WEB_API_ADAPTER === self::ADAPTER_REST) {
+            if (constant('TESTS_WEB_API_ADAPTER') === self::ADAPTER_REST) {
                 $errorData = $this->processRestExceptionResult($e);
                 self::assertEquals($expectedMessage, $errorData['message']);
                 self::assertEquals($notExistedAssetId, $errorData['parameters'][0]);
                 self::assertEquals(Exception::HTTP_NOT_FOUND, $e->getCode());
-            } elseif (TESTS_WEB_API_ADAPTER === self::ADAPTER_SOAP) {
+            } elseif (constant('TESTS_WEB_API_ADAPTER') === self::ADAPTER_SOAP) {
                 $this->assertInstanceOf('SoapFault', $e);
                 $this->checkSoapFault($e, $expectedMessage, 'env:Sender', [1 => $notExistedAssetId]);
             } else {
@@ -112,7 +112,7 @@ class GetByIdTest extends WebapiAbstract
             ],
         ];
 
-        if (TESTS_WEB_API_ADAPTER === self::ADAPTER_REST) {
+        if (constant('TESTS_WEB_API_ADAPTER') === self::ADAPTER_REST) {
             $assetResultData = $this->_webApiCall($serviceInfo);
         } else {
             $assetResultData = $this->_webApiCall($serviceInfo, ['id' => $assetId]);


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
I've analysed the code with PHPStan (level 1) and found the following issues:
```
 ------ ------------------------------------------------------------------ 
  Line   module-adobe-stock-asset/Test/Api/AssetRepository/DeleteTest.php  
 ------ ------------------------------------------------------------------ 
  55     Constant TESTS_WEB_API_ADAPTER not found.                         
  75     Constant TESTS_WEB_API_ADAPTER not found.                         
  77     Variable $notExistedAssetId might not be defined.                 
  79     Constant TESTS_WEB_API_ADAPTER not found.                         
  106    Constant TESTS_WEB_API_ADAPTER not found.                         
 ------ ------------------------------------------------------------------ 

 ------ ------------------------------------------------------------------- 
  Line   module-adobe-stock-asset/Test/Api/AssetRepository/GetByIdTest.php  
 ------ ------------------------------------------------------------------- 
  73     Constant TESTS_WEB_API_ADAPTER not found.                          
  80     Constant TESTS_WEB_API_ADAPTER not found.                          
  85     Constant TESTS_WEB_API_ADAPTER not found.                          
  115    Constant TESTS_WEB_API_ADAPTER not found.                          
 ------ ------------------------------------------------------------------- 
```

Issue with 'TESTS_WEB_API_ADAPTER' happens because constant is defined using xml file. I've wrapped it in `constant()` call.

Another issue fixed with a possibility of having an undefined variable.

### Manual testing scenarios (*)
Run API Functional tests