### PR TITLE
Update the phpdoc section for interfaces and classes

### DIFF
--- a/AdobeIms/Block/Adminhtml/SignIn.php
+++ b/AdobeIms/Block/Adminhtml/SignIn.php
@@ -18,7 +18,7 @@ use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\Serialize\Serializer\JsonHexTag;
 
 /**
- * Adobe sign in block
+ * Provides required data for the Adobe service authentication component
  *
  * @api
  */

--- a/AdobeIms/Controller/Adminhtml/OAuth/Callback.php
+++ b/AdobeIms/Controller/Adminhtml/OAuth/Callback.php
@@ -24,7 +24,7 @@ use Psr\Log\LoggerInterface;
 use Magento\AdobeImsApi\Api\GetImageInterface;
 
 /**
- * Class Callback
+ * Callback action for managing user authentication with the Adobe services
  */
 class Callback extends Action
 {

--- a/AdobeIms/Controller/Adminhtml/User/Logout.php
+++ b/AdobeIms/Controller/Adminhtml/User/Logout.php
@@ -14,7 +14,7 @@ use Magento\Framework\Controller\Result\Json;
 use Magento\Framework\Controller\ResultFactory;
 
 /**
- * Logout from adobe account
+ * Logout action from the Adobe account
  */
 class Logout extends Action
 {

--- a/AdobeIms/Controller/Adminhtml/User/Profile.php
+++ b/AdobeIms/Controller/Adminhtml/User/Profile.php
@@ -15,7 +15,7 @@ use Magento\Framework\Exception\NoSuchEntityException;
 use Psr\Log\LoggerInterface;
 
 /**
- * Backend controller for retrieving data for the current user
+ * Get Adobe services user account action
  */
 class Profile extends Action
 {

--- a/AdobeIms/Model/Config.php
+++ b/AdobeIms/Model/Config.php
@@ -14,7 +14,7 @@ use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\UrlInterface;
 
 /**
- * Class Config
+ * Represent the Adobe stock config model responsible for retrieving config settings for Adobe Ims
  */
 class Config implements ConfigInterface
 {

--- a/AdobeIms/Model/Config.php
+++ b/AdobeIms/Model/Config.php
@@ -14,7 +14,7 @@ use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\UrlInterface;
 
 /**
- * Represent the Adobe stock config model responsible for retrieving config settings for Adobe Ims
+ * Represent the Adobe IMS config model responsible for retrieving config settings for Adobe Ims
  */
 class Config implements ConfigInterface
 {

--- a/AdobeIms/Model/FlushUserTokens.php
+++ b/AdobeIms/Model/FlushUserTokens.php
@@ -12,7 +12,7 @@ use Magento\AdobeImsApi\Api\UserProfileRepositoryInterface;
 use Magento\Authorization\Model\UserContextInterface;
 
 /**
- * Remove user access and refresh tokens
+ * Represent the remove user access and refresh tokens functionality
  */
 class FlushUserTokens implements FlushUserTokensInterface
 {

--- a/AdobeIms/Model/GetAccessToken.php
+++ b/AdobeIms/Model/GetAccessToken.php
@@ -13,7 +13,7 @@ use Magento\Authorization\Model\UserContextInterface;
 use Magento\Framework\Exception\NoSuchEntityException;
 
 /**
- * Get admin user access token
+ * Represent the get user access token functionality
  */
 class GetAccessToken implements GetAccessTokenInterface
 {

--- a/AdobeIms/Model/GetImage.php
+++ b/AdobeIms/Model/GetImage.php
@@ -14,7 +14,7 @@ use Psr\Log\LoggerInterface;
 use Magento\AdobeImsApi\Api\ConfigInterface;
 
 /**
- * Get user image profile.
+ * Represent functionality for getting the Adobe services user profile image
  */
 class GetImage implements GetImageInterface
 {

--- a/AdobeIms/Model/GetToken.php
+++ b/AdobeIms/Model/GetToken.php
@@ -17,7 +17,7 @@ use Magento\AdobeImsApi\Api\Data\TokenResponseInterface;
 use Magento\AdobeImsApi\Api\Data\TokenResponseInterfaceFactory;
 
 /**
- * Class GetToken
+ * Represent the get user token functionality
  */
 class GetToken implements GetTokenInterface
 {

--- a/AdobeIms/Model/LogOut.php
+++ b/AdobeIms/Model/LogOut.php
@@ -14,7 +14,7 @@ use Magento\Framework\HTTP\Client\CurlFactory;
 use Psr\Log\LoggerInterface;
 
 /**
- * Log Out User from Adobe Account
+ * Represent functionality for log out users from the Adobe account
  */
 class LogOut implements LogOutInterface
 {

--- a/AdobeIms/Model/OAuth/TokenResponse.php
+++ b/AdobeIms/Model/OAuth/TokenResponse.php
@@ -12,7 +12,7 @@ use Magento\AdobeImsApi\Api\Data\TokenResponseInterface;
 use Magento\Framework\DataObject;
 
 /**
- * Class TokenResponse
+ * Represent the token response service data class
  */
 class TokenResponse extends DataObject implements TokenResponseInterface
 {

--- a/AdobeIms/Model/ResourceModel/UserProfile.php
+++ b/AdobeIms/Model/ResourceModel/UserProfile.php
@@ -11,7 +11,7 @@ namespace Magento\AdobeIms\Model\ResourceModel;
 use Magento\Framework\Model\ResourceModel\Db\AbstractDb;
 
 /**
- * Class UserProfile
+ * Represent the user profile resource model
  */
 class UserProfile extends AbstractDb
 {

--- a/AdobeIms/Model/ResourceModel/UserProfile/Collection.php
+++ b/AdobeIms/Model/ResourceModel/UserProfile/Collection.php
@@ -13,7 +13,7 @@ use Magento\AdobeIms\Model\UserProfile as UserProfileModel;
 use Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection;
 
 /**
- * Class Collection
+ * Represent the user profile collection
  */
 class Collection extends AbstractCollection
 {

--- a/AdobeIms/Model/UserAuthorized.php
+++ b/AdobeIms/Model/UserAuthorized.php
@@ -13,7 +13,7 @@ use Magento\AdobeImsApi\Api\UserProfileRepositoryInterface;
 use Magento\Authorization\Model\UserContextInterface;
 
 /**
- * User authorized
+ * Represent functionality for getting information is user authorised or not
  */
 class UserAuthorized implements UserAuthorizedInterface
 {

--- a/AdobeIms/Model/UserProfile.php
+++ b/AdobeIms/Model/UserProfile.php
@@ -13,7 +13,7 @@ use Magento\Framework\Model\AbstractExtensibleModel;
 use Magento\AdobeImsApi\Api\Data\UserProfileExtensionInterface;
 
 /**
- * Class UserProfile
+ * Represent the user profile service data class
  */
 class UserProfile extends AbstractExtensibleModel implements UserProfileInterface
 {

--- a/AdobeIms/Model/UserProfileRepository.php
+++ b/AdobeIms/Model/UserProfileRepository.php
@@ -17,7 +17,7 @@ use Magento\Framework\Exception\NoSuchEntityException;
 use Psr\Log\LoggerInterface;
 
 /**
- * Class UserProfileRepository
+ * Represent user profile repository
  */
 class UserProfileRepository implements UserProfileRepositoryInterface
 {

--- a/AdobeImsApi/Api/ConfigInterface.php
+++ b/AdobeImsApi/Api/ConfigInterface.php
@@ -9,7 +9,8 @@ declare(strict_types=1);
 namespace Magento\AdobeImsApi\Api;
 
 /**
- * Class Config
+ * Declare the the Adobe stock integration config which is responsible for retrieving config
+ * settings for Adobe Ims
  * @api
  */
 interface ConfigInterface

--- a/AdobeImsApi/Api/ConfigInterface.php
+++ b/AdobeImsApi/Api/ConfigInterface.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 namespace Magento\AdobeImsApi\Api;
 
 /**
- * Declare the the Adobe stock integration config which is responsible for retrieving config
+ * Declare the the Adobe IMS integration config which is responsible for retrieving config
  * settings for Adobe Ims
  * @api
  */

--- a/AdobeImsApi/Api/Data/TokenResponseInterface.php
+++ b/AdobeImsApi/Api/Data/TokenResponseInterface.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 namespace Magento\AdobeImsApi\Api\Data;
 
 /**
- * Interface UserProfileInterface
+ * Interface for the service data response object
  * @api
  */
 interface TokenResponseInterface

--- a/AdobeImsApi/Api/Data/UserProfileInterface.php
+++ b/AdobeImsApi/Api/Data/UserProfileInterface.php
@@ -11,7 +11,7 @@ namespace Magento\AdobeImsApi\Api\Data;
 use Magento\Framework\Api\ExtensibleDataInterface;
 
 /**
- * Interface UserProfileInterface
+ * Declare the user profile data service object
  * @api
  */
 interface UserProfileInterface extends ExtensibleDataInterface

--- a/AdobeImsApi/Api/FlushUserTokensInterface.php
+++ b/AdobeImsApi/Api/FlushUserTokensInterface.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 namespace Magento\AdobeImsApi\Api;
 
 /**
- * Interface UserAuthorizedInterface
+ * Declare functionality for remove user access and refresh tokens functionality
  * @api
  */
 interface FlushUserTokensInterface

--- a/AdobeImsApi/Api/GetAccessTokenInterface.php
+++ b/AdobeImsApi/Api/GetAccessTokenInterface.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 namespace Magento\AdobeImsApi\Api;
 
 /**
- * Interface GetAccessTokenInterface
+ * Declare functionality for getting user access token
  * @api
  */
 interface GetAccessTokenInterface

--- a/AdobeImsApi/Api/GetImageInterface.php
+++ b/AdobeImsApi/Api/GetImageInterface.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 namespace Magento\AdobeImsApi\Api;
 
 /**
- * Interface GetImageInterface
+ * Declare functionality for getting the Adobe services user profile image
  * @api
  */
 interface GetImageInterface

--- a/AdobeImsApi/Api/GetTokenInterface.php
+++ b/AdobeImsApi/Api/GetTokenInterface.php
@@ -12,7 +12,7 @@ use Magento\AdobeImsApi\Api\Data\TokenResponseInterface;
 use Magento\Framework\Exception\AuthorizationException;
 
 /**
- * Interface GetTokenInterface
+ * Declare functionality for getting user token
  * @api
  */
 interface GetTokenInterface

--- a/AdobeImsApi/Api/LogOutInterface.php
+++ b/AdobeImsApi/Api/LogOutInterface.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 namespace Magento\AdobeImsApi\Api;
 
 /**
- * Interface LogOutInterface
+ * Declare functionality for user logout from the Adobe account
  */
 interface LogOutInterface
 {

--- a/AdobeImsApi/Api/UserAuthorizedInterface.php
+++ b/AdobeImsApi/Api/UserAuthorizedInterface.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 namespace Magento\AdobeImsApi\Api;
 
 /**
- * Interface UserAuthorizedInterface
+ * Declare functionality for getting information is user authorised or not
  * @api
  */
 interface UserAuthorizedInterface

--- a/AdobeImsApi/Api/UserProfileRepositoryInterface.php
+++ b/AdobeImsApi/Api/UserProfileRepositoryInterface.php
@@ -12,7 +12,7 @@ use Magento\AdobeImsApi\Api\Data\UserProfileInterface;
 use Magento\Framework\Exception\CouldNotSaveException;
 
 /**
- * Interface UserProfileRepositoryInterface
+ * Declare user profile repository
  * @api
  */
 interface UserProfileRepositoryInterface


### PR DESCRIPTION
### Description (*)
Update the phpdoc section for classes and interfaces.

I provide the next pattern: 
1. An interface declares the data object or service functionality. Every interface description starts with the declare word, and then the description is started.
2. Implementation phpdoc description begins with the Representation word because of implementation represents declared functionality

### Fixed Issues (if relevant)
#736 

### Manual testing scenarios (*)
N/A