### PR TITLE
#issue-832 Added pagination to media gallery grid and adjusted the images provider for allowing paging

### DIFF
--- a/MediaGalleryUi/view/adminhtml/ui_component/media_gallery_listing.xml
+++ b/MediaGalleryUi/view/adminhtml/ui_component/media_gallery_listing.xml
@@ -45,6 +45,25 @@
                 </settings>
             </filterSelect>
         </filters>
+        <paging name="listing_paging">
+            <settings>
+                <options>
+                    <option name="32" xsi:type="array">
+                        <item name="value" xsi:type="number">32</item>
+                        <item name="label" xsi:type="string">32</item>
+                    </option>
+                    <option name="48" xsi:type="array">
+                        <item name="value" xsi:type="number">48</item>
+                        <item name="label" xsi:type="string">48</item>
+                    </option>
+                    <option name="64" xsi:type="array">
+                        <item name="value" xsi:type="number">64</item>
+                        <item name="label" xsi:type="string">64</item>
+                    </option>
+                </options>
+                <pageSize>32</pageSize>
+            </settings>
+        </paging>
     </listingToolbar>
     <columns name="media_gallery_columns" component="Magento_Ui/js/grid/masonry">
         <argument name="data" xsi:type="array">


### PR DESCRIPTION
### Description (*)
This PR adds the pagination functionality to the media gallery grid.

### Fixed Issues (if relevant)

1. magento/adobe-stock-integration#832: Add pagination to media gallery grid

### Manual testing scenarios (*)

1. Log in to Admin Panel
2. Select "Media Gallery Development" from the menu on the right