### PR TITLE
Resolved issue 644

### DIFF
--- a/AdobeStockImageAdminUi/view/adminhtml/web/css/source/_module.less
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/css/source/_module.less
@@ -98,7 +98,7 @@
             select {
                 border: none;
                 background-image: url(../images/arrows-bg.svg);
-                padding-right: 2.2rem;
+                padding-right: 3.6rem;
 
                 &:active {
                     background-image+: url('../images/arrows-bg.svg');

--- a/AdobeStockImageAdminUi/view/adminhtml/web/template/grid/toolbar.html
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/template/grid/toolbar.html
@@ -15,13 +15,13 @@
             'col-xs-10': hasChild('listing_massaction'),
             'col-xs-12': !hasChild('listing_massaction')">
             <div class="row">
-                <div class="col-xs-4">
+                <div class="col-xs-5">
                     <div class="masonry-results-number" ko-scope="requestChild('listing_paging')">
                         <render args="totalTmpl"/>
                     </div>
                     <each args="getRegion('sorting')" render=""/>
                 </div>
-                <div class="col-xs-8" ko-scope="requestChild('listing_paging')">
+                <div class="col-xs-7" ko-scope="requestChild('listing_paging')">
                     <div render=""/>
                 </div>
             </div>


### PR DESCRIPTION
### Description
- Added extra padding to the right and increased container size by one point to accomodate extra padding. This doesn't lead to any visible container reorganization. Just extra padding

### Fixed Issues
-  magento/adobe-stock-integration#644: Overflowing text in sort dropdown

### Manual testing scenarios
1.  Open Adobe Stock panel
2.  Verify sort options text don't overflow for all options