### PR TITLE
Grid header has extra space in right side

### DIFF
--- a/AdobeStockImageAdminUi/view/adminhtml/web/css/source/_module.less
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/css/source/_module.less
@@ -82,10 +82,13 @@
             }
         }
 
-        .admin__data-grid-outer-wrap {
-            .admin__data-grid-header-row {
-                padding-right: 8rem;
-            }
+        .admin__action-dropdown-wrap._active .admin__action-dropdown-text::after {
+            margin-right: 6px;
+        }
+
+        .admin__data-grid-action-bookmarks .admin__action-dropdown-menu {
+            right: 0;
+            left: auto;
         }
 
         .masonry-image-grid {

--- a/AdobeStockImageAdminUi/view/adminhtml/web/template/grid/column/preview/actions.html
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/template/grid/column/preview/actions.html
@@ -30,6 +30,6 @@
     <span data-bind="text: getLicenseButtonTitle()"></span>
 </button>
 <button class="action-default primary" type="button" data-bind="visible: isLicensed(), click: function () { saveLicensed(); }">
-    <span translate="'Save'"></span>
+    <span translate="'Save Licensed'"></span>
 </button>
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/adobe-stock-integration#845: Grid header has extra space in right side
2. magento/adobe-stock-integration#851: Rename "Save" image preview button to "Save Licensed" 
### Manual testing scenarios (*)

   

1.  Login to admin panel
2.     Navigate to Cms Pages
3.     User clicks Add New Page button
4.     Expand "Content" section
5.     User clicks "Insert Image..." button
6.     Click "Search Adobe Stock" button to open images grid

Expected result (*)
![DeepinScreenshot_select-area_20191210130437](https://user-images.githubusercontent.com/2481206/70524501-efedeb00-1b4d-11ea-9eef-d72c10d5b6a0.png)
