### PR TITLE
[WIP] Use image ID as a proposed filename for non-latin titles

### DIFF
--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/actions.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/actions.js
@@ -177,10 +177,13 @@ define([
          * @return string
          */
         generateImageName: function (record) {
-            return record.title.substring(0, 32)
+            var fileName = record.title.substring(0, 32)
                 .replace(/[^a-zA-Z0-9_]/g, '-')
                 .replace(/-{2,}/g, '-')
                 .toLowerCase();
+
+            /* If the filename does not contain latin chars, use ID as a filename */
+            return fileName === '-' ? record.id : fileName;
         },
 
         /**


### PR DESCRIPTION
### Description (*)
This PR introduces a slightly changed logic for media gallery file name generation. In case if an image from Adobe Stock does not have latin characters in its title, the image ID will be proposed as a file name. 

### Fixed Issues (if relevant)
1. #678 : Image file name is not visible if the title is in other than English language

### Manual testing scenarios (*)
1. Login to admin panel
2. Open Magento Media Gallery (i.e. go to Cms -> Pages, edit the page and insert image)
3. Click "Search Adobe Stock" button to open images grid
4. Enter text `246811446` in search by keywords
5. Click on the image to open the image preview
6. Click on Save Preview button

The image ID should be proposed as the file name. 