### PR TITLE
Added tab separator styles

### DIFF
--- a/AdobeStockImageAdminUi/view/adminhtml/web/css/source/_module.less
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/css/source/_module.less
@@ -242,6 +242,10 @@
 
             .adobe-stock-tabs {
                 margin-top: 30px;
+                border-bottom: 1px solid @color-gray68;
+                .ui-state-default {
+                    border-bottom: none;
+                }
             }
 
             .adobe-stock-related-images-tab-content {


### PR DESCRIPTION
### Description

Added tab separator styles

### Fixed Issues
1. magento/adobe-stock-integration#735: Tabs separation line is absent for related images in image preview

### Manual testing scenarios
1. Please check issue images for expected styles