### PR TITLE
[WIP] Add ability to get the image asset data by request

### DIFF
--- a/AdobeStockAsset/Model/GetAssetById.php
+++ b/AdobeStockAsset/Model/GetAssetById.php
@@ -21,6 +21,8 @@ use Magento\AdobeStockAssetApi\Api\GetAssetByIdInterface;
  */
 class GetAssetById implements GetAssetByIdInterface
 {
+    private const MEDIA_ID = 'media_id';
+
     /**
      * @var SearchCriteriaBuilder
      */
@@ -56,7 +58,7 @@ class GetAssetById implements GetAssetByIdInterface
      */
     public function execute(int $adobeId): Document
     {
-        $mediaIdFilter = $this->filterBuilder->setField('media_id')
+        $mediaIdFilter = $this->filterBuilder->setField(self::MEDIA_ID)
             ->setValue($adobeId)
             ->create();
         $searchCriteria = $this->searchCriteriaBuilder

--- a/AdobeStockImage/Model/GetImageDataSerialised.php
+++ b/AdobeStockImage/Model/GetImageDataSerialised.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Magento\AdobeStockImage\Model;
+
+use Magento\AdobeStockAssetApi\Api\GetAssetByIdInterface;
+use Magento\AdobeStockImageApi\Api\GetImageDataSerialisedInterface;
+use Magento\Framework\Exception\IntegrationException;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Class GetImageDataSerialised
+ */
+class GetImageDataSerialised implements GetImageDataSerialisedInterface
+{
+    /**
+     * @var GetAssetByIdInterface
+     */
+    private $getAssetById;
+
+    /**
+     * @var SerializeImageAsset
+     */
+    private $serializeImageAsset;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * GetImageDataSerialised constructor.
+     *
+     * @param GetAssetByIdInterface $getAssetById
+     * @param SerializeImageAsset $serializeImageAsset
+     * @param LoggerInterface $logger
+     */
+    public function __construct(
+        GetAssetByIdInterface $getAssetById,
+        SerializeImageAsset $serializeImageAsset,
+        LoggerInterface $logger
+    ) {
+        $this->getAssetById = $getAssetById;
+        $this->serializeImageAsset = $serializeImageAsset;
+        $this->logger = $logger;
+    }
+
+    /**
+     * @param int $imageAssetId
+     *
+     * @return array
+     * @throws IntegrationException
+     */
+    public function execute(int $imageAssetId): array
+    {
+        try {
+            $imageAsset = $this->getAssetById->execute($imageAssetId);
+            $imageAssetSerialized = $this->serializeImageAsset->execute([$imageAsset]);
+
+            return $imageAssetSerialized;
+        } catch (\Exception $exception) {
+            $this->logger->critical($exception);
+            $message = __('Image asset serialisation failed: %error', ['error' => $exception->getMessage()]);
+            throw new IntegrationException($message, $exception);
+        }
+    }
+}

--- a/AdobeStockImage/Model/GetImageDataSerialised.php
+++ b/AdobeStockImage/Model/GetImageDataSerialised.php
@@ -51,10 +51,11 @@ class GetImageDataSerialised implements GetImageDataSerialisedInterface
     }
 
     /**
-     * @param int $imageAssetId
+     * Serialised image asset from the asset object to an array.
      *
-     * @return array
+     * @param int $imageAssetId
      * @throws IntegrationException
+     * @return array
      */
     public function execute(int $imageAssetId): array
     {

--- a/AdobeStockImage/Model/SerializeImageAsset.php
+++ b/AdobeStockImage/Model/SerializeImageAsset.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Magento\AdobeStockImage\Model;
+
+use Magento\Framework\Api\AttributeInterface;
+use Magento\Framework\Api\Search\Document;
+use Magento\Framework\Exception\SerializationException;
+use Psr\Log\LoggerInterface;
+
+class SerializeImageAsset
+{
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * SerializeImageAsset constructor.
+     *
+     * @param LoggerInterface $logger
+     */
+    public function __construct(LoggerInterface $logger)
+    {
+        $this->logger = $logger;
+    }
+
+    /**
+     * Serialize image asset data.
+     *
+     * @param Document[] $images
+     * @return array
+     * @throws SerializationException
+     */
+    public function execute(array $images): array
+    {
+        $data = [];
+        try {
+            /** @var Document $image */
+            foreach ($images as $image) {
+                $itemData = [];
+                /** @var AttributeInterface $attribute */
+                foreach ($image->getCustomAttributes() as $attribute) {
+                    if ($attribute->getAttributeCode() === 'thumbnail_240_url') {
+                        $itemData['thumbnail_url'] = $attribute->getValue();
+                        continue;
+                    }
+                    $itemData[$attribute->getAttributeCode()] = $attribute->getValue();
+                }
+                $data[] = $itemData;
+            }
+            return $data;
+        } catch (\Exception $exception) {
+            $this->logger->critical($exception);
+            throw new SerializationException(
+                __(
+                    'An error occurred during asset data serialization: %error',
+                    ['error' => $exception->getMessage()]
+                )
+            );
+        }
+    }
+}

--- a/AdobeStockImage/etc/di.xml
+++ b/AdobeStockImage/etc/di.xml
@@ -12,6 +12,7 @@
     <preference for="Magento\AdobeStockImageApi\Api\SaveLicensedImageInterface" type="Magento\AdobeStockImage\Model\SaveLicensedImage"/>
     <preference for="Magento\AdobeStockImageApi\Api\GetRelatedImagesInterface" type="Magento\AdobeStockImage\Model\GetRelatedImages"/>
     <preference for="Magento\AdobeStockImageApi\Api\ConfigInterface" type="Magento\AdobeStockImage\Model\Config"/>
+    <preference for="Magento\AdobeStockImageApi\Api\GetImageDataSerialisedInterface" type="Magento\AdobeStockImage\Model\GetImageDataSerialised"/>
 
     <type name="Magento\AdobeStockImage\Model\GetImageList">
         <arguments>

--- a/AdobeStockImageAdminUi/Controller/Adminhtml/Preview/ImageAsset.php
+++ b/AdobeStockImageAdminUi/Controller/Adminhtml/Preview/ImageAsset.php
@@ -7,7 +7,7 @@ declare(strict_types=1);
 
 namespace Magento\AdobeStockImageAdminUi\Controller\Adminhtml\Preview;
 
-use Magento\AdobeStockImage\Model\GetImageDataSerialised;
+use Magento\AdobeStockImageApi\Api\GetImageDataSerialisedInterface;
 use Magento\Backend\App\Action;
 use Magento\Framework\Controller\Result\Json;
 use Magento\Framework\Controller\ResultFactory;
@@ -32,7 +32,7 @@ class ImageAsset extends Action
     private $logger;
 
     /**
-     * @var GetImageDataSerialised
+     * @var GetImageDataSerialisedInterface
      */
     private $getImageDataSerialised;
 
@@ -40,12 +40,12 @@ class ImageAsset extends Action
      * ImageAsset constructor.
      *
      * @param Action\Context $context
-     * @param GetImageDataSerialised $getImageDataSerialised
+     * @param GetImageDataSerialisedInterface $getImageDataSerialised
      * @param LoggerInterface $logger
      */
     public function __construct(
         Action\Context $context,
-        GetImageDataSerialised $getImageDataSerialised,
+        GetImageDataSerialisedInterface $getImageDataSerialised,
         LoggerInterface $logger
     ) {
         parent::__construct($context);

--- a/AdobeStockImageAdminUi/Controller/Adminhtml/Preview/ImageAsset.php
+++ b/AdobeStockImageAdminUi/Controller/Adminhtml/Preview/ImageAsset.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\AdobeStockImageAdminUi\Controller\Adminhtml\Preview;
+
+use Magento\AdobeStockImage\Model\GetImageDataSerialised;
+use Magento\Backend\App\Action;
+use Magento\Framework\Controller\Result\Json;
+use Magento\Framework\Controller\ResultFactory;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Class ImageAsset
+ */
+class ImageAsset extends Action
+{
+    private const HTTP_OK = 200;
+    private const HTTP_INTERNAL_ERROR = 500;
+
+    /**
+     * @see _isAllowed()
+     */
+    public const ADMIN_RESOURCE = 'Magento_AdobeStockImageAdminUi::save_preview_images';
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @var GetImageDataSerialised
+     */
+    private $getImageDataSerialised;
+
+    /**
+     * ImageAsset constructor.
+     *
+     * @param Action\Context $context
+     * @param GetImageDataSerialised $getImageDataSerialised
+     * @param LoggerInterface $logger
+     */
+    public function __construct(
+        Action\Context $context,
+        GetImageDataSerialised $getImageDataSerialised,
+        LoggerInterface $logger
+    ) {
+        parent::__construct($context);
+        $this->getImageDataSerialised = $getImageDataSerialised;
+        $this->logger = $logger;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function execute()
+    {
+        try {
+            $params = $params = $this->getRequest()->getParams();
+            $imageId = (int) $params['image_id'];
+            $imageAssetSerialized = $this->getImageDataSerialised->execute($imageId);
+
+            $responseCode = self::HTTP_OK;
+            $responseContent = [
+                'success' => true,
+                'message' => __('Get media asset request completed successfully'),
+                'result' => $imageAssetSerialized,
+            ];
+        } catch (\Exception $exception) {
+            $this->logger->critical($exception);
+            $responseCode = self::HTTP_INTERNAL_ERROR;
+            $responseContent = [
+                'success' => false,
+                'message' => __('An error occurred while getting image asset. Contact support.'),
+            ];
+        }
+
+        /** @var Json $resultJson */
+        $resultJson = $this->resultFactory->create(ResultFactory::TYPE_JSON);
+        $resultJson->setHttpResponseCode($responseCode);
+        $resultJson->setData($responseContent);
+
+        return $resultJson;
+    }
+}

--- a/AdobeStockImageAdminUi/Ui/Component/Listing/Columns/ImagePreview.php
+++ b/AdobeStockImageAdminUi/Ui/Component/Listing/Columns/ImagePreview.php
@@ -56,6 +56,7 @@ class ImagePreview extends Column
                     'saveLicensedAndDownloadUrl' => $this->url->getUrl('adobe_stock/license/saveLicensed'),
                     'confirmationUrl' => $this->url->getUrl('adobe_stock/license/confirmation'),
                     'relatedImagesUrl' => $this->url->getUrl('adobe_stock/preview/relatedimages'),
+                    'imageAssetUrl' => $this->url->getUrl('adobe_stock/preview/imageAsset'),
                     'buyCreditsUrl' => 'https://stock.adobe.com/'
                 ]
             )

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/image-preview.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/image-preview.js
@@ -16,6 +16,7 @@ define([
             saveLicensedAndDownloadUrl: 'adobe_stock/license/saveLicensed',
             confirmationUrl: 'adobe_stock/license/confirmation',
             relatedImagesUrl: 'adobe_stock/preview/relatedimages',
+            imageAssetUrl: 'adobe_stock/preview/imageAsset',
             buyCreditsUrl: 'https://stock.adobe.com/',
             mediaGallerySelector: '.media-gallery-modal:has(#search_adobe_stock)',
             adobeStockModalSelector: '#adobe-stock-images-search-modal',
@@ -115,11 +116,30 @@ define([
          * @inheritdoc
          */
         show: function (record) {
+            this.requestImageAssetCurrentData(record);
             this.related().selectedTab(null);
             this.keywords().hideAllKeywords();
             this.displayedRecord(record);
             this._super(record);
             this.related().loadRelatedImages(record);
+        },
+
+        /**
+         * Get image asset
+         *
+         * @param {Object} record
+         */
+        requestImageAssetCurrentData: function (record) {
+            $.ajax({
+                type: 'GET',
+                url: this.imageAssetUrl,
+                dataType: 'json',
+                data: {
+                    'image_id': record.id,
+                }
+            }).done(function () {
+                // TODO update record with the new data
+            });
         },
 
         /**

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/image-preview.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/image-preview.js
@@ -135,7 +135,7 @@ define([
                 url: this.imageAssetUrl,
                 dataType: 'json',
                 data: {
-                    'image_id': record.id,
+                    'image_id': record.id
                 }
             }).done(function () {
                 // TODO update record with the new data

--- a/AdobeStockImageApi/Api/GetImageDataSerialisedInterface.php
+++ b/AdobeStockImageApi/Api/GetImageDataSerialisedInterface.php
@@ -8,8 +8,6 @@ declare(strict_types=1);
 
 namespace Magento\AdobeStockImageApi\Api;
 
-use Magento\Framework\Exception\IntegrationException;
-
 /**
  * Serialise image asset data.
  *
@@ -21,7 +19,7 @@ interface GetImageDataSerialisedInterface
      * Serialised image asset from the asset object to an array.
      *
      * @param int $imageAssetId
-     *
+     * @throws \Magento\Framework\Exception\IntegrationException
      * @return array
      */
     public function execute(int $imageAssetId): array;

--- a/AdobeStockImageApi/Api/GetImageDataSerialisedInterface.php
+++ b/AdobeStockImageApi/Api/GetImageDataSerialisedInterface.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Magento\AdobeStockImageApi\Api;
+
+use Magento\Framework\Exception\IntegrationException;
+
+/**
+ * Serialise image asset data.
+ *
+ * @api
+ */
+interface GetImageDataSerialisedInterface
+{
+    /**
+     * Serialised image asset from the asset object to an array.
+     *
+     * @param int $imageAssetId
+     *
+     * @return array
+     */
+    public function execute(int $imageAssetId): array;
+}


### PR DESCRIPTION
### Description (*)

The original problem, requested at the #720 , caused by next: we didn't update image asset information when open/switch between images. As a suggestion, I provided the next change: on image preview change we send a request with the image id and get an image asset object back. It will have all related information with which we can update image presentation. 'is_downloaded' as well :) By updating the record we can dynamically affect its representation.

The problem I faced: I didn't find a good solution for the latest case - open the grid widget. I do not know at this moment how to fire a needed request on its opening. Other cases (press buttons, switch between series) work fine.

**What's left:**
- solve the modal open issue
- add tests

**Additional changes:**
- refactoring
- add a new class with serialization


### Fixed Issues (if relevant)
#720

### Manual testing scenarios (*)
