### PR TITLE
Add screenshot uploading support to Travis MFTF builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -100,13 +100,8 @@ install:
 before_script:
   - bash -x dev/travis/before_script.sh
 script:
-  - pushd magento2
-  - if [ $TEST_SUITE == 'unit' ]; then vendor/bin/phpunit --configuration dev/tests/unit/phpunit.xml; fi
-  - if [ $TEST_SUITE == 'phpstan' ]; then composer require --dev phpstan/phpstan fooman/phpstan-magento2-magic-methods && vendor/bin/phpstan analyse -l 2 app/code/Magento/Adobe* -a dev/tests/api-functional/framework/autoload.php ; fi
-  - if [ $TEST_SUITE == 'static' ]; then vendor/bin/phpcs --standard=dev/tests/static/framework/Magento/ app/code/Magento/Adobe*; fi
-  - if [ $TEST_SUITE == 'static' ]; then ! find app/code/Magento/Adobe*/ -type f -name "*.php" -exec grep -L strict_types=1 {} + | grep Adobe; fi
-  - if [ $TEST_SUITE == 'functional' ]; then echo "Running MFTF suite ${MFTF_SUITE}" && vendor/bin/mftf run:group $MFTF_SUITE --remove -vvv; fi
+  - bash -x dev/travis/script.sh
 after_success:
-  - if [ $TEST_SUITE == 'unit' ]; then cd ../ && travis_retry coveralls; fi
+  - if [ $TEST_SUITE == 'unit' ]; then travis_retry coveralls; fi
 after_failure:
-  - if [ $TEST_SUITE == 'functional' ]; then cat "${HOME}/selenium.log"; cat "${TRAVIS_BUILD_DIR}/chromedriver.log"; cat "${TRAVIS_BUILD_DIR}/magento2/var/log/debug.log"; cat "${TRAVIS_BUILD_DIR}/magento2/var/log/system.log"; ls -al "${TRAVIS_BUILD_DIR}/magento2/dev/tests/acceptance/tests/_output";fi
+  - bash -x dev/travis/after_failure.sh

--- a/dev/travis/after_failure.sh
+++ b/dev/travis/after_failure.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# Copyright © Magento, Inc. All rights reserved.
+# See COPYING.txt for license details.
+
+if [ "$TEST_SUITE" == 'functional' ]; then
+    cat "${HOME}/selenium.log"
+    cat "${TRAVIS_BUILD_DIR}/chromedriver.log"
+    cat "${TRAVIS_BUILD_DIR}/magento2/var/log/debug.log"
+    cat "${TRAVIS_BUILD_DIR}/magento2/var/log/system.log"
+    pushd "${TRAVIS_BUILD_DIR}/magento2/dev/tests/acceptance/tests/_output"
+    set +x
+    for screenshot in *.png;
+    do
+        echo ""
+        echo "Uploading ${screenshot}, image URL follows..."
+        curl --location --request POST --form "image=@${screenshot}" "https://api.imgbb.com/1/upload?key=${IMGBB_API_KEY}" | jq '.data.url'
+    done
+    set -x
+    popd
+fi

--- a/dev/travis/script.sh
+++ b/dev/travis/script.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# Copyright © Magento, Inc. All rights reserved.
+# See COPYING.txt for license details.
+
+set -e
+pushd magento2
+
+if [ $TEST_SUITE == 'unit' ];
+then
+    vendor/bin/phpunit --configuration dev/tests/unit/phpunit.xml;
+fi
+
+if [ $TEST_SUITE == 'phpstan' ];
+then
+    composer require --dev phpstan/phpstan fooman/phpstan-magento2-magic-methods;
+    vendor/bin/phpstan analyse -l 2 app/code/Magento/Adobe* -a dev/tests/api-functional/framework/autoload.php;
+fi
+
+if [ $TEST_SUITE == 'static' ]; then
+    vendor/bin/phpcs --standard=dev/tests/static/framework/Magento/ app/code/Magento/Adobe*;
+    ! find app/code/Magento/Adobe*/ -type f -name "*.php" -exec grep -L strict_types=1 {} + | grep Adobe;
+fi
+
+if [ $TEST_SUITE == 'functional' ]; then
+    echo "Running MFTF suite ${MFTF_SUITE}";
+    vendor/bin/mftf run:group $MFTF_SUITE --remove -vvv;
+fi
+
+popd


### PR DESCRIPTION
This is done during the `after_failure` travis lifecycle / phase.

Also factor as many of the script blocks out of the travis yml and into dedicated script files. Unfortunately some travis shell helpers (like `travis_retry`) are not available in shell scripts so those helper commands must remain in the travis yml.

I've already added the ImgBB API key to the travis settings (ImgBB is where we upload the screenshots).

To view the screenshots, load up the relevant travis job, click into an MFTF travis sub-job, scroll all the way down and expand the `after_failure` log block. Scroll all the way down again and the URL should be in the logs.