### PR TITLE
Fixing AdminAdobeStockListingStateTest

### DIFF
--- a/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockListingStateTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockListingStateTest.xml
@@ -26,36 +26,35 @@
             <actionGroup ref="AdminAdobeStockOpenPanelFromMediaGalleryActionGroup" stepKey="openAdobeStockPanel"/>
         </before>
         <after>
+            <actionGroup ref="AdminAdobeStockOpenPanelFromMediaGalleryActionGroup" stepKey="openAdobeStockPanel"/>
             <actionGroup ref="resetAdminDataGridToDefaultView" stepKey="resetAdminDataGridToDefaultView"/>
             <actionGroup ref="logout" stepKey="logout"/>
         </after>
-        <actionGroup ref="AdminAdobeStockExpandFiltersActionGroup" stepKey="expandFilters1"/>
-        <actionGroup ref="AdminAdobeStockApplyIsolatedFilterActionGroup" stepKey="applyIsolatedFilter"/>
         <actionGroup ref="AdminAdobeStockExpandFiltersActionGroup" stepKey="expandFilters"/>
-        <actionGroup ref="AdminApplyColorFilterValue" stepKey="userChoseAndApplyColorFilter">
-            <argument name="color" value="#000000"/>
-        </actionGroup>
-        <actionGroup ref="AdminAdobeStockExpandFiltersActionGroup" stepKey="expandFilters2"/>
         <actionGroup ref="AdminFilterResultsActionGroup" stepKey="setOrientationFilterToHorizontal">
             <argument name="type" value="Horizontal"/>
             <argument name="filter" value="{{AdobeStockFilterSection.orientationFilter}}"/>
             <argument name="filterOption" value="orientation_filter"/>
         </actionGroup>
-        <actionGroup ref="AdminAdobeStockExpandFiltersActionGroup" stepKey="expandFilters3"/>
-        <actionGroup ref="AdminUserApplySafeSearchFilterActionGroup" stepKey="see32imagesOnTheSecondPage"/>
         <actionGroup ref="AdminAdobeStockOpenNextPageActionGroup" stepKey="openNextPage"/>
         <actionGroup ref="AdminAdobeStockExpandImagePreviewActionGroup" stepKey="expandImagePreview"/>
-        <actionGroup ref="AdminAdobeStockSavePreviewActionGroup" stepKey="saveImagePreview"/>
-        <actionGroup ref="AdminAssertAdobeStockImageSavedActionGroup" stepKey="assertImageSaved"/>
+
+        <click selector="{{AdobeStockImagePreviewSection.savePreview}}" stepKey="clickSavePreview"/>
+        <waitForPageLoad stepKey="waitForPromptModal" />
+        <grabValueFrom selector="{{AdobeStockImagePreviewSection.imageNameField}}" stepKey="grabImageFileName" />
+        <click selector="{{AdobeStockImagePreviewSection.confirm}}" stepKey="clickOnPopupConfirm"/>
+        <waitForPageLoad stepKey="waitForMediaGalleryOpen" />
+        <seeElement selector="{{AdobeStockSection.mediaGalleryImage({$grabImageFileName})}}" stepKey="assertSavedImage" />
         <actionGroup ref="AdminAdobeStockOpenPanelFromMediaGalleryActionGroup" stepKey="openAdobeStockPanel"/>
         <actionGroup ref="AdminAssertAdobeStockCurrentPageNumberActionGroup" stepKey="seeSecondPage">
             <argument name="pageNumber" value="2"/>
         </actionGroup>
-        <actionGroup ref="AssertsFilterResultsActionGroup" stepKey="verifyAppliedFilter1">
-            <argument name="resultValue" value="Isolated Only"/>
+        <actionGroup ref="AssertsFilterResultsActionGroup" stepKey="verifyAppliedFilter">
+            <argument name="resultValue" value="Horizontal"/>
         </actionGroup>
-        <actionGroup ref="AssertsFilterResultsActionGroup" stepKey="verifyAppliedFilter2">
-            <argument name="resultValue" value="#000000"/>
+        <actionGroup ref="AdminOpenMediaGalleryForPageNoEditorActionGroup" stepKey="openMediaGalleryForPage"/>
+        <actionGroup ref="AdminMediaGalleryDeleteImage" stepKey="deleteImageActionGroup">
+            <argument name="name" value="{$grabImageFileName}"/>
         </actionGroup>
     </test>
 </tests>


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)

Since the  introduction of the default gallery/collection, this test has been failing, due to incorrect assumptions around number of images present in searches. For details see #751 

I expect this PR to cause the MFTF "filters" suite of tests to now be green on Travis CI!

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
This PR fixes #751 

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Run the test: `vendor/bin/mftf run:test AdminAdobeStockListingStateTest --remove --verbose`
2. See it pass!