### PR TITLE
for travis branch builds, only build the develop branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+branches:
+  only:
+    - develop
 sudo: required
 dist: trusty
 group: edge


### PR DESCRIPTION
this should reduce number of duplicate PR builds
