### PR TITLE
fixing up using suite vs group name for running new license suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ env:
     - TEST_SUITE=functional MFTF_SUITE=adobe_stock_integration_suite_keywords
     - TEST_SUITE=functional MFTF_SUITE=adobe_stock_integration_suite_ims
     - TEST_SUITE=functional MFTF_SUITE=adobe_stock_integration_suite_see_more
-    - TEST_SUITE=functional MFTF_SUITE=adobe_stock_integration_license
+    - TEST_SUITE=functional MFTF_SUITE=adobe_stock_integration_suite_license
 matrix:
   fast_finish: true
 jobs:
@@ -66,7 +66,7 @@ jobs:
     - php: '7.1'
       env: TEST_SUITE=functional MFTF_SUITE=adobe_stock_integration_suite_see_more
     - php: '7.1'
-      env: TEST_SUITE=functional MFTF_SUITE=adobe_stock_integration_license
+      env: TEST_SUITE=functional MFTF_SUITE=adobe_stock_integration_suite_license
     - php: '7.2'
       env: TEST_SUITE=functional MFTF_SUITE=adobe_stock_integration_suite_filters
     - php: '7.2'


### PR DESCRIPTION
Keeping the naming and use of suite vs group names consistent. This should also stop kicking off a PHP 7.2 MFTF sub-build for the new license suite of tests.