### PR TITLE
#738 : Long Adobe IMS account names show weirdly in Stock Search Grid

### DIFF
--- a/AdobeIms/view/adminhtml/web/css/source/_module.less
+++ b/AdobeIms/view/adminhtml/web/css/source/_module.less
@@ -23,7 +23,7 @@
 
         .adobe-user-information {
             float: right;
-            width: 220px;
+            width: auto;
             margin-top: -54px;
 
             .adobe-profile-image-small {


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR will fix the display issue with long name in IMS
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/adobe-stock-integration#738: Long Adobe IMS account names show weirdly in Stock Search Grid

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Open the Stock search grid.
2. Sign in with an Adobe IMS account (ideally with a long name - if not, you can open web inspector and manually make your name long).

### Expected Result
![image](https://user-images.githubusercontent.com/39480008/69746217-cb673b80-1169-11ea-8c40-8a7dbefdbac4.png)