### PR TITLE
Fix Save Licensed Image MFTF test

### DIFF
--- a/AdobeStockImageAdminUi/Test/Mftf/ActionGroup/AdminAdobeStockAssertUserLoggedActionGroup.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/ActionGroup/AdminAdobeStockAssertUserLoggedActionGroup.xml
@@ -9,6 +9,7 @@
 <actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
               xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
     <actionGroup name="AdminAdobeStockAssertUserLoggedActionGroup">
+        <waitForAjaxLoad stepKey="waitForIMSProfileToLoad"/>
         <seeElement selector="{{AdobeStockSection.userImageSmall}}" stepKey="seeUserIcon" />
     </actionGroup>
 </actionGroups>


### PR DESCRIPTION
Hat tip to @sivaschenko for pointing out that we load image licensing state in the background asynchronously after an IMS sign in, which was causing one of the MFTF tests to fail.

This PR adds a wait in the user profile assertion action group, ensuring asynchronous requests complete before asserting that the IMS profile image is visible. This will also wait for licensing information to load in the background.

Expectation is that the `AdminAdobeStockSavedLicensedImageLocateTest` test passes in this PR.