### PR TITLE
MFTF Automation for: User locates preview image in the Media Gallery

### DIFF
--- a/AdobeStockImageAdminUi/Test/Mftf/ActionGroup/AdminMediaGalleryDeleteImageActionGroup.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/ActionGroup/AdminMediaGalleryDeleteImageActionGroup.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="AdminMediaGalleryDeleteImage">
+        <arguments>
+            <argument name="generatedImageName" type="string"/>
+        </arguments>
+        <seeElement selector="{{AdobeStockSection.mediaGalleryImage(generatedImageName)}}" stepKey="seeImageToDelete"/>
+        <click selector="{{AdobeStockSection.mediaGalleryImage(generatedImageName)}}" stepKey="clickImageToDelete"/>
+        <waitForElementVisible selector="{{AdobeStockSection.mediaGalleryDeleteButton}}" stepKey="waitForDeleteButton"/>
+        <click selector="{{AdobeStockSection.mediaGalleryDeleteButton}}" stepKey="clickDeleteButton"/>
+        <waitForElementVisible selector="{{AdobeStockImagePreviewSection.confirm}}" stepKey="waitForConfirmationModal"/>
+        <click selector="{{AdobeStockImagePreviewSection.confirm}}" stepKey="clickConfirmButton"/>
+        <waitForPageLoad stepKey="waitForMaskDisappeared"/>
+        <dontSeeElement selector="{{AdobeStockSection.mediaGalleryImage(generatedImageName)}}" stepKey="assertImageIsDeleted"/>
+    </actionGroup>
+</actionGroups>

--- a/AdobeStockImageAdminUi/Test/Mftf/ActionGroup/AdminMediaGalleryDeleteImageActionGroup.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/ActionGroup/AdminMediaGalleryDeleteImageActionGroup.xml
@@ -13,6 +13,12 @@
         </arguments>
         <seeElement selector="{{AdobeStockSection.mediaGalleryImage(generatedImageName)}}" stepKey="seeImageToDelete"/>
         <click selector="{{AdobeStockSection.mediaGalleryImage(generatedImageName)}}" stepKey="clickImageToDelete"/>
+        <!-- Click image again, incase image was already selected and above step unselected the image by clicking it -->
+        <conditionalClick
+            visible="false"
+            dependentSelector="{{AdobeStockSection.mediaGalleryDeleteButton}}"
+            selector="{{AdobeStockSection.mediaGalleryImage(generatedImageName)}}"
+            stepKey="clickImageToDeleteAgain"/>
         <waitForElementVisible selector="{{AdobeStockSection.mediaGalleryDeleteButton}}" stepKey="waitForDeleteButton"/>
         <click selector="{{AdobeStockSection.mediaGalleryDeleteButton}}" stepKey="clickDeleteButton"/>
         <waitForElementVisible selector="{{AdobeStockImagePreviewSection.confirm}}" stepKey="waitForConfirmationModal"/>

--- a/AdobeStockImageAdminUi/Test/Mftf/Data/AdobeStockConfigData.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Data/AdobeStockConfigData.xml
@@ -29,4 +29,7 @@
     <entity name="AdobeStockConfigDataSignInPasswordData">
         <data key="value">{{_ENV.ADOBE_STOCK_USER_PASSWORD}}</data>
     </entity>
+    <entity name="AdobeStockConfigDataUnlicensedImage">
+        <data key="value">{{_ENV.ADOBE_STOCK_UNLICENSED_IMAGE}}</data>
+    </entity>
 </entities>

--- a/AdobeStockImageAdminUi/Test/Mftf/Section/AdobeStockImagePreviewSection.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Section/AdobeStockImagePreviewSection.xml
@@ -8,7 +8,8 @@
 
 <sections xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:mftf:Page/etc/SectionObject.xsd">
     <section name="AdobeStockImagePreviewSection">
-        <element name="save" type="block" selector="//button[@class='action-secondary']/span[contains(.,'Save Preview')]"/>
+        <element name="savePreview" type="button" selector="//button[@class='action-secondary']//span[text()='Save Preview']"/>
+        <element name="locateImage" type="button" selector="//button[@class='action-secondary']//span[text()='Locate']"/>
         <element name="image" type="block" selector="//div[@class='masonry-image-preview']//img"/>
         <element name="navigation" type="button" selector="//div[@class='masonry-image-preview']//div[contains(@class, 'action-buttons')]/button[@class='action-{{type}}']" parameterized="true"/>
         <element name="attribute" type="block" selector="//*[@id='adobe-stock-images-search-modal']//div[@data-role='image-attributes-value']//span[text()='{{type}}']/parent::div//div[@class='value']//span" parameterized="true"/>

--- a/AdobeStockImageAdminUi/Test/Mftf/Section/AdobeStockSection.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Section/AdobeStockSection.xml
@@ -21,7 +21,8 @@
         <element name="modalError" type="text" selector="//aside[contains(@class, 'modal-popup')]//div[@class='modal-content']//div[text()='Something went wrong.']"/>
         <element name="countGridImages" type="text" selector="//div[@class='masonry-image-grid']/div[contains(.,data-repeat-index)]"/>
         <element name="recordsFound" type="text" selector="//*[@id='adobe-stock-images-search-modal']//*[text()='records found']/parent::div"/>
-        <element name="selectedImagePreview" type="text" selector="//img[contains(@alt,'{{imageName}}')]" parameterized="true"/>
+        <element name="mediaGalleryImage" type="button" selector="//img[contains(@alt,'{{imageName}}')]" parameterized="true"/>
+        <element name="mediaGalleryDeleteButton" type="button" selector="#delete_files"/>
         <element name="systemAclActions" type="checkbox" selector="//a[text()='Adobe Stock']/parent::li[contains(.,'Actions')]//a"/>
         <element name="adobeSignIn" type="button" selector=".adobe-sign-in-button"/>
         <element name="adobeImsPopupUserEmail" type="button" selector="#adobeid_username"/>

--- a/AdobeStockImageAdminUi/Test/Mftf/Section/AdobeStockSection.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Section/AdobeStockSection.xml
@@ -22,7 +22,7 @@
         <element name="countGridImages" type="text" selector="//div[@class='masonry-image-grid']/div[contains(.,data-repeat-index)]"/>
         <element name="recordsFound" type="text" selector="//*[@id='adobe-stock-images-search-modal']//*[text()='records found']/parent::div"/>
         <element name="mediaGalleryImage" type="button" selector="//img[contains(@alt,'{{imageName}}')]" parameterized="true"/>
-        <element name="mediaGalleryDeleteButton" type="button" selector="#delete_files"/>
+        <element name="mediaGalleryDeleteButton" type="button" selector="[data-ui-id=wysiwyg-images-content-delete-files-button]"/>
         <element name="systemAclActions" type="checkbox" selector="//a[text()='Adobe Stock']/parent::li[contains(.,'Actions')]//a"/>
         <element name="adobeSignIn" type="button" selector=".adobe-sign-in-button"/>
         <element name="adobeImsPopupUserEmail" type="button" selector="#adobeid_username"/>

--- a/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockPreviewedNotLicensedImageLocateTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockPreviewedNotLicensedImageLocateTest.xml
@@ -10,7 +10,7 @@
     <test name="AdminAdobeStockPreviewedNotLicensedImageLocateTest">
         <annotations>
             <features value="AdobeStockImagePanel"/>
-            <stories value="User locates preview saved image inside Media Gallery"/>
+            <stories value="User locates preview image in the Media Gallery"/>
             <title value="Adobe Stock Preview Saved Image Locate"/>
             <description value="User can locate previously preview saved and unlicensed image in Media Gallery"/>
             <severity value="CRITICAL"/>
@@ -39,9 +39,6 @@
         </before>
         <after>
             <actionGroup ref="AdminOpenMediaGalleryForPageNoEditorActionGroup" stepKey="openMediaGalleryForPage"/>
-            <actionGroup ref="AdminMediaGalleryDeleteImage" stepKey="deleteImageActionGroup">
-                <argument name="generatedImageName" value="{$grabImageFileName}"/>
-            </actionGroup>
             <actionGroup ref="AdminAdobeStockOpenPanelFromMediaGalleryActionGroup" stepKey="openAdobeStockPanel"/>
             <actionGroup ref="AdminAdobeStockUserSignOutActionGroup" stepKey="adobeLogout"/>
             <actionGroup ref="AdminAdobeStockAssertUserNotLoggedActionGroup" stepKey="assertAdobeUserLoggedOut"/>
@@ -56,5 +53,8 @@
         <click selector="{{AdobeStockImagePreviewSection.locateImage}}" stepKey="clickLocate"/>
         <waitForPageLoad stepKey="waitForMediaGalleryOpen"/>
         <seeElement selector="{{AdobeStockSection.mediaGalleryImage({$grabImageFileName})}}" stepKey="assertSavedImage"/>
+        <actionGroup ref="AdminMediaGalleryDeleteImage" stepKey="deleteImageActionGroup">
+            <argument name="generatedImageName" value="{$grabImageFileName}"/>
+        </actionGroup>
     </test>
 </tests>

--- a/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockPreviewedNotLicensedImageLocateTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockPreviewedNotLicensedImageLocateTest.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+    <test name="AdminAdobeStockPreviewedNotLicensedImageLocateTest">
+        <annotations>
+            <features value="AdobeStockImagePanel"/>
+            <stories value="User locates preview saved image inside Media Gallery"/>
+            <title value="Adobe Stock Preview Saved Image Locate"/>
+            <description value="User can locate previously preview saved and unlicensed image in Media Gallery"/>
+            <severity value="CRITICAL"/>
+            <group value="adobe_stock_integration_license"/>
+            <group value="adobe_stock_integration"/>
+        </annotations>
+        <before>
+            <actionGroup ref="LoginAsAdmin" stepKey="loginAsAdmin"/>
+            <actionGroup ref="AdminOpenMediaGalleryForPageNoEditorActionGroup" stepKey="openMediaGalleryForPage"/>
+            <actionGroup ref="AdminAdobeStockOpenPanelFromMediaGalleryActionGroup" stepKey="openAdobeStockPanel"/>
+            <actionGroup ref="AdminAdobeStockClickSignInActionGroup" stepKey="clickOnSignIn"/>
+            <actionGroup ref="AdminAdobeStockImsPopupSignInFillUserDataActionGroup" stepKey="fillUserCredentials"/>
+            <actionGroup ref="AdminAdobeStockImsPopupClickSignInActionGroup" stepKey="clickSignInImsPopup"/>
+            <actionGroup ref="AdminAdobeStockAssertUserLoggedActionGroup" stepKey="assertUserLoggedIn"/>
+            <actionGroup ref="AdminSearchImagesOnModalActionGroup" stepKey="searchForUnlicensedImage">
+                <argument name="query" value="{{AdobeStockConfigDataUnlicensedImage.value}}"/>
+            </actionGroup>
+            <actionGroup ref="AdminAdobeStockExpandImagePreviewActionGroup" stepKey="expandUnlicensedImage"/>
+            <click selector="{{AdobeStockImagePreviewSection.savePreview}}" stepKey="clickSavePreviewButton"/>
+            <waitForPageLoad stepKey="waitForPromptModal"/>
+            <grabValueFrom selector="{{AdobeStockImagePreviewSection.generatedImageName}}" stepKey="grabSaveImageFileName"/>
+            <click selector="{{AdobeStockImagePreviewSection.confirm}}" stepKey="clickOnPopupConfirm"/>
+            <waitForPageLoad stepKey="waitForMediaGalleryOpen"/>
+            <seeElement selector="{{AdobeStockSection.mediaGalleryImage({$grabSaveImageFileName})}}" stepKey="assertSavedImage"/>
+            <actionGroup ref="AdminAdobeStockOpenPanelFromMediaGalleryActionGroup" stepKey="openAdobeStockPanelAgain"/>
+        </before>
+        <after>
+            <actionGroup ref="AdminOpenMediaGalleryForPageNoEditorActionGroup" stepKey="openMediaGalleryForPage"/>
+            <actionGroup ref="AdminMediaGalleryDeleteImage" stepKey="deleteImageActionGroup">
+                <argument name="generatedImageName" value="{$grabImageFileName}"/>
+            </actionGroup>
+            <actionGroup ref="AdminAdobeStockOpenPanelFromMediaGalleryActionGroup" stepKey="openAdobeStockPanel"/>
+            <actionGroup ref="AdminAdobeStockUserSignOutActionGroup" stepKey="adobeLogout"/>
+            <actionGroup ref="AdminAdobeStockAssertUserNotLoggedActionGroup" stepKey="assertAdobeUserLoggedOut"/>
+            <actionGroup ref="resetAdminDataGridToDefaultView" stepKey="resetAdminDataGridToDefaultView"/>
+            <actionGroup ref="logout" stepKey="adminLogout"/>
+        </after>
+        <actionGroup ref="AdminSearchImagesOnModalActionGroup" stepKey="searchForPreviewedImage">
+            <argument name="query" value="{{AdobeStockConfigDataUnlicensedImage.value}}"/>
+        </actionGroup>
+        <actionGroup ref="AdminAdobeStockExpandImagePreviewActionGroup" stepKey="expandPreviewedImage"/>
+        <grabAttributeFrom selector="{{AdobeStockImagePreviewSection.locateImage}}" userInput="name" stepKey="grabImageFileName"/>
+        <click selector="{{AdobeStockImagePreviewSection.locateImage}}" stepKey="clickLocate"/>
+        <waitForPageLoad stepKey="waitForMediaGalleryOpen"/>
+        <seeElement selector="{{AdobeStockSection.mediaGalleryImage({$grabImageFileName})}}" stepKey="assertSavedImage"/>
+    </test>
+</tests>

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/actions.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/actions.js
@@ -414,6 +414,15 @@ define([
          */
         getLicenseButtonTitle: function () {
             return this.isDownloaded() ?  $.mage.__('License') : $.mage.__('License and Save');
+        },
+
+        /**
+         * Returns image name of previously saved preview image
+         *
+         * @returns {String}
+         */
+        getImageName: function () {
+            return this.preview().displayedRecord()['path'].split('/').pop();
         }
     });
 });

--- a/AdobeStockImageAdminUi/view/adminhtml/web/template/grid/column/preview/actions.html
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/template/grid/column/preview/actions.html
@@ -18,8 +18,10 @@
 <button class="action-secondary" type="button" data-bind="visible: !isDownloaded() && !isLicensed(), click: function(){ savePreview() }">
     <span translate="'Save Preview'"/>
 </button>
-<button class="action-secondary" type="button" data-bind="visible: isDownloaded(), click: function(){ locate() }">
-    <span translate="'Locate'"/>
+<button class="action-secondary"
+        type="button"
+        data-bind="visible: isDownloaded(), click: function(){ locate() }">
+    <span attr="name: getImageName()" translate="'Locate'"/>
 </button>
 <button class="action-default primary"
         type="button"


### PR DESCRIPTION
### Description
Added MFTF test for below mentioned issue

### Fixed Issues
-  magento/adobe-stock-integration#446: [MFTF] User locates preview image in the Media Gallery

### Manual testing scenarios
`vendor/bin/mftf run:test AdminAdobeStockPreviewedNotLicensedImageLocateTest --remove`