### PR TITLE
Added MFTF test for viewing licensed label

### DIFF
--- a/AdobeStockImageAdminUi/Test/Mftf/Section/AdobeStockSection.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Section/AdobeStockSection.xml
@@ -36,5 +36,6 @@
         <element name="sortDropdown" type="button" selector="div[class='masonry-sorting'] select"/>
         <element name="sortOption" type="button" selector="//div[@class='masonry-sorting'] //option[@value='{{sortOption}}']" parameterized="true"/>
         <element name="deleteMediaButton" type="button" selector="button#delete_files"/>
+        <element name="licensedLabel" type="block" selector="//div[@class='masonry-image-column' and @data-repeat-index='0']//span[text()='Licensed']"/>
     </section>
 </sections>

--- a/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockLicensedImageViewLabelTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockLicensedImageViewLabelTest.xml
@@ -14,6 +14,7 @@
             <useCaseId value="https://github.com/magento/adobe-stock-integration/issues/309"/>
             <title value="User views licensed label for licensed images in Adobe Stock Panel"/>
             <description value="User views licensed label for licensed images in Adobe Stock Panel"/>
+            <testCaseId value="https://app.hiptest.com/projects/131313/test-plan/folders/1051731/scenarios/3579363"/>
             <severity value="CRITICAL"/>
             <group value="adobe_stock_integration_license"/>
             <group value="adobe_stock_integration"/>

--- a/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockLicensedImageViewLabelTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockLicensedImageViewLabelTest.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+    <test name="AdminAdobeStockLicensedImageViewLabelTest">
+        <annotations>
+            <features value="AdobeStockImagePanel"/>
+            <stories value="[Story #22] User views licensed images in the grid"/>
+            <useCaseId value="https://github.com/magento/adobe-stock-integration/issues/309"/>
+            <title value="User views licensed label for licensed images in Adobe Stock Panel"/>
+            <description value="User views licensed label for licensed images in Adobe Stock Panel"/>
+            <severity value="CRITICAL"/>
+            <group value="adobe_stock_integration_license"/>
+            <group value="adobe_stock_integration"/>
+        </annotations>
+        <before>
+            <actionGroup ref="LoginAsAdmin" stepKey="loginAsAdmin"/>
+            <actionGroup ref="AdminOpenMediaGalleryForPageNoEditorActionGroup" stepKey="openMediaGalleryForPage"/>
+            <actionGroup ref="AdminAdobeStockOpenPanelFromMediaGalleryActionGroup" stepKey="openAdobeStockPanel"/>
+            <actionGroup ref="AdminAdobeStockClickSignInActionGroup" stepKey="clickOnSignIn"/>
+            <actionGroup ref="AdminAdobeStockImsPopupSignInFillUserDataActionGroup" stepKey="fillUserCredentials"/>
+            <actionGroup ref="AdminAdobeStockImsPopupClickSignInActionGroup" stepKey="clickSignInImsPopup"/>
+            <actionGroup ref="AdminAdobeStockAssertUserLoggedActionGroup" stepKey="assertUserLoggedIn"/>
+        </before>
+        <after>
+            <actionGroup ref="AdminOpenMediaGalleryForPageNoEditorActionGroup" stepKey="openMediaGalleryForPage"/>
+            <actionGroup ref="AdminAdobeStockOpenPanelFromMediaGalleryActionGroup" stepKey="openAdobeStockPanel"/>
+            <actionGroup ref="AdminAdobeStockUserSignOutActionGroup" stepKey="adobeLogout"/>
+            <actionGroup ref="AdminAdobeStockAssertUserNotLoggedActionGroup" stepKey="assertAdobeUserLoggedOut"/>
+            <actionGroup ref="resetAdminDataGridToDefaultView" stepKey="resetAdminDataGridToDefaultView"/>
+            <actionGroup ref="logout" stepKey="adminLogout"/>
+        </after>
+        <actionGroup ref="AdminSearchImagesOnModalActionGroup" stepKey="searchForLicensedImage">
+            <argument name="query" value="{{AdobeStockLicensedImage.id}}"/>
+        </actionGroup>
+        <seeElementInDOM selector="{{AdobeStockSection.licensedLabel}}" stepKey="seeLicensedLabel"/>
+    </test>
+</tests>


### PR DESCRIPTION
### Description

-  Added MFTF test to ensure user can see _Licensed_ label for licensed images

### Fixed Issues
-  magento/adobe-stock-integration#442: [MFTF] User views licensed images in the grid (https://github.com/magento/adobe-stock-integration/issues/442#issuecomment-553616654)

### Manual testing scenarios

-  Run `vendor/bin/mftf run:test AdminAdobeStockLicensedImageViewLabelTest --remove`