### PR TITLE
removing test that attempt to license images

### DIFF
--- a/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockNotLicensedImageLicenseTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockNotLicensedImageLicenseTest.xml
@@ -9,6 +9,9 @@
        xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
     <test name="AdminAdobeStockNotLicensedImageLicenseTest">
         <annotations>
+            <skip>
+                <issueId value="https://github.com/magento/adobe-stock-integration/issues/783"/>
+            </skip>
             <features value="AdobeStockImagePanel"/>
             <stories value="User licenses an image"/>
             <title value="Adobe Stock License Image"/>


### PR DESCRIPTION
This fixes #783 by deleting the test. It is not possible to license the same image multiple times, nor is it possible to unlicense images, therefore this test is not possible to automate if the project is running against the production Adobe Stock service.

I have updated hiptest to mark this test case as 'not automatable' BTW

