### PR TITLE
Shifting view controls to the left by applying a right padding

### DIFF
--- a/AdobeStockImageAdminUi/view/adminhtml/web/css/source/_module.less
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/css/source/_module.less
@@ -80,7 +80,7 @@
         }
 
         .admin__data-grid-outer-wrap {
-            .admin__data-grid-header {
+            .admin__data-grid-header-row {
                 padding-right: 8rem;
             }
         }

--- a/AdobeStockImageAdminUi/view/adminhtml/web/css/source/_module.less
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/css/source/_module.less
@@ -79,6 +79,12 @@
             }
         }
 
+        .admin__data-grid-outer-wrap {
+            .admin__data-grid-header {
+                padding-right: 8rem;
+            }
+        }
+
         .masonry-image-grid {
             + .admin__data-grid-header {
                 .selectmenu-items {


### PR DESCRIPTION
...so that saved views and related buttons slide back into the viewport.

<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)

The view controls are shifted to the far to the left, so if you want to edit or delete saved views, you are going to have a bad time right now.

The fix is applying a right padding to the header controls. The size of this padding was determined by looking at the `min-width` CSS property for the saved view menu items (see [its definition here](https://github.com/magento/magento2/blob/0eb8677b0b4e35606032e856cc1ef7c80e68829f/app/design/adminhtml/Magento/backend/Magento_Ui/web/css/source/module/data-grid/data-grid-header/_data-grid-action-bookmarks.less#L74)). The right padding needs to be just shy of 50% of the View dropdown item `min-width` for all saved view buttons to be visible.

We should also possibly consider filing a new issue to cover using these buttons in an MFTF test, in order to catch these buttons becoming invisible again in the future.

Screenshots of the new changes in action:

<img width="548" alt="Screen Shot 2019-12-03 at 6 23 28 PM" src="https://user-images.githubusercontent.com/52645/70078128-0fd75900-15fa-11ea-985c-97ab9e10df35.png">

<img width="595" alt="Screen Shot 2019-12-03 at 6 23 35 PM" src="https://user-images.githubusercontent.com/52645/70078150-149c0d00-15fa-11ea-8d80-6c613210b524.png">


### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. #821 

### Manual testing scenarios (*)

1. From Magento Admin go to Content - Pages, click **Add New Page**
2. Expand **Content** Click **Show / Hide Editor**, select **Insert Image...**
3. Click **Search Adobe Stock**
4. Click **Filters** and **Apply** any filter, _Price - Standard_ for example (this step is done to enable Save View As button)
5. Click **Default View** and select **Save View As...**
6. Type in any name and click Enter key
7. Click on View dropdown again
8. You should be able  to see the pencil icon (without this PR, you won't)
9. Even if you click the pencil icon, you should be able to see a Trash can icon after clicking it.