### PR TITLE
Serie Id and Model Id filters do not indicate applied values

### DIFF
--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/related.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/related.js
@@ -43,16 +43,11 @@ define([
         initialize: function () {
             this._super();
 
-            this.filterChips()._elems.each(function (elem) {
-                        if (elem.index === 'serie_id' && elem.initialValue === '') {
-                            elem.initialValue = this.serieFilterValue();
-                        } else if (elem.index === 'model_id' && elem.initialValue === '') {
-                            elem.initialValue = this.modelFilterValue();
-                        }
-                    }.bind(this));
+            this.filterChips().updateActive();
 
             return this;
         },
+
         /**
          * Init observable variables
          * @return {Object}

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/related.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/related.js
@@ -38,6 +38,22 @@ define([
         },
 
         /**
+         * Initializes related component.
+         */
+        initialize: function () {
+            this._super();
+
+            this.filterChips()._elems.each(function (elem) {
+                        if (elem.index === 'serie_id' && elem.initialValue === '') {
+                            elem.initialValue = this.serieFilterValue();
+                        } else if (elem.index === 'model_id' && elem.initialValue === '') {
+                            elem.initialValue = this.modelFilterValue();
+                        }
+                    }.bind(this));
+
+            return this;
+        },
+        /**
          * Init observable variables
          * @return {Object}
          */


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/adobe-stock-integration#514: Serie Id and Model Id filters do not indicate applied values
2. ...

### Manual testing scenarios (*)

1.     Login to admin panel
2.     Open Magento Media Gallery (i.e. go to Cms -> Pages, edit the page and insert image)
3.     Click "Search Adobe Stock" button to open images grid
4.     Click on any image to expand image preview
5.     Click on "See more" link in the related images section
6.     Logout from admin panel
7.     Login back to admin panel from another/incognito browser
8.     Reopen the Adobe Stock grid
9. 
Expected result

The filter applied value should be indicated in the applied filters section