### PR TITLE
Fix Search by keywords is broken

### DIFF
--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/keywords.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/keywords.js
@@ -21,10 +21,6 @@ define([
                 chips: '${ $.chipsProvider }',
                 preview: '${ $.parentName }.preview'
             },
-            exports: {
-                inputValue: '${ $.provider }:params.search',
-                chipInputValue: '${ $.searchChipsProvider }:value'
-            }
         },
 
         /**
@@ -79,8 +75,7 @@ define([
          */
         searchByKeyWord: function (keyword) {
             _.invoke(this.chips().elems(), 'clear');
-            this.inputValue(keyword);
-            this.chipInputValue(keyword);
+            _.invoke(this.chips().elems(), 'apply', keyword);
         }
     });
 });

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/keywords.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/keywords.js
@@ -12,12 +12,10 @@ define([
         defaults: {
             template: 'Magento_AdobeStockImageAdminUi/grid/column/preview/keywords',
             chipsProvider: 'componentType = filtersChips, ns = ${ $.ns }',
-            searchChipsProvider: 'componentType = keyword_search, ns = ${ $.ns }',
             defaultKeywordsLimit: 5,
             keywordsLimit: 5,
             canViewMoreKeywords: true,
             modules: {
-                searchChips: '${ $.searchChipsProvider }',
                 chips: '${ $.chipsProvider }',
                 preview: '${ $.parentName }.preview'
             }

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/keywords.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/keywords.js
@@ -20,7 +20,7 @@ define([
                 searchChips: '${ $.searchChipsProvider }',
                 chips: '${ $.chipsProvider }',
                 preview: '${ $.parentName }.preview'
-            },
+            }
         },
 
         /**


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/adobe-stock-integration#694: Search by keywords is broken
2. ...

### Manual testing scenarios (*)

1. Login to admin panel
2. Navigate to Cms Pages
3. User clicks Add New Page button
4. Expand "Content" section
5. User clicks "Insert Image..." button
6. Click "Search Adobe Stock" button to open images grid
7. Click on an image to expand the preview
8. Click on first image keyword

Grid result is updated
Selected keyword is shown in the search filter