### PR TITLE
Fix for preview keywords search test

### DIFF
--- a/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockImagePreviewKeywordsSearchTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockImagePreviewKeywordsSearchTest.xml
@@ -29,25 +29,17 @@
         </after>
 
         <actionGroup ref="AdminSearchImagesOnModalActionGroup" stepKey="searchForInterior">
-            <argument name="query" value="Interior"/>
+            <argument name="query" value="273672939"/>
         </actionGroup>
         <actionGroup ref="AdminAdobeStockExpandImagePreviewActionGroup" stepKey="expandImagePreview"/>
-        <actionGroup ref="AdminImagePreviewKeywordSearchActionGroup" stepKey="searchByImageKeyword">
-            <argument name="keyword" value="interior"/>
+        <executeJS function="document.querySelector('.keywords').scrollIntoView()" stepKey="scrollToKeywords"/>
+        <actionGroup ref="AdminImagePreviewKeywordSearchActionGroup" stepKey="clickAccessoryKeyword">
+            <argument name="keyword" value="accessory"/>
         </actionGroup>
 
         <!-- verify that clicking on keyword initialize new search -->
         <actionGroup ref="AssertsFilterResultsActionGroup" stepKey="assertKeywordFilterApplied">
-            <argument name="resultValue" value="interior"/>
-        </actionGroup>
-
-        <actionGroup ref="AdminAdobeStockExpandImagePreviewActionGroup" stepKey="clickOnImage"/>
-        <click selector="{{AdobeStockImagePreviewSection.viewAllKeywords}}" stepKey="clickOnViewAlKeywords"/>
-        <actionGroup ref="AdminImagePreviewKeywordSearchActionGroup" stepKey="searchByKeyword">
-            <argument name="keyword" value="window"/>
-        </actionGroup>
-        <actionGroup ref="AssertsFilterResultsActionGroup" stepKey="assertSearchFilterForNewSearch">
-            <argument name="resultValue" value="window"/>
+            <argument name="resultValue" value="accessory"/>
         </actionGroup>
     </test>
 </tests>


### PR DESCRIPTION
### Description (*)

This PR fixes the test that exercises the keywords/tags searching via the image preview section.

I believe this should fix the `adobe_stock_integration_suite_keywords` MFTF Travis sub-build.

### Fixed Issues (if relevant)

This PR fixes #686

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Run `vendor/bin/mftf run:test AdminAdobeStockImagePreviewKeywordsSearchTest --remove --verbose`