### PR TITLE
A "500 Internat Server Error" appears in Developer Console each time when No records are found using search by filter(must be signed in Adobe Stock)

### DIFF
--- a/AdobeIms/view/adminhtml/web/css/source/_module.less
+++ b/AdobeIms/view/adminhtml/web/css/source/_module.less
@@ -24,6 +24,7 @@
         .adobe-user-information {
             float: right;
             width: auto;
+            margin-right: 30px;
             margin-top: -54px;
 
             .adobe-profile-image-small {

--- a/AdobeStockClient/Model/Client/Files.php
+++ b/AdobeStockClient/Model/Client/Files.php
@@ -26,7 +26,7 @@ class Files implements FilesInterface
     /**
      * Successful curl result code.
      */
-    private const CURL_STATUS_OK = 0;
+    private const CURL_STATUS_OK = 200;
 
     private const FILES = 'files';
 

--- a/AdobeStockImageAdminUi/Controller/Adminhtml/License/GetList.php
+++ b/AdobeStockImageAdminUi/Controller/Adminhtml/License/GetList.php
@@ -60,13 +60,13 @@ class GetList extends Action
         try {
             $params = $this->getRequest()->getParams();
 
-            $files = $this->files->execute(
-                explode(',', $params['ids']),
-                [
-                    self::FIELD_ID,
-                    self::FIELD_IS_LICENSED
-                ]
-            );
+            $files = [];
+            if ($params['ids'] !== '') {
+                $files[] = $this->files->execute(
+                    explode(',', $params['ids']),
+                    [self::FIELD_ID, self::FIELD_IS_LICENSED]
+                );
+            }
 
             $result = [];
 

--- a/AdobeStockImageAdminUi/Controller/Adminhtml/License/GetList.php
+++ b/AdobeStockImageAdminUi/Controller/Adminhtml/License/GetList.php
@@ -61,17 +61,17 @@ class GetList extends Action
             $params = $this->getRequest()->getParams();
 
             $files = [];
+            $result = [];
+
             if ($params['ids'] !== '') {
                 $files[] = $this->files->execute(
                     explode(',', $params['ids']),
                     [self::FIELD_ID, self::FIELD_IS_LICENSED]
                 );
-            }
 
-            $result = [];
-
-            foreach ($files as $file) {
-                $result[$file[self::FIELD_ID]] = (bool) $file[self::FIELD_IS_LICENSED];
+                foreach ($files as $file) {
+                    $result[$file[self::FIELD_ID]] = (bool) $file[self::FIELD_IS_LICENSED];
+                }
             }
 
             $responseCode = self::HTTP_OK;

--- a/AdobeStockImageAdminUi/Controller/Adminhtml/License/GetList.php
+++ b/AdobeStockImageAdminUi/Controller/Adminhtml/License/GetList.php
@@ -60,18 +60,17 @@ class GetList extends Action
         try {
             $params = $this->getRequest()->getParams();
 
-            $files = [];
+            $result = [];
+
             if ($params['ids'] !== '') {
-                $files[] = $this->files->execute(
+                $files = $this->files->execute(
                     explode(',', $params['ids']),
                     [self::FIELD_ID, self::FIELD_IS_LICENSED]
                 );
-            }
 
-            $result = [];
-
-            foreach ($files as $file) {
-                $result[$file[self::FIELD_ID]] = (bool) $file[self::FIELD_IS_LICENSED];
+                foreach ($files as $file) {
+                    $result[$file[self::FIELD_ID]] = (bool) $file[self::FIELD_IS_LICENSED];
+                }
             }
 
             $responseCode = self::HTTP_OK;


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/adobe-stock-integration#791: Issue title
2. ...

### Manual testing scenarios (*)

1. Open Developer Console in your WEB Browser
2. From Admin go to Content - Pages, click Add New Page
3. Expand Content Click Show / Hide Editor, select Insert Image...
4. Click Search Adobe Stock
5. Sign Into Adobe Stock Integration
6. Click Filters and try to apply a filter that will not find any records.