### PR TITLE
#514 : [Bug] Serie Id and Model Id filters do not indicate applied values after relogin to admin panel 

### DIFF
--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/image-preview.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/image-preview.js
@@ -32,7 +32,8 @@ define([
                 },
                 {
                     component: 'Magento_AdobeStockImageAdminUi/js/components/grid/column/preview/related',
-                    name: '${ $.name }_related'
+                    name: '${ $.name }_related',
+                    provider: '${ $.provider }'
                 },
                 {
                     component: 'Magento_AdobeStockImageAdminUi/js/components/grid/column/preview/actions',


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR will fix the issue with series id and model id filter value which are persisted after relogin to magento grid
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/adobe-stock-integration#514: [Bug] Serie Id and Model Id filters do not indicate applied values after relogin to admin panel 

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Login to admin panel
2. Open Magento Media Gallery (i.e. go to Cms -> Pages, edit the page and insert image)
3. Click "Search Adobe Stock" button to open images grid
4. Click on any image to expand image preview
5. Click on "See more" link in the related images section
6. Logout from admin panel
7. Login back to admin panel
8. Reopen the Adobe Stock grid

### Expected Result
Series Id or Model Id value should be visible in the filter chips