### PR TITLE
Not enough permissions error message is not shown to Admin user on attempt to license image

### DIFF
--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/actions.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/actions.js
@@ -378,10 +378,10 @@ define([
                      * On error
                      */
                     error: function (response) {
-                        var errorMessage = response.JSON ? response.JSON.meassage : '';
+                        var errorMessage = response.JSON ? response.JSON.meassage : 'Failed to fetch licensing information.';
 
                         if (response.status === 403) {
-                            errorMessage = $.mage.__('You have not enough permission to license images');
+                            errorMessage = $.mage.__('Your admin role does not have permissions to license an image');
                         }
 
                         messages.add('error', errorMessage);

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/actions.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/actions.js
@@ -378,11 +378,11 @@ define([
                      * On error
                      */
                     error: function (response) {
-			var errorMessage = response.JSON ? response.JSON.meassage : '';
+                        var errorMessage = response.JSON ? response.JSON.meassage : '';
 
-			if (response.status === 403) {
-				errorMessage = $.mage.__('You have not enough permission to license images');
-			}
+                        if (response.status === 403) {
+                            errorMessage = $.mage.__('You have not enough permission to license images');
+                        }
 
                         messages.add('error', errorMessage);
                         messages.scheduleCleanup(this.messageDelay);

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/actions.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/actions.js
@@ -378,7 +378,13 @@ define([
                      * On error
                      */
                     error: function (response) {
-                        messages.add('error', response.responseJSON.message);
+			var errorMessage = response.JSON ? response.JSON.meassage : '';
+
+			if (response.status === 403) {
+				errorMessage = $.mage.__('You have not enough permission to license images');
+			}
+
+                        messages.add('error', errorMessage);
                         messages.scheduleCleanup(this.messageDelay);
                     }
                 }

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/actions.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/actions.js
@@ -378,7 +378,8 @@ define([
                      * On error
                      */
                     error: function (response) {
-                        var errorMessage = response.JSON ? response.JSON.meassage : 'Failed to fetch licensing information.';
+                        var defaultMessage = 'Failed to fetch licensing information.',
+                            errorMessage = response.JSON ? response.JSON.meassage : defaultMessage;
 
                         if (response.status === 403) {
                             errorMessage = $.mage.__('Your admin role does not have permissions to license an image');


### PR DESCRIPTION
### Description (*)


### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/adobe-stock-integration#856: Not enough permissions error message is not shown to Admin user on an attempt to license the image

### Manual testing scenarios (*)

1. Create admin user test_user with new_role1
2.     Login to admin panel by test_user
3.     Navigate to Cms Pages
4.     User clicks Add New Page button
5.     Expand the "Content" section
6.     User clicks "Insert Image..." button
7.     Click "Search Adobe Stock" button to open images grid
8.     Expand image preview
9.     Click License and Save

Expected result (*)

Admin can log in to adobe stock account but cannot license images