### PR TITLE
Fix for issues found with PHPStan (Level 2)

### DIFF
--- a/AdobeIms/Controller/Adminhtml/OAuth/Callback.php
+++ b/AdobeIms/Controller/Adminhtml/OAuth/Callback.php
@@ -19,6 +19,7 @@ use Magento\Framework\Controller\ResultInterface;
 use Magento\Framework\Exception\AuthorizationException;
 use Magento\Framework\Exception\CouldNotSaveException;
 use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\User\Api\Data\UserInterface;
 use Psr\Log\LoggerInterface;
 use Magento\AdobeImsApi\Api\GetImageInterface;
 
@@ -107,7 +108,7 @@ class Callback extends Action
             $userProfile->setName($tokenResponse->getName());
             $userProfile->setEmail($tokenResponse->getEmail());
             $userProfile->setImage($userImage);
-            $userProfile->setUserId((int)$this->_auth->getUser()->getId());
+            $userProfile->setUserId((int)$this->getUser()->getId());
             $userProfile->setAccessToken($tokenResponse->getAccessToken());
             $userProfile->setRefreshToken($tokenResponse->getRefreshToken());
             $userProfile->setAccessTokenExpiresAt(
@@ -152,11 +153,25 @@ class Callback extends Action
     {
         try {
             return $this->userProfileRepository->getByUserId(
-                (int)$this->_auth->getUser()->getId()
+                (int)$this->getUser()->getId()
             );
         } catch (NoSuchEntityException $e) {
             return $this->userProfileFactory->create();
         }
+    }
+
+    /**
+     * Get Authorised User
+     *
+     * @return UserInterface
+     */
+    private function getUser(): UserInterface
+    {
+        if (!$this->_auth->getUser() instanceof UserInterface) {
+            throw new \RuntimeException('Auth user object must be an instance of UserInterface');
+        }
+
+        return $this->_auth->getUser();
     }
 
     /**

--- a/AdobeIms/Controller/Adminhtml/User/Logout.php
+++ b/AdobeIms/Controller/Adminhtml/User/Logout.php
@@ -28,7 +28,7 @@ class Logout extends Action
     public const ADMIN_RESOURCE = 'Magento_AdobeIms::logout';
 
     /**
-     * @var CurlFactory
+     * @var LogOutInterface
      */
     private $logout;
 

--- a/AdobeIms/Model/GetToken.php
+++ b/AdobeIms/Model/GetToken.php
@@ -81,7 +81,7 @@ class GetToken implements GetTokenInterface
         );
 
         $tokenResponse = $this->json->unserialize($curl->getBody());
-        /** @var TokenResponse $tokenResponse */
+        /** @var TokenResponseInterface $tokenResponse */
         $tokenResponse = $this->tokenResponseFactory->create()
             ->addData(is_array($tokenResponse) ? $tokenResponse : ['error' => __('The response is empty.')]);
 

--- a/AdobeIms/Test/Unit/Controller/Adminhtml/OAuth/CallbackTest.php
+++ b/AdobeIms/Test/Unit/Controller/Adminhtml/OAuth/CallbackTest.php
@@ -126,11 +126,9 @@ class CallbackTest extends TestCase
      */
     public function testExecute(): void
     {
-        $this->authMock->expects($this->exactly(2))
-            ->method('getUser')
+        $this->authMock->method('getUser')
             ->will($this->returnValue($this->userMock));
-        $this->userMock->expects($this->exactly(2))
-            ->method('getId')
+        $this->userMock->method('getId')
             ->willReturn(1);
         $userProfileMock = $this->createMock(UserProfileInterface::class);
         $this->getImage->expects($this->once())->method('execute')->willReturn('https://image.url/image.png');

--- a/AdobeIms/Test/Unit/Model/GetImageTest.php
+++ b/AdobeIms/Test/Unit/Model/GetImageTest.php
@@ -44,7 +44,7 @@ class GetImageTest extends TestCase
     private $jsonMock;
 
     /**
-     * @var LoggerInterface $logger
+     * @var LoggerInterface|MockObject $logger
      */
     private $logger;
 

--- a/AdobeIms/Test/Unit/Model/UserProfileRepositoryTest.php
+++ b/AdobeIms/Test/Unit/Model/UserProfileRepositoryTest.php
@@ -62,7 +62,10 @@ class UserProfileRepositoryTest extends TestCase
     public function testSave(): void
     {
         $userProfile = $this->objectManager->getObject(UserProfile::class);
-        $this->assertNull($this->model->save($userProfile));
+        $this->resource->expects($this->once())
+            ->method('save')
+            ->with($userProfile);
+        $this->model->save($userProfile);
     }
 
     /**

--- a/AdobeImsApi/Api/Data/UserProfileInterface.php
+++ b/AdobeImsApi/Api/Data/UserProfileInterface.php
@@ -79,7 +79,7 @@ interface UserProfileInterface extends ExtensibleDataInterface
      * Set's user profile image.
      *
      * @param string $value
-     * @return void|null
+     * @return void
      */
     public function setImage(string $value): void;
 

--- a/AdobeStockAsset/Model/CategoryRepository.php
+++ b/AdobeStockAsset/Model/CategoryRepository.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
 
 namespace Magento\AdobeStockAsset\Model;
 
-use Magento\AdobeStockAsset\Model\ResourceModel\Category as Resource;
+use Magento\AdobeStockAsset\Model\ResourceModel\Category as CategoryResource;
 use Magento\AdobeStockAsset\Model\ResourceModel\Category\Collection as CategoryCollection;
 use Magento\AdobeStockAsset\Model\ResourceModel\Category\CollectionFactory as CategoryCollectionFactory;
 use Magento\AdobeStockAsset\Model\ResourceModel\Category\Command\Save;
@@ -27,7 +27,7 @@ use Magento\Framework\Exception\NoSuchEntityException;
 class CategoryRepository implements CategoryRepositoryInterface
 {
     /**
-     * @var Resource
+     * @var CategoryResource
      */
     private $resource;
 
@@ -64,7 +64,7 @@ class CategoryRepository implements CategoryRepositoryInterface
     /**
      * CategoryRepository constructor.
      *
-     * @param Resource $resource
+     * @param CategoryResource $resource
      * @param Save $commandSave
      * @param CategoryCollectionFactory $collectionFactory
      * @param CategoryFactory $factory
@@ -73,7 +73,7 @@ class CategoryRepository implements CategoryRepositoryInterface
      * @param CategorySearchResultsInterfaceFactory $searchResultFactory
      */
     public function __construct(
-        Resource $resource,
+        CategoryResource $resource,
         Save $commandSave,
         CategoryCollectionFactory $collectionFactory,
         CategoryFactory $factory,

--- a/AdobeStockAsset/Test/Api/AssetRepository/DeleteTest.php
+++ b/AdobeStockAsset/Test/Api/AssetRepository/DeleteTest.php
@@ -30,7 +30,7 @@ class DeleteTest extends WebapiAbstract
     private $objectManager;
 
     /**
-     * @var Collection
+     * @var CollectionFactory
      */
     private $assetCollectionFactory;
 

--- a/AdobeStockAsset/Test/Api/AssetRepository/GetByIdTest.php
+++ b/AdobeStockAsset/Test/Api/AssetRepository/GetByIdTest.php
@@ -32,7 +32,7 @@ class GetByIdTest extends WebapiAbstract
     private $objectManager;
 
     /**
-     * @var Collection
+     * @var CollectionFactory
      */
     private $assetCollectionFactory;
 

--- a/AdobeStockAssetApi/Api/Data/AssetInterface.php
+++ b/AdobeStockAssetApi/Api/Data/AssetInterface.php
@@ -76,7 +76,7 @@ interface AssetInterface extends ExtensibleDataInterface
     /**
      * Retrieve existing extension attributes object or create a new one.
      *
-     * @return \Magento\AdobeStockAssetApi\Api\Data\AssetExtensionInterface|null
+     * @return \Magento\AdobeStockAssetApi\Api\Data\AssetExtensionInterface
      */
     public function getExtensionAttributes(): AssetExtensionInterface;
 

--- a/AdobeStockImage/Test/Unit/Model/Extract/DocumentToAssetTest.php
+++ b/AdobeStockImage/Test/Unit/Model/Extract/DocumentToAssetTest.php
@@ -143,9 +143,9 @@ class DocumentToAssetTest extends TestCase
 
     /**
      * @param array $attributes
-     * @return Document|MockObject
+     * @return MockObject
      */
-    private function getDocument(array $attributes): Document
+    private function getDocument(array $attributes): MockObject
     {
         $document = $this->createMock(Document::class);
 

--- a/AdobeStockImage/Test/Unit/Model/GetImageListTest.php
+++ b/AdobeStockImage/Test/Unit/Model/GetImageListTest.php
@@ -65,7 +65,7 @@ class GetImageListTest extends TestCase
     private $filterBuilderMock;
 
     /**
-     * @var ConfigInterface $config
+     * @var ConfigInterface|MockObject
      */
     private $config;
 
@@ -239,12 +239,12 @@ class GetImageListTest extends TestCase
     /**
      * Set's filter group with 'gallery_id' filter
      *
-     * @param SearchCriteriaInterface $searchCriteria
+     * @param MockObject $searchCriteria
      * @param FilterGroup $appliedFilters
      * @return void
      */
     private function applyDefaultGalleryFilter(
-        SearchCriteriaInterface $searchCriteria,
+        MockObject $searchCriteria,
         FilterGroup $appliedFilters
     ): void {
         $this->filterBuilderMock->expects($this->at(0))

--- a/AdobeStockImage/Test/Unit/Model/GetRelatedImagesTest.php
+++ b/AdobeStockImage/Test/Unit/Model/GetRelatedImagesTest.php
@@ -77,12 +77,12 @@ class GetRelatedImagesTest extends TestCase
     /**
      * Check if related images can be executed.
      *
-     * @param $relatedImagesProvider
-     * @param $expectedResult
+     * @param array $relatedImagesProvider
+     * @param array $expectedResult
      * @throws IntegrationException
      * @dataProvider relatedImagesDataProvider
      */
-    public function testExecute($relatedImagesProvider, $expectedResult): void
+    public function testExecute(array $relatedImagesProvider, array $expectedResult): void
     {
         $this->filterBuilder->expects($this->any())
             ->method('setField')

--- a/AdobeStockImage/Test/Unit/Model/SaveImageTest.php
+++ b/AdobeStockImage/Test/Unit/Model/SaveImageTest.php
@@ -3,6 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
 namespace Magento\AdobeStockImage\Test\Unit\Model;
 
@@ -180,9 +181,9 @@ class SaveImageTest extends TestCase
      * Get document
      *
      * @param string|null $path
-     * @return Document|MockObject
+     * @return MockObject
      */
-    private function getDocument(?string $path = null): Document
+    private function getDocument(?string $path = null): MockObject
     {
         $document = $this->createMock(Document::class);
         $pathAttribute = $this->createMock(AttributeInterface::class);

--- a/AdobeStockImage/Test/Unit/Model/SaveLicensedImageTest.php
+++ b/AdobeStockImage/Test/Unit/Model/SaveLicensedImageTest.php
@@ -25,7 +25,7 @@ use PHPUnit\Framework\TestCase;
 class SaveLicensedImageTest extends TestCase
 {
     /**
-     * @var SaveLicensed
+     * @var SaveLicensedImage
      */
     private $sut;
 

--- a/AdobeStockImageAdminUi/Controller/Adminhtml/License/SaveLicensed.php
+++ b/AdobeStockImageAdminUi/Controller/Adminhtml/License/SaveLicensed.php
@@ -36,7 +36,7 @@ class SaveLicensed extends Action
     private $logger;
 
     /**
-     * @var AttributeInterfaceFactory
+     * @var SaveLicensedImageInterface
      */
     private $saveLicensedImage;
 

--- a/AdobeStockImageAdminUi/Test/Unit/Controller/Adminhtml/License/LicenseTest.php
+++ b/AdobeStockImageAdminUi/Test/Unit/Controller/Adminhtml/License/LicenseTest.php
@@ -148,11 +148,11 @@ class LicenseTest extends TestCase
      *
      * @dataProvider exceptionsDataProvider
      *
-     * @param $exception
+     * @param LocalizedException $exception
      * @param int $responseCode
      * @param array $result
      */
-    public function testNotFoundAsset($exception, int $responseCode, array $result): void
+    public function testNotFoundAsset(LocalizedException $exception, int $responseCode, array $result): void
     {
         $mediaId = 283415387;
 

--- a/AdobeStockImageAdminUi/Test/Unit/Controller/Adminhtml/License/SaveLicensedTest.php
+++ b/AdobeStockImageAdminUi/Test/Unit/Controller/Adminhtml/License/SaveLicensedTest.php
@@ -142,11 +142,11 @@ class SaveLicensedTest extends TestCase
      *
      * @dataProvider exceptionsDataProvider
      *
-     * @param $exception
+     * @param LocalizedException $exception
      * @param int $responseCode
      * @param array $result
      */
-    public function testNotFoundAsset($exception, int $responseCode, array $result): void
+    public function testNotFoundAsset(LocalizedException $exception, int $responseCode, array $result): void
     {
         $mediaId = 283415387;
         $destinationPath = 'destination_path';

--- a/AdobeStockImageAdminUi/Test/Unit/Model/Listing/DataProviderTest.php
+++ b/AdobeStockImageAdminUi/Test/Unit/Model/Listing/DataProviderTest.php
@@ -143,9 +143,9 @@ class DataProviderTest extends TestCase
 
     /**
      * @param array $itemsData
-     * @return SearchResultInterface|MockObject
+     * @return MockObject
      */
-    private function getSearchResult(array $itemsData): SearchResultInterface
+    private function getSearchResult(array $itemsData): MockObject
     {
         $items = [];
 

--- a/AdobeStockImageAdminUi/Test/Unit/Model/SignInConfigProviderTest.php
+++ b/AdobeStockImageAdminUi/Test/Unit/Model/SignInConfigProviderTest.php
@@ -103,10 +103,10 @@ class SignInConfigProviderTest extends TestCase
      *
      * @dataProvider exceptionsDataProvider
      *
-     * @param $exception
+     * @param \Exception $exception
      * @param array $userQuota
      */
-    public function testGettingUserQuotaOnExceptions($exception, array $userQuota): void
+    public function testGettingUserQuotaOnExceptions(\Exception $exception, array $userQuota): void
     {
         $userIsAuthorized = true;
         $quotaUrl = 'http://site.com/adobe_stock/license/quota';

--- a/AdobeStockImageAdminUi/Test/Unit/Ui/Component/Listing/Filter/ColorTest.php
+++ b/AdobeStockImageAdminUi/Test/Unit/Ui/Component/Listing/Filter/ColorTest.php
@@ -177,7 +177,7 @@ class ColorTest extends TestCase
         $color->prepare();
     }
 
-    private function verifyApplyFilter(string $appliedValue, Filter $filter, ContextInterface $context): void
+    private function verifyApplyFilter(string $appliedValue, Filter $filter, MockObject $context): void
     {
         $this->filterBuilder->expects($this->once())
             ->method('setConditionType')
@@ -207,9 +207,9 @@ class ColorTest extends TestCase
      * Get wrapped component
      *
      * @param ContextInterface $context
-     * @return MockObject|UiComponentInterface
+     * @return MockObject
      */
-    private function getWrappedComponent(ContextInterface $context): UiComponentInterface
+    private function getWrappedComponent(ContextInterface $context): MockObject
     {
         $wrappedComponent = $this->createMock(UiComponentInterface::class);
         $wrappedComponent->expects($this->once())


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
I've run PHPStan (Level 2) check and found these errors.

```
------ ---------------------------------------------------------------------------- 
  Line   module-adobe-ims-api/Api/Data/UserProfileInterface.php                      
 ------ ---------------------------------------------------------------------------- 
  84     PHPDoc tag @return with type void|null is not subtype of native type void.  
 ------ ---------------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------------------------------- 
  Line   module-adobe-ims/Controller/Adminhtml/OAuth/Callback.php                                      
 ------ ---------------------------------------------------------------------------------------------- 
  110    Call to an undefined method Magento\Backend\Model\Auth\Credential\StorageInterface::getId().  
  155    Call to an undefined method Magento\Backend\Model\Auth\Credential\StorageInterface::getId().  
 ------ ---------------------------------------------------------------------------------------------- 

 ------ ----------------------------------------------------------------------------------- 
  Line   module-adobe-ims/Controller/Adminhtml/User/Logout.php                              
 ------ ----------------------------------------------------------------------------------- 
  52     Call to an undefined method Magento\Framework\HTTP\Client\CurlFactory::execute().  
 ------ ----------------------------------------------------------------------------------- 

 ------ -------------------------------------------------------------------------------------------- 
  Line   module-adobe-ims/Model/GetToken.php                                                         
 ------ -------------------------------------------------------------------------------------------- 
  88     Call to method getAccessToken() on an unknown class Magento\AdobeIms\Model\TokenResponse.   
  88     Call to method getRefreshToken() on an unknown class Magento\AdobeIms\Model\TokenResponse.  
  90     Call to method getError() on an unknown class Magento\AdobeIms\Model\TokenResponse.         
 ------ -------------------------------------------------------------------------------------------- 

 ------ ----------------------------------------------------------------- 
  Line   module-adobe-ims/Test/Unit/Model/GetImageTest.php                
 ------ ----------------------------------------------------------------- 
  111    Call to an undefined method Psr\Log\LoggerInterface::expects().  
 ------ ----------------------------------------------------------------- 

 ------ --------------------------------------------------------------------------------------- 
  Line   module-adobe-ims/Test/Unit/Model/UserProfileRepositoryTest.php                         
 ------ --------------------------------------------------------------------------------------- 
  65     Result of method Magento\AdobeIms\Model\UserProfileRepository::save() (void) is used.  
 ------ --------------------------------------------------------------------------------------- 

 ------ ----------------------------------------------------------------------------------------------------------------------------- 
  Line   module-adobe-stock-asset-api/Api/Data/AssetInterface.php                                                                     
 ------ ----------------------------------------------------------------------------------------------------------------------------- 
  81     PHPDoc tag @return with type Magento\AdobeStockAssetApi\Api\Data\AssetExtensionInterface|null is not subtype of native type  
         Magento\AdobeStockAssetApi\Api\Data\AssetExtensionInterface.                                                                 
 ------ ----------------------------------------------------------------------------------------------------------------------------- 

 ------ ----------------------------------------------------------------------------------------------------------------------------------------------------- 
  Line   module-adobe-stock-asset/Model/CategoryRepository.php                                                                                                
 ------ ----------------------------------------------------------------------------------------------------------------------------------------------------- 
  75     PHPDoc tag @param for parameter $resource with type resource is incompatible with native type Magento\AdobeStockAsset\Model\ResourceModel\Category.  
  108    Cannot call method delete() on resource.                                                                                                             
  139    Cannot call method load() on resource.                                                                                                               
 ------ ----------------------------------------------------------------------------------------------------------------------------------------------------- 

 ------ ----------------------------------------------------------------------------------------------------- 
  Line   module-adobe-stock-asset/Test/Api/AssetRepository/DeleteTest.php                                     
 ------ ----------------------------------------------------------------------------------------------------- 
  119    Call to an undefined method Magento\AdobeStockAsset\Model\ResourceModel\Asset\Collection::create().  
 ------ ----------------------------------------------------------------------------------------------------- 

 ------ ----------------------------------------------------------------------------------------------------- 
  Line   module-adobe-stock-asset/Test/Api/AssetRepository/GetByIdTest.php                                    
 ------ ----------------------------------------------------------------------------------------------------- 
  132    Call to an undefined method Magento\AdobeStockAsset\Model\ResourceModel\Asset\Collection::create().  
 ------ ----------------------------------------------------------------------------------------------------- 

 ------ ----------------------------------------------------------------------------------------- 
  Line   module-adobe-stock-image-admin-ui/Controller/Adminhtml/License/SaveLicensed.php          
 ------ ----------------------------------------------------------------------------------------- 
  67     Call to an undefined method Magento\Framework\Api\AttributeInterfaceFactory::execute().  
 ------ ----------------------------------------------------------------------------------------- 

 ------ -------------------------------------------------------------------------------------------------------------------------- 
  Line   module-adobe-stock-image-admin-ui/Test/Unit/Controller/Adminhtml/License/LicenseTest.php                                  
 ------ -------------------------------------------------------------------------------------------------------------------------- 
  155    PHPDoc tag @param has invalid value ($exception): Unexpected token "$exception", expected TOKEN_IDENTIFIER at offset 134  
 ------ -------------------------------------------------------------------------------------------------------------------------- 

 ------ -------------------------------------------------------------------------------------------------------------------------- 
  Line   module-adobe-stock-image-admin-ui/Test/Unit/Controller/Adminhtml/License/SaveLicensedTest.php                             
 ------ -------------------------------------------------------------------------------------------------------------------------- 
  149    PHPDoc tag @param has invalid value ($exception): Unexpected token "$exception", expected TOKEN_IDENTIFIER at offset 134  
 ------ -------------------------------------------------------------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------- 
  Line   module-adobe-stock-image-admin-ui/Test/Unit/Model/Listing/DataProviderTest.php                                                                         
 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------- 
  148    PHPDoc tag @return with type Magento\Framework\Api\Search\SearchResultInterface|PHPUnit\Framework\MockObject\MockObject is not subtype of native type  
         Magento\Framework\Api\Search\SearchResultInterface.                                                                                                    
 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------- 

 ------ -------------------------------------------------------------------------------------------------------------------------- 
  Line   module-adobe-stock-image-admin-ui/Test/Unit/Model/SignInConfigProviderTest.php                                            
 ------ -------------------------------------------------------------------------------------------------------------------------- 
  109    PHPDoc tag @param has invalid value ($exception): Unexpected token "$exception", expected TOKEN_IDENTIFIER at offset 155  
 ------ -------------------------------------------------------------------------------------------------------------------------- 

 ------ -------------------------------------------------------------------------------------------------------------------------------------------------------- 
  Line   module-adobe-stock-image-admin-ui/Test/Unit/Ui/Component/Listing/Filter/ColorTest.php                                                                   
 ------ -------------------------------------------------------------------------------------------------------------------------------------------------------- 
  198    Call to an undefined method Magento\Framework\View\Element\UiComponent\ContextInterface::expects().                                                     
  212    PHPDoc tag @return with type Magento\Framework\View\Element\UiComponentInterface|PHPUnit\Framework\MockObject\MockObject is not subtype of native type  
         Magento\Framework\View\Element\UiComponentInterface.                                                                                                    
 ------ -------------------------------------------------------------------------------------------------------------------------------------------------------- 

 ------ --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  Line   module-adobe-stock-image/Test/Unit/Model/Extract/DocumentToAssetTest.php                                                                                                         
 ------ --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  148    PHPDoc tag @return with type Magento\Framework\Api\Search\Document|PHPUnit\Framework\MockObject\MockObject is not subtype of native type Magento\Framework\Api\Search\Document.  
 ------ --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------------------------------- 
  Line   module-adobe-stock-image/Test/Unit/Model/GetImageListTest.php                                 
 ------ ---------------------------------------------------------------------------------------------- 
  113    Call to an undefined method Magento\AdobeStockImageApi\Api\ConfigInterface::expects().        
  275    Call to an undefined method Magento\Framework\Api\Search\SearchCriteriaInterface::expects().  
 ------ ---------------------------------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------------------------------------------------------------------------------------- 
  Line   module-adobe-stock-image/Test/Unit/Model/GetRelatedImagesTest.php                                                                                
 ------ ------------------------------------------------------------------------------------------------------------------------------------------------- 
  85     PHPDoc tag @param has invalid value ($expectedResult): Unexpected token "$expectedResult", expected TOKEN_IDENTIFIER at offset 110               
  85     PHPDoc tag @param has invalid value ($relatedImagesProvider): Unexpected token "$relatedImagesProvider", expected TOKEN_IDENTIFIER at offset 73  
 ------ ------------------------------------------------------------------------------------------------------------------------------------------------- 

 ------ --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  Line   module-adobe-stock-image/Test/Unit/Model/SaveImageTest.php                                                                                                                       
 ------ --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  185    PHPDoc tag @return with type Magento\Framework\Api\Search\Document|PHPUnit\Framework\MockObject\MockObject is not subtype of native type Magento\Framework\Api\Search\Document.  
 ------ --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 

 ------ ----------------------------------------------------------------------------------------------------------------------------------- 
  Line   module-adobe-stock-image/Test/Unit/Model/SaveLicensedImageTest.php                                                                 
 ------ ----------------------------------------------------------------------------------------------------------------------------------- 
  91     Method Magento\AdobeStockImageAdminUi\Controller\Adminhtml\License\SaveLicensed::execute() invoked with 2 parameters, 0 required.  
 ------ ----------------------------------------------------------------------------------------------------------------------------------- 

```

All of them have been fixed in the pull request. Some fixes had required small fixes in unit tests as well.

### Manual testing scenarios (*)
No behaviour changed   
Just run current tests should be enough  
One new exception has been introduced but it must not happen, it's just a replacement for possible "method does not exists" php error.