### PR TITLE
Added empty API key error

### DIFF
--- a/AdobeStockAdminUi/Block/Adminhtml/System/Config/TestConnection.php
+++ b/AdobeStockAdminUi/Block/Adminhtml/System/Config/TestConnection.php
@@ -93,7 +93,7 @@ class TestConnection extends Field
             return $this->client->testConnection($this->config->getApiKey());
         }
 
-        return false;
+        return true;
     }
 
     /**

--- a/AdobeStockAdminUi/view/adminhtml/templates/system/config/connection.phtml
+++ b/AdobeStockAdminUi/view/adminhtml/templates/system/config/connection.phtml
@@ -16,7 +16,7 @@
                 "components": {
                     "adobe-stock-test-connection": {
                         "component": "Magento_AdobeStockAdminUi/js/connection",
-                        "serverSuccess": "<?= $block->escapeHtmlAttr($block->isConnectionSuccessful()) ?>",
+                        "success": "<?= $block->escapeHtmlAttr($block->isConnectionSuccessful()) ?>",
                         "url": "<?= $block->escapeJs($block->escapeUrl($block->getAjaxUrl())) ?>",
                         "buttonLabel": "<?= $block->escapeHtml($block->getButtonLabel()) ?>"
                     }

--- a/AdobeStockAdminUi/view/adminhtml/web/js/connection.js
+++ b/AdobeStockAdminUi/view/adminhtml/web/js/connection.js
@@ -51,8 +51,10 @@ define([
          * Send request to server to test connection to Adobe Stock API and display the result
          */
         testConnection: function () {
-            this.visible(false);
             var apiKey = document.getElementById(this.apiKeyInputId).value;
+
+            this.visible(false);
+
             if (apiKey.length === 0) {
                 this.showMessage(false, this.emptyApiKeyErrorMessage);
             } else {

--- a/AdobeStockAdminUi/view/adminhtml/web/js/connection.js
+++ b/AdobeStockAdminUi/view/adminhtml/web/js/connection.js
@@ -13,6 +13,7 @@ define([
         defaults: {
             template: 'Magento_AdobeStockAdminUi/connection',
             defaultErrorMessage: 'Connection test failed.',
+            emptyApiKeyErrorMessage: 'Please enter an API Key and then test the connection',
             apiKeyInputId: 'system_adobe_stock_integration_api_key',
             url: '',
             serverSuccess: false
@@ -51,20 +52,25 @@ define([
          */
         testConnection: function () {
             this.visible(false);
-            $.ajax({
-                type: 'POST',
-                url: this.url,
-                dataType: 'json',
-                data: {
-                    'api_key': document.getElementById(this.apiKeyInputId).value
-                },
-                success: $.proxy(function (response) {
-                    this.showMessage(response.success === true, response.message);
-                }, this),
-                error: $.proxy(function () {
-                    this.showMessage(false, this.defaultErrorMessage);
-                }, this)
-            });
+            var apiKey = document.getElementById(this.apiKeyInputId).value;
+            if (apiKey.length === 0) {
+                this.showMessage(false, this.emptyApiKeyErrorMessage);
+            } else {
+                $.ajax({
+                    type: 'POST',
+                    url: this.url,
+                    dataType: 'json',
+                    data: {
+                        'api_key': apiKey
+                    },
+                    success: $.proxy(function (response) {
+                        this.showMessage(response.success === true, response.message);
+                    }, this),
+                    error: $.proxy(function () {
+                        this.showMessage(false, this.defaultErrorMessage);
+                    }, this)
+                });
+            }
         }
     });
 });


### PR DESCRIPTION
### Description

Added an error message to display when API key is empty and not test the connection

### Fixed Issues

1. magento/adobe-stock-integration#737: Do not autovalidate API key if it's empty or not yet set

### Manual testing scenarios

1. Test Connection in Admin Configuration for Adobe Stock Integration without an API key