### PR TITLE
See more link can be overlapped by similar keywords

### DIFF
--- a/AdobeStockImageAdminUi/view/adminhtml/web/css/source/_module.less
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/css/source/_module.less
@@ -200,7 +200,8 @@
                         justify-content: center;
                         position: relative;
                         height: 100px;
-                        width: 150px;
+                        max-width: 130px;
+                        width: 100%;
                         overflow: hidden;
                         margin-right: 10px;
                         vertical-align: middle;
@@ -216,7 +217,7 @@
                         display: inline-block;
                         max-height: 100px;
                         text-align: center;
-                        max-width: 140px;
+                        max-width: 130px;
                         vertical-align: middle;
                         width: 100%;
                         cursor: pointer;

--- a/AdobeStockImageAdminUi/view/adminhtml/web/css/source/_module.less
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/css/source/_module.less
@@ -213,7 +213,7 @@
                         justify-content: center;
                         position: relative;
                         height: 100px;
-                        max-width: 130px;
+                        max-width: 150px;
                         width: 100%;
                         overflow: hidden;
                         margin-right: 10px;
@@ -230,7 +230,7 @@
                         display: inline-block;
                         max-height: 100px;
                         text-align: center;
-                        max-width: 130px;
+                        max-width: 140px;
                         vertical-align: middle;
                         width: 100%;
                         cursor: pointer;
@@ -331,6 +331,23 @@
 
             .admin__field-tooltip {
                 margin: -5px 0 0 5px;
+            }
+        }
+    }
+}
+
+@media (max-width: 1400px) {
+    .adobe-stock-images-search-modal-content {
+        .masonry-image-preview {
+            .adobe-stock-related-images-tab-content {
+                .ui-tabs-panel {
+                    .thumbnail {
+                        max-width: 130px;
+                    }
+                    .see-more-wrapper {
+                        max-width: 130px;
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR will fix the overlap issue with see more element in related image section for kindle device
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/adobe-stock-integration#827: Element '#adobe-stock-tabs-content .three-dots' can be overlapped by "Similar keywords"

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. On CMS edit page try to add an image by searching
2. In Chrome Dev Tools toggle Device Toolbar and choose Kindle Fire HDX in landscape mode

### Expected Result
![image](https://user-images.githubusercontent.com/39480008/70346819-30671380-1885-11ea-9731-90226b939ee5.png)
