### PR TITLE
Resolved issue 691

### DIFF
--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/panel.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/panel.js
@@ -25,6 +25,11 @@ define([
          * @return {exports}
          */
         initialize: function () {
+            var imageIndex, startIndex, endIndex,
+                imagePreviewSelector = '.masonry-image-preview',
+                imageColumnSelector = '.masonry-image-column',
+                adobeModalSelector = '.adobe-stock-modal';
+
             this._super();
 
             $(this.containerId).modal({
@@ -35,6 +40,25 @@ define([
             }).on('openModal', function () {
                 this.masonry().setLayoutStylesWhenLoaded();
             }.bind(this)).applyBindings();
+
+            $(document).on('keydown', function(e) {
+                startIndex = 0;
+                endIndex = $('.masonry-image-grid')[0].children.length - 1;
+
+                if($(imagePreviewSelector).length > 0) {
+                    imageIndex = $(imagePreviewSelector)
+                        .parents(imageColumnSelector)
+                        .data('repeatIndex');
+                }
+
+                if($(adobeModalSelector).hasClass('_show')) {
+                    if(e.keyCode === 37 && imageIndex !== startIndex) {
+                        $(imagePreviewSelector + ' .action-previous').click();
+                    } else if (e.keyCode === 39 && imageIndex !== endIndex) {
+                        $(imagePreviewSelector + ' .action-next').click();
+                    }
+                }
+            });
 
             return this;
         }


### PR DESCRIPTION
### Description
-  Added left//right arrow navigation for image preview in grid
-  Various checks involved to prevent JS errors
   -  Check if image preview is opened
   -  Check if Adobe Stock panel is opened
   -  Prevent left navigation for first image
   -  Prevent right navigation for last image

### Fixed Issues
-  magento/adobe-stock-integration#691: Cannot navigate to next image in preview using keyboard arrows

### Manual testing scenarios
1.  Open Adobe Stock panel
2.  Open any image preview
3.  Navigate left and right with keyboard arrow keys