### PR TITLE
AdminAdobeStockSafeContentFilterTest fails consistently

### DIFF
--- a/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockSafeContentFilterTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockSafeContentFilterTest.xml
@@ -28,6 +28,10 @@
             <actionGroup ref="resetAdminDataGridToDefaultView" stepKey="resetAdminDataGridToDefaultView"/>
             <actionGroup ref="logout" stepKey="logout"/>
         </after>
+        
+        <actionGroup ref="AdminSearchImagesOnModalActionGroup" stepKey="searchForPear">
+            <argument name="query" value="cars"/>
+        </actionGroup>
         <grabTextFrom selector="{{AdobeStockSection.recordsFound}}" stepKey="countWithoutSafeFilter"/>
         <actionGroup ref="AdminAdobeStockExpandFiltersActionGroup" stepKey="expandFilters"/>
         <actionGroup ref="AdminUserApplySafeSearchFilterActionGroup" stepKey="see32imagesOnTheSecondPage"/>

--- a/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockSafeContentFilterTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockSafeContentFilterTest.xml
@@ -34,7 +34,7 @@
         </actionGroup>
         <grabTextFrom selector="{{AdobeStockSection.recordsFound}}" stepKey="countWithoutSafeFilter"/>
         <actionGroup ref="AdminAdobeStockExpandFiltersActionGroup" stepKey="expandFilters"/>
-        <actionGroup ref="AdminUserApplySafeSearchFilterActionGroup" stepKey="see32imagesOnTheSecondPage"/>
+        <actionGroup ref="AdminUserApplySafeSearchFilterActionGroup" stepKey="applySafeSearchFilter"/>
         <grabTextFrom selector="{{AdobeStockSection.recordsFound}}" stepKey="countWithAppliedFilter"/>
         <assertNotContains stepKey="checkThatResultCountChangesAfterFilterApplied">
             <actualResult type="variable">$countWithoutSafeFilter</actualResult>

--- a/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockSafeContentFilterTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockSafeContentFilterTest.xml
@@ -29,7 +29,7 @@
             <actionGroup ref="logout" stepKey="logout"/>
         </after>
         
-        <actionGroup ref="AdminSearchImagesOnModalActionGroup" stepKey="searchForPear">
+        <actionGroup ref="AdminSearchImagesOnModalActionGroup" stepKey="searchForCars">
             <argument name="query" value="cars"/>
         </actionGroup>
         <grabTextFrom selector="{{AdobeStockSection.recordsFound}}" stepKey="countWithoutSafeFilter"/>


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Added words filter to disable default gallery_id filter

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/adobe-stock-integration#684: AdminAdobeStockSafeContentFilterTest fails consistently


### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
Run functional tests