### PR TITLE
Fixed Adobe configuration settings

### DIFF
--- a/AdobeStockAdminUi/etc/adminhtml/system.xml
+++ b/AdobeStockAdminUi/etc/adminhtml/system.xml
@@ -16,30 +16,26 @@
                     <config_path>adobe_stock/integration/enabled</config_path>
                 </field>
                 <field id="api_key" translate="label" type="password" sortOrder="20" showInDefault="1" showInWebsite="0" showInStore="0">
-                    <label>API Key</label>
-                    <comment><![CDATA[Configure an Adobe Stock account on the <a href="https://console.adobe.io/" target="_blank">Adobe.io</a> site to retrieve an API key (Client ID).]]></comment>
+                    <label>API Key (Client ID)</label>
                     <config_path>adobe_stock/integration/api_key</config_path>
-                    <validate>required-entry</validate>
                     <backend_model>Magento\Config\Model\Config\Backend\Encrypted</backend_model>
                     <depends>
                         <field id="enabled">1</field>
                     </depends>
                 </field>
-                <field id="adobe_stock_test_connect_wizard" translate="button_label" sortOrder="30" showInDefault="1" showInWebsite="0" showInStore="0">
+                <field id="private_key" translate="label" type="password" sortOrder="30" showInDefault="1" showInWebsite="0" showInStore="0">
+                    <label>Client Secret</label>
+                    <config_path>adobe_stock/integration/private_key</config_path>
+                    <backend_model>Magento\Config\Model\Config\Backend\Encrypted</backend_model>
+                    <depends>
+                        <field id="enabled">1</field>
+                    </depends>
+                    <comment><![CDATA[Configure an Adobe Stock account on <a href="https://console.adobe.io" target="_blank">adobe.io</a> to get the API Key (Client ID) and Client Secret. You will not be able to use the integration without both the API Key and Client Secret.]]></comment>
+                </field>
+                <field id="adobe_stock_test_connect_wizard" translate="button_label" sortOrder="40" showInDefault="1" showInWebsite="0" showInStore="0">
                     <label/>
                     <button_label>Test Connection</button_label>
                     <frontend_model>Magento\AdobeStockAdminUi\Block\Adminhtml\System\Config\TestConnection</frontend_model>
-                    <depends>
-                        <field id="enabled">1</field>
-                    </depends>
-                    <comment><![CDATA[Check currently inserted value on the fly or already saved value if the API Key input value is not changed.]]></comment>
-                </field>
-                <field id="private_key" translate="label" type="password" sortOrder="40" showInDefault="1" showInWebsite="0" showInStore="0">
-                    <label>Private Key</label>
-                    <comment model="Magento\AdobeStockAdminUi\Model\System\Config\Comment" />
-                    <config_path>adobe_stock/integration/private_key</config_path>
-                    <validate>required-entry</validate>
-                    <backend_model>Magento\Config\Model\Config\Backend\Encrypted</backend_model>
                     <depends>
                         <field id="enabled">1</field>
                     </depends>


### PR DESCRIPTION
### Description

-  Removed `required-entry` validation for API Key and Client Secret fields
-  Fixed layout and comment according to https://github.com/magento/adobe-stock-integration/issues/696#issuecomment-554009737

### Fixed Issues

-  magento/adobe-stock-integration#696: Configuration cannot be saved if Adobe Stock Integration is not configured

### Manual testing scenarios

-  Open Adobe Stock configuration and verify layout
-  Save configuration without inputting keys