### PR TITLE
Added MFTF test for Adobe sign in failure when Secret Key is incorrect

### DIFF
--- a/AdobeStockImageAdminUi/Test/Mftf/Section/AdobeStockSection.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Section/AdobeStockSection.xml
@@ -37,5 +37,7 @@
         <element name="sortOption" type="button" selector="//div[@class='masonry-sorting'] //option[@value='{{sortOption}}']" parameterized="true"/>
         <element name="deleteMediaButton" type="button" selector="button#delete_files"/>
         <element name="licensedLabel" type="block" selector="//div[@class='masonry-image-column' and @data-repeat-index='0']//span[text()='Licensed']"/>
+        <element name="IncorrectSecretModalText" type="block" selector="//*[contains(@class, 'modal-popup')]//div[contains(text(), 'Login failed')]"/>
+        <element name="IncorrectSecretModalButton" type="button" selector="//*[contains(@class, 'modal-popup')]//*[@class='modal-footer']/button//span[text()='Ok']"/>
     </section>
 </sections>

--- a/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockIncorrectSecretSignInTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockIncorrectSecretSignInTest.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+    <test name="AdminAdobeStockIncorrectSecretSignInTest">
+        <annotations>
+            <features value="AdobeStockImagePanel"/>
+            <!-- TODO: Add story reference -->
+            <stories value=""/>
+            <useCaseId value="https://github.com/magento/adobe-stock-integration/issues/799"/>
+            <title value="Admin User attempts to sign in to Adobe Stock with incorrect Secret Key configured"/>
+            <testCaseId value="https://app.hiptest.com/projects/131313/test-plan/folders/1051731/scenarios/3579351"/>
+            <description value="Admin User attempts to sign in to Adobe Stock with incorrect Secret Key configured"/>
+            <severity value="CRITICAL"/>
+            <group value="adobe_stock_integration_ims"/>
+            <group value="adobe_stock_integration"/>
+        </annotations>
+        <before>
+            <actionGroup ref="LoginAsAdmin" stepKey="adminLogin"/>
+            <actionGroup ref="AdminAdobeStockSetConfigActionGroup" stepKey="setIncorrectAdobeSecret">
+                <argument name="privateKey" value="RandomIncorrectSecretKey"/>
+            </actionGroup>
+            <actionGroup ref="AdminOpenMediaGalleryForPageNoEditorActionGroup" stepKey="openMediaGalleryForPage"/>
+            <actionGroup ref="AdminAdobeStockOpenPanelFromMediaGalleryActionGroup" stepKey="openAdobeStockPanel"/>
+        </before>
+        <after>
+            <actionGroup ref="AdminAdobeStockSetConfigActionGroup" stepKey="setCorrectAdobeSecret"/>
+            <actionGroup ref="logout" stepKey="adminLogout"/>
+        </after>
+        <actionGroup ref="AdminAdobeStockClickSignInActionGroup" stepKey="clickOnSignIn"/>
+        <actionGroup ref="AdminAdobeStockImsPopupSignInFillUserDataActionGroup" stepKey="fillUserCredentials"/>
+        <actionGroup ref="AdminAdobeStockImsPopupClickSignInActionGroup" stepKey="clickSignInImsPopup"/>
+        <seeElement selector="{{AdobeStockSection.IncorrectSecretModalText}}" stepKey="seeErrorModal"/>
+        <click selector="{{AdobeStockSection.IncorrectSecretModalButton}}" stepKey="closeErrorModal"/>
+        <actionGroup ref="AdminAdobeStockAssertUserNotLoggedActionGroup" stepKey="assertUserNotLogged"/>
+    </test>
+</tests>

--- a/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockIncorrectSecretSignInTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockIncorrectSecretSignInTest.xml
@@ -10,8 +10,7 @@
     <test name="AdminAdobeStockIncorrectSecretSignInTest">
         <annotations>
             <features value="AdobeStockImagePanel"/>
-            <!-- TODO: Add story reference -->
-            <stories value=""/>
+            <stories value="[Story #21] Adobe Sign-in (incorrect credentials)"/>
             <useCaseId value="https://github.com/magento/adobe-stock-integration/issues/799"/>
             <title value="Admin User attempts to sign in to Adobe Stock with incorrect Secret Key configured"/>
             <testCaseId value="https://app.hiptest.com/projects/131313/test-plan/folders/1051731/scenarios/3579351"/>


### PR DESCRIPTION
### Description

-  Added MFTF test for Adobe sign in _failure_ when Secret Key is incorrectly configured

### Fixed Issues

-  magento/adobe-stock-integration#799: [MFTF] Cover the case when Admin User attemps to login with incorrect Secret key in configuration

### Manual testing scenarios

Run `vendor/bin/mftf run:test AdminAdobeStockIncorrectSecretSignInTest --remove`