### PR TITLE
#704 Add check for non strict_types=1 files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,5 +54,6 @@ script:
   - if [ $TEST_SUITE == 'unit' ]; then phpunit --configuration dev/tests/unit/phpunit.xml; fi
   - if [ $TEST_SUITE == 'phpstan' ]; then composer require --dev phpstan/phpstan fooman/phpstan-magento2-magic-methods && phpstan analyse -l 2 ../ext -a dev/tests/api-functional/framework/autoload.php ; fi
   - if [ $TEST_SUITE == 'static' ]; then phpcs --standard=dev/tests/static/framework/Magento/ ../ext ; fi
+  - if [ $TEST_SUITE == 'static' ]; then ! find ../ext -type f -name "*.php" -exec grep -L strict_types=1 {} + | grep ext/magento/adobe-stock-integration/; fi
 after_success:
   - if [ $TEST_SUITE == 'unit' ]; then cd ../ && travis_retry coveralls; fi

--- a/AdobeIms/registration.php
+++ b/AdobeIms/registration.php
@@ -3,6 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
 use Magento\Framework\Component\ComponentRegistrar;
 

--- a/AdobeImsApi/registration.php
+++ b/AdobeImsApi/registration.php
@@ -3,6 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
 use Magento\Framework\Component\ComponentRegistrar;
 

--- a/AdobeStockAdminUi/registration.php
+++ b/AdobeStockAdminUi/registration.php
@@ -3,6 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
 use Magento\Framework\Component\ComponentRegistrar;
 

--- a/AdobeStockAsset/Test/Unit/Model/GetAssetByIdTest.php
+++ b/AdobeStockAsset/Test/Unit/Model/GetAssetByIdTest.php
@@ -3,6 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
 namespace Magento\AdobeStockAsset\Test\Unit\Model;
 

--- a/AdobeStockAsset/Test/Unit/Model/SaveAssetTest.php
+++ b/AdobeStockAsset/Test/Unit/Model/SaveAssetTest.php
@@ -3,6 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
 namespace Magento\AdobeStockAsset\Test\Unit\Model;
 

--- a/AdobeStockAsset/registration.php
+++ b/AdobeStockAsset/registration.php
@@ -3,6 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
 use Magento\Framework\Component\ComponentRegistrar;
 

--- a/AdobeStockAssetApi/registration.php
+++ b/AdobeStockAssetApi/registration.php
@@ -3,6 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
 use Magento\Framework\Component\ComponentRegistrar;
 

--- a/AdobeStockClient/Model/SearchParametersProvider/Premium.php
+++ b/AdobeStockClient/Model/SearchParametersProvider/Premium.php
@@ -3,6 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
 namespace Magento\AdobeStockClient\Model\SearchParametersProvider;
 

--- a/AdobeStockClient/registration.php
+++ b/AdobeStockClient/registration.php
@@ -3,6 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
 use Magento\Framework\Component\ComponentRegistrar;
 

--- a/AdobeStockClientApi/registration.php
+++ b/AdobeStockClientApi/registration.php
@@ -3,6 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
 use Magento\Framework\Component\ComponentRegistrar;
 

--- a/AdobeStockImage/Test/Api/SearchExecuteTest.php
+++ b/AdobeStockImage/Test/Api/SearchExecuteTest.php
@@ -3,6 +3,8 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento\AdobeStockImage\Test\Api;
 
 use Magento\Framework\Api\FilterBuilder;

--- a/AdobeStockImage/Test/Unit/Model/GetRelatedImagesTest.php
+++ b/AdobeStockImage/Test/Unit/Model/GetRelatedImagesTest.php
@@ -3,6 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
 namespace Magento\AdobeStockImage\Test\Unit\Model;
 

--- a/AdobeStockImage/Test/Unit/Model/Storage/DeleteTest.php
+++ b/AdobeStockImage/Test/Unit/Model/Storage/DeleteTest.php
@@ -3,6 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
 namespace Magento\AdobeStockImage\Test\Unit\Model\Storage;
 

--- a/AdobeStockImage/Test/Unit/Model/Storage/SaveTest.php
+++ b/AdobeStockImage/Test/Unit/Model/Storage/SaveTest.php
@@ -3,6 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
 namespace Magento\AdobeStockImage\Test\Unit\Model\Storage;
 

--- a/AdobeStockImage/registration.php
+++ b/AdobeStockImage/registration.php
@@ -3,6 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
 use Magento\Framework\Component\ComponentRegistrar;
 

--- a/AdobeStockImageAdminUi/registration.php
+++ b/AdobeStockImageAdminUi/registration.php
@@ -3,6 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
 use Magento\Framework\Component\ComponentRegistrar;
 

--- a/AdobeStockImageApi/registration.php
+++ b/AdobeStockImageApi/registration.php
@@ -3,6 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
 use Magento\Framework\Component\ComponentRegistrar;
 


### PR DESCRIPTION
Ticket #704 

### Description
Core Magento LiveCodeTest.php file tests files for having `strict_types=1` in changed files. But there is no way to check all codebase or provided folder. I've created a script to find all PHP files in our repository and check if they have these lines.

After setting up check it was found that 17 files didn't have the required declaration and they were fixed in this pull request.

Example of a job fail when files without strict_types=1 found: https://travis-ci.org/magento/adobe-stock-integration/jobs/613269038

Example of a success job once all files fixed: https://travis-ci.org/magento/adobe-stock-integration/jobs/613269754