### PR TITLE
Hide tabs with related images if result is empty

### DIFF
--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/related.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/related.js
@@ -111,9 +111,37 @@ define([
 
                 relatedImages.series[record.id] = data.result['same_series'];
                 relatedImages.model[record.id] = data.result['same_model'];
+
                 this.relatedImages(relatedImages);
                 this.preview().updateHeight();
+
+                /* Switch to the model tab if the series tab is hidden */
+                if (relatedImages.series[record.id].length === 0) {
+                    $('#adobe-stock-tabs').data().mageTabs.select(1);
+                }
             }.bind(this));
+        },
+
+        /**
+         * Returns true if the series tab should be show, false otherwise
+         *
+         * @param {Object} record
+         * @returns boolean
+         */
+        showSeriesTab: function (record) {
+            return typeof this.relatedImages().series[record.id] === 'undefined' ||
+                this.relatedImages().series[record.id].length !== 0;
+        },
+
+        /**
+         * Returns true if the model tab should be show, false otherwise
+         *
+         * @param {Object} record
+         * @returns boolean
+         */
+        showModelTab: function (record) {
+            return typeof this.relatedImages().model[record.id] === 'undefined' ||
+                this.relatedImages().model[record.id].length !== 0;
         },
 
         /**

--- a/AdobeStockImageAdminUi/view/adminhtml/web/template/grid/column/preview/related.html
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/template/grid/column/preview/related.html
@@ -5,23 +5,22 @@
  */
 -->
 <div if="isVisible($row())"
-    class="related-container">
+     class="related-container">
     <div id="adobe-stock-tabs"
          class="adobe-stock-tabs"
          data-bind="mageInit: {
                     'mage/backend/tabs': {
-                    active: 'series_content_' + $row().id,
                     destination: '#adobe-stock-tabs-content',
                     shadowTabs: [],
                 }
             }">
         <ul class="tabs-horiz">
-            <li>
+            <li if="showSeriesTab($row())">
                 <a id="series_tab" attr="'href': '#series_content_' + $row().id">
                     <span class="title" translate="'More from this series'"></span>
                 </a>
             </li>
-            <li>
+            <li if="showModelTab($row())">
                 <a id="model_tab" attr="'href': '#model_content_' + $row().id">
                     <span class="title" translate="'More from this model'"></span>
                 </a>
@@ -31,7 +30,7 @@
 
     <div id="adobe-stock-tabs-content"
          class="adobe-stock-related-images-tab-content">
-        <div attr="'id': 'series_content_' + $row().id">
+        <div if="showSeriesTab($row())" attr="'id': 'series_content_' + $row().id">
             <!-- ko foreach: getSeries($row()) -->
             <div class="thumbnail" data-bind="click: function(){ $parent.switchImagePreviewToSeriesImage($data) }">
                 <img attr="src: thumbnail_url, alt: title">
@@ -50,7 +49,7 @@
             </div>
             <!-- /ko -->
         </div>
-        <div attr="'id': 'model_content_' + $row().id">
+        <div if="showModelTab($row())" attr="'id': 'model_content_' + $row().id">
             <!-- ko foreach: getModel($row()) -->
             <div class="thumbnail" data-bind="click: function(){ $parent.switchImagePreviewToModelImage($data) }">
                 <img attr="src: thumbnail_url, alt: title">
@@ -71,4 +70,3 @@
         </div>
     </div>
 </div>
-


### PR DESCRIPTION
### Description (*)
This PR adjusts the related images tabs behavior. So if there are no related images from the same series or model, the corresponding tab is being hidden.

### Fixed Issues (if relevant)
1. #677 : See more from series/model tabs to hide if result is empty

### Manual testing scenarios (*)
1. Login to admin panel
2. Open Magento Media Gallery (i.e. go to Cms -> Pages, edit the page and insert image)
3. Click "Search Adobe Stock" button to open images grid
4. Enter text `81214721` in search by keywords
5. Click on the image to open the image preview

The "More from this series" tab should be hidden since there are no images from the same series.