### PR TITLE
Exclude Adobe stock related knowledge from the Adobe IMS

### DIFF
--- a/AdobeIms/Model/Config.php
+++ b/AdobeIms/Model/Config.php
@@ -18,13 +18,13 @@ use Magento\Framework\UrlInterface;
  */
 class Config implements ConfigInterface
 {
-    private const XML_PATH_API_KEY = 'adobe_stock/integration/api_key';
-    private const XML_PATH_PRIVATE_KEY = 'adobe_stock/integration/private_key';
-    private const XML_PATH_TOKEN_URL = 'adobe_stock/integration/token_url';
-    private const XML_PATH_AUTH_URL_PATTERN = 'adobe_stock/integration/auth_url_pattern';
-    private const XML_PATH_LOGOUT_URL_PATTERN = 'adobe_stock/integration/logout_url';
-    private const XML_PATH_DEFAULT_PROFILE_IMAGE = 'adobe_stock/integration/default_profile_image';
-    private const XML_PATH_IMAGE_URL_PATTERN = 'adobe_stock/integration/image_url';
+    private const XML_PATH_API_KEY = 'adobe_ims/integration/api_key';
+    private const XML_PATH_PRIVATE_KEY = 'adobe_ims/integration/private_key';
+    private const XML_PATH_TOKEN_URL = 'adobe_ims/integration/token_url';
+    private const XML_PATH_AUTH_URL_PATTERN = 'adobe_ims/integration/auth_url_pattern';
+    private const XML_PATH_LOGOUT_URL_PATTERN = 'adobe_ims/integration/logout_url';
+    private const XML_PATH_DEFAULT_PROFILE_IMAGE = 'adobe_ims/integration/default_profile_image';
+    private const XML_PATH_IMAGE_URL_PATTERN = 'adobe_ims/integration/image_url';
 
     /**
      * @var ScopeConfigInterface

--- a/AdobeIms/Test/Unit/Model/ConfigTest.php
+++ b/AdobeIms/Test/Unit/Model/ConfigTest.php
@@ -18,7 +18,7 @@ use PHPUnit\Framework\TestCase;
  */
 class ConfigTest extends TestCase
 {
-    private const CONFIG_XML_PATH_API_KEY = 'adobe_stock/integration/api_key';
+    private const CONFIG_XML_PATH_API_KEY = 'adobe_ims/integration/api_key';
 
     /**
      * @var ObjectManager

--- a/AdobeIms/etc/config.xml
+++ b/AdobeIms/etc/config.xml
@@ -7,7 +7,7 @@
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Store:etc/config.xsd">
     <default>
-        <adobe_stock>
+        <adobe_ims>
             <integration>
                 <api_key backend_model="Magento\Config\Model\Config\Backend\Encrypted"/>
                 <private_key backend_model="Magento\Config\Model\Config\Backend\Encrypted"/>
@@ -17,6 +17,6 @@
                 <default_profile_image>https://a5.behance.net/27000444e0c8b62c56deff3fc491e1a92d07f0cb/img/profile/no-image-276.png</default_profile_image>
                 <auth_url_pattern><![CDATA[https://ims-na1.adobelogin.com/ims/authorize?client_id=#{client_id}&redirect_uri=#{redirect_uri}&locale=#{locale}&scope=openid,creative_sdk&response_type=code]]></auth_url_pattern>
             </integration>
-        </adobe_stock>
+        </adobe_ims>
     </default>
 </config>

--- a/AdobeIms/etc/db_schema.xml
+++ b/AdobeIms/etc/db_schema.xml
@@ -6,7 +6,7 @@
  */
 -->
 <schema xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Setup/Declaration/Schema/etc/schema.xsd">
-    <table name="adobe_user_profile" resource="default" engine="innodb" comment="Adobe Stock User Profile">
+    <table name="adobe_user_profile" resource="default" engine="innodb" comment="Adobe IMS User Profile">
         <column xsi:type="int" name="id" padding="10" unsigned="true" nullable="false" identity="true" comment="Entity ID"/>
         <column xsi:type="int" name="admin_user_id" padding="10" unsigned="true" nullable="false" identity="false" default="0" comment="Admin User Id"/>
         <column xsi:type="varchar" length="255" name="name" nullable="false" comment="Display Name"/>

--- a/AdobeIms/view/adminhtml/web/js/action/authorization.js
+++ b/AdobeIms/view/adminhtml/web/js/action/authorization.js
@@ -34,7 +34,7 @@ define([], function () {
         /**
          * Opens authorization window with special parameters
          */
-        authWindow = window.adobeStockAuthWindow = window.open(
+        authWindow = window.adobeIMSAuthWindow = window.open(
             config.url,
             '',
             buildWindowParams(

--- a/AdobeIms/view/adminhtml/web/template/signIn.html
+++ b/AdobeIms/view/adminhtml/web/template/signIn.html
@@ -22,7 +22,7 @@
             <li>
                 <img class="adobe-profile-image-large" attr="src: user().image">
             </li>
-            <li class="adobe-stock-user-quota">
+            <li class="adobe-ims-user-quota">
                 <ul>
                     <li><!--ko text: user().name--><!--/ko--></li>
                     <li><!--ko text: user().email--><!--/ko--></li>

--- a/AdobeIms/view/adminhtml/web/template/signIn.html
+++ b/AdobeIms/view/adminhtml/web/template/signIn.html
@@ -22,7 +22,7 @@
             <li>
                 <img class="adobe-profile-image-large" attr="src: user().image">
             </li>
-            <li class="adobe-ims-user-quota">
+            <li class="adobe-user-info">
                 <ul>
                     <li><!--ko text: user().name--><!--/ko--></li>
                     <li><!--ko text: user().email--><!--/ko--></li>

--- a/AdobeStockAdminUi/etc/adminhtml/system.xml
+++ b/AdobeStockAdminUi/etc/adminhtml/system.xml
@@ -13,11 +13,11 @@
                 <field id="enabled" translate="label" type="select" sortOrder="10" showInDefault="1" showInWebsite="0" showInStore="0">
                     <label>Enabled Adobe Stock</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-                    <config_path>adobe_stock/integration/enabled</config_path>
+                    <config_path>adobe_ims/integration/enabled</config_path>
                 </field>
                 <field id="api_key" translate="label" type="obscure" sortOrder="20" showInDefault="1" showInWebsite="0" showInStore="0">
                     <label>API Key (Client ID)</label>
-                    <config_path>adobe_stock/integration/api_key</config_path>
+                    <config_path>adobe_ims/integration/api_key</config_path>
                     <backend_model>Magento\Config\Model\Config\Backend\Encrypted</backend_model>
                     <depends>
                         <field id="enabled">1</field>
@@ -25,7 +25,7 @@
                 </field>
                 <field id="private_key" translate="label" type="obscure" sortOrder="30" showInDefault="1" showInWebsite="0" showInStore="0">
                     <label>Client Secret</label>
-                    <config_path>adobe_stock/integration/private_key</config_path>
+                    <config_path>adobe_ims/integration/private_key</config_path>
                     <backend_model>Magento\Config\Model\Config\Backend\Encrypted</backend_model>
                     <depends>
                         <field id="enabled">1</field>

--- a/AdobeStockAdminUi/etc/adminhtml/system.xml
+++ b/AdobeStockAdminUi/etc/adminhtml/system.xml
@@ -13,7 +13,7 @@
                 <field id="enabled" translate="label" type="select" sortOrder="10" showInDefault="1" showInWebsite="0" showInStore="0">
                     <label>Enabled Adobe Stock</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-                    <config_path>adobe_ims/integration/enabled</config_path>
+                    <config_path>adobe_stock/integration/enabled</config_path>
                 </field>
                 <field id="api_key" translate="label" type="obscure" sortOrder="20" showInDefault="1" showInWebsite="0" showInStore="0">
                     <label>API Key (Client ID)</label>
@@ -23,7 +23,7 @@
                         <field id="enabled">1</field>
                     </depends>
                 </field>
-                <field id="private_key" translate="label" type="obscure" sortOrder="30" showInDefault="1" showInWebsite="0" showInStore="0">
+                <field id="private_key" translate="label comment" type="obscure" sortOrder="30" showInDefault="1" showInWebsite="0" showInStore="0">
                     <label>Client Secret</label>
                     <config_path>adobe_ims/integration/private_key</config_path>
                     <backend_model>Magento\Config\Model\Config\Backend\Encrypted</backend_model>

--- a/AdobeStockAsset/etc/di.xml
+++ b/AdobeStockAsset/etc/di.xml
@@ -26,8 +26,8 @@
     <type name="Magento\Config\Model\Config\TypePool">
         <arguments>
             <argument name="sensitive" xsi:type="array">
-                <item name="adobe_stock/integration/api_key" xsi:type="string">1</item>
-                <item name="adobe_stock/integration/private_key" xsi:type="string">1</item>
+                <item name="adobe_ims/integration/api_key" xsi:type="string">1</item>
+                <item name="adobe_ims/integration/private_key" xsi:type="string">1</item>
             </argument>
         </arguments>
     </type>

--- a/AdobeStockImageAdminUi/Test/Mftf/Data/AdobeStockConfigData.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Data/AdobeStockConfigData.xml
@@ -20,7 +20,7 @@
         <data key="value">{{_CREDS.magento/ADOBE_STOCK_API_KEY}}</data>
     </entity>
     <entity name="AdobeStockConfigDataPrivateKey">
-        <data key="path">adobe_stock/integration/private_key</data>
+        <data key="path">adobe_ims/integration/private_key</data>
         <data key="value">{{_CREDS.magento/ADOBE_STOCK_PRIVATE_KEY}}</data>
     </entity>
 </entities>

--- a/AdobeStockImageAdminUi/Test/Mftf/Section/AdobeStockSection.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Section/AdobeStockSection.xml
@@ -31,7 +31,7 @@
         <element name="adobeSkipAddPhoneNumber" type="button" selector="#cancelBtn"/>
         <element name="userImageSmall" type="text" selector=".adobe-profile-image-small"/>
         <element name="userNameButton" type="button" selector=".adobe-user-name"/>
-        <element name="userQuota" type="block" selector=".adobe-stock-user-quota"/>
+        <element name="userQuota" type="block" selector=".adobe-ims-user-quota"/>
         <element name="userSignOut" type="button" selector=".adobe-sign-out-button"/>
         <element name="sortDropdown" type="button" selector="div[class='masonry-sorting'] select"/>
         <element name="sortOption" type="button" selector="//div[@class='masonry-sorting'] //option[@value='{{sortOption}}']" parameterized="true"/>

--- a/AdobeStockImageAdminUi/Test/Mftf/Section/AdobeStockSection.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Section/AdobeStockSection.xml
@@ -31,7 +31,7 @@
         <element name="adobeSkipAddPhoneNumber" type="button" selector="#cancelBtn"/>
         <element name="userImageSmall" type="text" selector=".adobe-profile-image-small"/>
         <element name="userNameButton" type="button" selector=".adobe-user-name"/>
-        <element name="userQuota" type="block" selector=".adobe-ims-user-quota"/>
+        <element name="userQuota" type="block" selector=".adobe-user-info"/>
         <element name="userSignOut" type="button" selector=".adobe-sign-out-button"/>
         <element name="sortDropdown" type="button" selector="div[class='masonry-sorting'] select"/>
         <element name="sortOption" type="button" selector="//div[@class='masonry-sorting'] //option[@value='{{sortOption}}']" parameterized="true"/>

--- a/AdobeStockImageAdminUi/view/adminhtml/web/css/source/_module.less
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/css/source/_module.less
@@ -122,7 +122,7 @@
         .adobe-login-container {
             .adobe-user-information {
                 .adobe-user-popup {
-                    .adobe-ims-user-quota {
+                    .adobe-user-info {
                         padding-top: 15px;
                     }
                 }

--- a/AdobeStockImageAdminUi/view/adminhtml/web/css/source/_module.less
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/css/source/_module.less
@@ -122,7 +122,7 @@
         .adobe-login-container {
             .adobe-user-information {
                 .adobe-user-popup {
-                    .adobe-stock-user-quota {
+                    .adobe-ims-user-quota {
                         padding-top: 15px;
                     }
                 }

--- a/AdobeStockImageAdminUi/view/adminhtml/web/template/signIn.html
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/template/signIn.html
@@ -22,7 +22,7 @@
             <li>
                 <img class="adobe-profile-image-large" attr="src: user().image">
             </li>
-            <li class="adobe-ims-user-quota">
+            <li class="adobe-user-info">
                 <ul>
                     <li><!--ko text: user().name--><!--/ko--></li>
                     <li><!--ko text: user().email--><!--/ko--></li>
@@ -30,7 +30,7 @@
                 </ul>
             </li>
             <li>
-                <div class="adobe-ims-user-quota">
+                <div class="adobe-user-info">
                     <span>AVAILABLE</span>
                     <p><b><!--ko text: userQuota().images--><!--/ko--></b> Images | <b><!--ko text: userQuota().credits -->
                         <!--/ko--></b> Credits</p>

--- a/AdobeStockImageAdminUi/view/adminhtml/web/template/signIn.html
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/template/signIn.html
@@ -22,7 +22,7 @@
             <li>
                 <img class="adobe-profile-image-large" attr="src: user().image">
             </li>
-            <li class="adobe-stock-user-quota">
+            <li class="adobe-ims-user-quota">
                 <ul>
                     <li><!--ko text: user().name--><!--/ko--></li>
                     <li><!--ko text: user().email--><!--/ko--></li>
@@ -30,7 +30,7 @@
                 </ul>
             </li>
             <li>
-                <div class="adobe-stock-user-quota">
+                <div class="adobe-ims-user-quota">
                     <span>AVAILABLE</span>
                     <p><b><!--ko text: userQuota().images--><!--/ko--></b> Images | <b><!--ko text: userQuota().credits -->
                         <!--/ko--></b> Credits</p>


### PR DESCRIPTION
### Description (*)
The Adobe IMS module must not know anything about particularAdobe modules. This PR provides next:
1. Exclude `adobe_stock` from the IMS config by replacing it with the `adobe_ims`
1. Adjust related functionality to use new parameter key `adobe_ims`

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios (*)
N/A