### PR TITLE
Set Acl  for Adobe Integration Depend On Pages

### DIFF
--- a/AdobeStockImageAdminUi/etc/acl.xml
+++ b/AdobeStockImageAdminUi/etc/acl.xml
@@ -11,7 +11,7 @@
             <resource id="Magento_Backend::admin">
                 <resource id="Magento_Backend::content">
                     <resource id="Magento_Backend::content_elements">
-                        <resource id="Magento_Cms::media_gallery">
+                        <resource id="Magento_Cms::page">
                             <resource id="Magento_AdobeStockImageAdminUi::media_gallery" title="Adobe Stock" translate="title" sortOrder="70">
                                 <resource id="Magento_AdobeStockImageAdminUi::save_preview_images" title="Save Preview Image" translate="title" sortOrder="30" />
                                 <resource id="Magento_AdobeStockImageAdminUi::license_images" title="License images" translate="title" sortOrder="40" />


### PR DESCRIPTION


<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/adobe-stock-integration#801:Set Acl only for Adobe Integration (Media Gallery resource) brokes Admin Panel 
2. ...

### Manual testing scenarios (*)
Same as in Issue description
