### PR TITLE
AdminAdobeStockImagePreviewKeywordsTest fails consistently && Static test fix

### DIFF
--- a/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockImagePreviewKeywordsTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockImagePreviewKeywordsTest.xml
@@ -31,6 +31,7 @@
         </after>
         <actionGroup ref="AdminAdobeStockExpandImagePreviewActionGroup" stepKey="expandImagePreview"/>
         <!-- Verify view all button and numbers of keywords-->
+        <scrollTo selector="{{AdobeStockImagePreviewSection.viewAllKeywords}}" stepKey="scrollToViewAllButton" />
         <seeElement selector="{{AdobeStockImagePreviewSection.viewAllKeywords}}" stepKey="VerifyViewAllButtonPresnt"/>
         <seeElement selector="{{AdobeStockImagePreviewSection.keywordsTitle}}" stepKey="seeAttributeTitle"/>
         <actionGroup ref="AssertNumberOfKeywordsInImagePreviewActionGroup" stepKey="verifyKeywordsCount">
@@ -40,7 +41,7 @@
         <click selector="{{AdobeStockImagePreviewSection.viewAllKeywords}}" stepKey="clickOnViewAlKeywords"/>
         <!-- Verify that keywords expanded -->
         <actionGroup ref="AssertNumberOfKeywordsInImagePreviewActionGroup" stepKey="verifyKeywordsCountAfterClickViewAll">
-            <argument name="keywordsNumber" value="28"/>
+            <argument name="keywordsNumber" value="50"/>
         </actionGroup>
         <dontSeeElement selector="{{AdobeStockImagePreviewSection.viewAllKeywords}}" stepKey="VerifyViewAllButtonDisappears"/>
         <!-- Verify that keywords closed after navigate to next image -->

--- a/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockImagePreviewKeywordsTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockImagePreviewKeywordsTest.xml
@@ -29,22 +29,28 @@
             <actionGroup ref="resetAdminDataGridToDefaultView" stepKey="resetAdminDataGridToDefaultView"/>
             <actionGroup ref="logout" stepKey="logout"/>
         </after>
+        <actionGroup ref="AdminSearchImagesOnModalActionGroup" stepKey="searchForCars">
+            <argument name="query" value="cars"/>
+        </actionGroup>
         <actionGroup ref="AdminAdobeStockExpandImagePreviewActionGroup" stepKey="expandImagePreview"/>
         <!-- Verify view all button and numbers of keywords-->
-        <scrollTo selector="{{AdobeStockImagePreviewSection.viewAllKeywords}}" stepKey="scrollToViewAllButton" />
+        <executeJS function="document.querySelector('.keywords').scrollIntoView()" stepKey="scrollToKeywords"/>
         <seeElement selector="{{AdobeStockImagePreviewSection.viewAllKeywords}}" stepKey="VerifyViewAllButtonPresnt"/>
         <seeElement selector="{{AdobeStockImagePreviewSection.keywordsTitle}}" stepKey="seeAttributeTitle"/>
         <actionGroup ref="AssertNumberOfKeywordsInImagePreviewActionGroup" stepKey="verifyKeywordsCount">
             <argument name="keywordsNumber" value="5"/>
         </actionGroup>
+        <executeJS function="return document.querySelector('.keywords').childElementCount;" stepKey="expandedKeywordsCount"/>
         <!-- Click view all keywords -->
         <click selector="{{AdobeStockImagePreviewSection.viewAllKeywords}}" stepKey="clickOnViewAlKeywords"/>
         <!-- Verify that keywords expanded -->
-        <actionGroup ref="AssertNumberOfKeywordsInImagePreviewActionGroup" stepKey="verifyKeywordsCountAfterClickViewAll">
-            <argument name="keywordsNumber" value="50"/>
-        </actionGroup>
+        <assertGreaterThan stepKey="assertKeywordsExpanded">
+            <actualResult type="variable">expandedKeywordsCount</actualResult>
+            <expectedResult type="string">5</expectedResult>
+        </assertGreaterThan>
         <dontSeeElement selector="{{AdobeStockImagePreviewSection.viewAllKeywords}}" stepKey="VerifyViewAllButtonDisappears"/>
         <!-- Verify that keywords closed after navigate to next image -->
+        <executeJS function="document.querySelector('.action-next').scrollIntoView()" stepKey="scrollToActions"/>
         <click selector="{{AdobeStockImagePreviewSection.navigation('next')}}" stepKey="navigateToNextImage"/>
         <waitForLoadingMaskToDisappear stepKey="waitForNextImageToLoad"/>
         <click selector="{{AdobeStockImagePreviewSection.navigation('previous')}}" stepKey="navigateToPreviousImage"/>

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/overlay.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/overlay.js
@@ -16,8 +16,11 @@ define([
          * @returns {Object}
          */
         getStyles: function (record) {
-            var height = record.styles()['height'].replace('px', '');
-            return {top: (height - 50) + 'px'};
+            var height = record.styles()['height'].replace('px', '') - 50;
+
+            return {
+                   top: height + 'px'
+                };
         }
     });
 });

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/overlay.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/overlay.js
@@ -16,11 +16,11 @@ define([
          * @returns {Object}
          */
         getStyles: function (record) {
-            var height = record.styles()['height'].replace('px', '') - 50;
+            var height = record.styles().height().replace('px', '') - 50;
 
             return {
-                   top: height + 'px'
-                };
+                top: height + 'px'
+            };
         }
     });
 });

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/keywords.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/keywords.js
@@ -64,6 +64,7 @@ define([
             this.keywordsLimit(record.keywords.length);
             this.canViewMoreKeywords(false);
             this.preview().updateHeight();
+            this.preview().scrollToPreview();
         },
 
         /**


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/adobe-stock-integration#687 AdminAdobeStockImagePreviewKeywordsTest fails consistently

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Expand preview first time
2. Assert that page slowly scrolled correct and keyword section visible
3. Close, open again must be the same behavior