### PR TITLE
fix MFTF tests that previously relied on "Locate" button

### DIFF
--- a/AdobeStockImageAdminUi/Test/Mftf/ActionGroup/AdminAdobeStockImagePreviewLocateActionGroup.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/ActionGroup/AdminAdobeStockImagePreviewLocateActionGroup.xml
@@ -9,7 +9,7 @@
 <actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
               xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
     <actionGroup name="AdminAdobeStockImagePreviewLocateActionGroup">
-        <click selector="{{AdobeStockImagePreviewSection.locateImage}}" stepKey="clickLocate"/>
+        <click selector="{{AdobeStockImagePreviewSection.openInMediaGallery}}" stepKey="clickOpenInMediaGallery"/>
         <waitForPageLoad stepKey="waitForMediaGalleryOpen"/>
     </actionGroup>
 </actionGroups>

--- a/AdobeStockImageAdminUi/Test/Mftf/README.md
+++ b/AdobeStockImageAdminUi/Test/Mftf/README.md
@@ -8,6 +8,12 @@ The Functional Test Module for **Magento AdobeStockImageAdminUI** module.
 vendor/bin/mftf run:group AdobeStockIntegration
 ```
 
+Or, if you want to run individual tests:
+
+```bash
+vendor/bin/mftf run:test <Test Name>
+```
+
 ## Configuration
 
 ### `.env`

--- a/AdobeStockImageAdminUi/Test/Mftf/Section/AdobeStockImagePreviewSection.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Section/AdobeStockImagePreviewSection.xml
@@ -11,7 +11,7 @@
         <element name="savePreview" type="button" selector="//button[@class='action-secondary']//span[text()='Save Preview']"/>
         <element name="licenseAndSave" type="button" selector="//button[@class='action-default primary']//span[text()='License and Save']"/>
         <element name="save" type="block" selector="//button[@class='action-secondary']//span[text()='Save Preview']"/>
-        <element name="locateImage" type="block" selector="//button[@class='action-secondary']//span[text()='Locate']"/>
+        <element name="openInMediaGallery" type="block" selector="//button[@class='action-secondary']//span[text()='Open in Media Gallery']"/>
         <element name="saveLicensedImage" type="button" selector="//div[@class='actions']/descendant::span[text()='Save']"/>
         <element name="image" type="block" selector="//div[@class='masonry-image-preview']//img"/>
         <element name="navigation" type="button" selector="//div[@class='masonry-image-preview']//div[contains(@class, 'action-buttons')]/button[@class='action-{{type}}']" parameterized="true"/>

--- a/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockACLTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockACLTest.xml
@@ -14,7 +14,7 @@
             <stories value="[Story #19] User controls access to Adobe Stock images from Admin Panel in ACL"/>
             <useCaseId value="https://github.com/magento/adobe-stock-integration/issues/42"/>
             <title value="User controls access to Adobe Stock images from Admin Panel in ACL"/>
-            <description value="Test to cover scenario: User controls access to Adobe Stock images from Admin Panel in ACL"/>
+            <description value="User controls access to Adobe Stock images from Admin Panel in ACL"/>
             <testCaseId value="https://app.hiptest.com/projects/131313/test-plan/folders/943908/scenarios/3218882"/>
             <severity value="MAJOR"/>
             <group value="adobe_stock_integration_configuration"/>

--- a/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockImagePreviewLocateTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockImagePreviewLocateTest.xml
@@ -10,9 +10,11 @@
     <test name="AdminAdobeStockImagePreviewLocateTest">
         <annotations>
             <features value="AdobeStockImagePanel"/>
-            <stories value="User locates preview image in the Media Gallery"/>
-            <title value="Adobe Stock Preview Saved Image Locate"/>
-            <description value="User can locate previously preview saved and unlicensed image in Media Gallery"/>
+            <stories value="[Story #27] User locates preview image in the Media Gallery"/>
+            <useCaseId value="https://github.com/magento/adobe-stock-integration/issues/329"/>
+            <title value="User locates preview image in the Media Gallery"/>
+            <description value="User can locate previously saved previewed but unlicensed image in Media Gallery"/>
+            <testCaseId value="https://app.hiptest.com/projects/131313/test-plan/folders/1051731/scenarios/3579494"/>
             <severity value="CRITICAL"/>
             <group value="adobe_stock_integration_preview"/>
             <group value="adobe_stock_integration"/>

--- a/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockSavedLicensedImageLocateTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockSavedLicensedImageLocateTest.xml
@@ -5,15 +5,16 @@
   * See COPYING.txt for license details.
   */
 -->
-
 <tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
     <test name="AdminAdobeStockSavedLicensedImageLocateTest">
         <annotations>
             <features value="AdobeStockImagePanel"/>
-            <stories value="User locates licensed and uploaded image inside Media Gallery"/>
-            <title value="Adobe Stock Saved Licensed Image Locate"/>
+            <stories value="[Story #24] User locates licensed and uploaded image inside Media Gallery"/>
+            <useCaseId value="https://github.com/magento/adobe-stock-integration/issues/312"/>
+            <title value="User locates licensed and uploaded image inside Media Gallery"/>
             <description value="User can locate previously licensed and saved image in Media Gallery"/>
+            <testCaseId value="https://app.hiptest.com/projects/131313/test-plan/folders/1051731/scenarios/3579444"/>
             <severity value="CRITICAL"/>
             <group value="adobe_stock_integration_license"/>
             <group value="adobe_stock_integration"/>


### PR DESCRIPTION
since button was renamed, update tests to reflect button label. also add a few annotations to a couple of MFTF tests (use case links, hiptest links)

This should once again fix the `preview` suite of MFTF test runs on Travis