### PR TITLE
Added MFTF test for Adobe Stock panel bookmarks functionality

### DIFF
--- a/AdobeStockImageAdminUi/Test/Mftf/ActionGroup/AdminAdobeStockSaveViewActionGroup.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/ActionGroup/AdminAdobeStockSaveViewActionGroup.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="AdminAdobeStockSaveViewActionGroup">
+        <click selector="{{AdminGridDefaultViewControls.defaultView}}" stepKey="openViews"/>
+        <click selector="{{AdminGridDefaultViewControls.saveViewAs}}" stepKey="saveView"/>
+        <fillField selector="{{AdminGridDefaultViewControls.viewName}}" userInput="Test View" stepKey="inputViewName"/>
+        <pressKey selector="{{AdminGridDefaultViewControls.viewName}}" parameterArray="[\Facebook\WebDriver\WebDriverKeys::ENTER]" stepKey="pressEnterKey"/>
+        <seeElement selector="{{AdminGridDefaultViewControls.viewByName('Test View')}}{{AdobeStockSection.editViewButtonPartial}}" stepKey="seeEditButton"/>
+        <click selector="{{AdminGridDefaultViewControls.viewByName('Test View')}}{{AdobeStockSection.editViewButtonPartial}}" stepKey="clickEditButton"/>
+        <seeElement selector="{{AdobeStockSection.deleteViewButton}}" stepKey="seeDeleteButton"/>
+        <click selector="{{AdobeStockSection.deleteViewButton}}" stepKey="clickDeleteButton"/>
+        <waitForPageLoad stepKey="waitForDeletion" time="10"/>
+    </actionGroup>
+</actionGroups>

--- a/AdobeStockImageAdminUi/Test/Mftf/Section/AdobeStockSection.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Section/AdobeStockSection.xml
@@ -37,5 +37,7 @@
         <element name="sortOption" type="button" selector="//div[@class='masonry-sorting'] //option[@value='{{sortOption}}']" parameterized="true"/>
         <element name="deleteMediaButton" type="button" selector="button#delete_files"/>
         <element name="licensedLabel" type="block" selector="//div[@class='masonry-image-column' and @data-repeat-index='0']//span[text()='Licensed']"/>
+        <element name="editViewButtonPartial" type="button" selector="/following-sibling::div/button[@class='action-edit']"/>
+        <element name="deleteViewButton" type="button" selector="//div[@data-bind='afterRender: \$data.setToolbarNode']//input/following-sibling::div/button[@class='action-delete']"/>
     </section>
 </sections>

--- a/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockGridBookmarksTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockGridBookmarksTest.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+    <test name="AdminAdobeStockGridBookmarksTest">
+        <annotations>
+            <features value="AdobeStockImagePanel"/>
+            <stories value="[Story #1] User accesses stock images from Magento Admin"/>
+            <useCaseId value="https://github.com/magento/adobe-stock-integration/issues/860"/>
+            <title value="User has access to bookmarks"/>
+            <description value="User is able to see and use the available Adobe Stock grid bookmarks"/>
+            <testCaseId value="https://app.hiptest.com/projects/131313/test-plan/folders/943908/scenarios/3222613"/>
+            <severity value="CRITICAL"/>
+            <group value="adobe_stock_integration_grid"/>
+            <group value="adobe_stock_integration"/>
+        </annotations>
+        <before>
+            <actionGroup ref="LoginAsAdmin" stepKey="loginAsAdmin"/>
+            <actionGroup ref="AdminOpenMediaGalleryForPageNoEditorActionGroup" stepKey="openMediaGalleryForPage"/>
+            <actionGroup ref="AdminAdobeStockOpenPanelFromMediaGalleryActionGroup" stepKey="openAdobeStockPanel"/>
+        </before>
+        <after>
+            <actionGroup ref="resetAdminDataGridToDefaultView" stepKey="resetAdminDataGridToDefaultView"/>
+            <actionGroup ref="logout" stepKey="logout"/>
+        </after>
+        <actionGroup ref="AdminAdobeStockExpandFiltersActionGroup" stepKey="expandFilters"/>
+        <actionGroup ref="AssertIsVisibleAdobeStockFilterElementActionGroup" stepKey="checkPriceFilter">
+            <argument name="filterName" value="Price"/>
+        </actionGroup>
+        <actionGroup ref="AdminFilterResultsActionGroup" stepKey="setPriceFilterToStandard">
+            <argument name="type" value="Standard"/>
+            <argument name="filter" value="{{AdobeStockFilterSection.premiumPriceFilter}}"/>
+            <argument name="filterOption" value="premium_price_filter"/>
+        </actionGroup>
+        <actionGroup ref="AdminAdobeStockSaveViewActionGroup" stepKey="saveAndDeleteView"/>
+    </test>
+</tests>

--- a/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockGridBookmarksTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockGridBookmarksTest.xml
@@ -25,7 +25,7 @@
             <actionGroup ref="AdminAdobeStockOpenPanelFromMediaGalleryActionGroup" stepKey="openAdobeStockPanel"/>
         </before>
         <after>
-            <actionGroup ref="resetAdminDataGridToDefaultView" stepKey="resetAdminDataGridToDefaultView"/>
+            <actionGroup ref="ResetAdminDataGridToDefaultViewActionGroup" stepKey="resetAdminDataGridToDefaultView"/>
             <actionGroup ref="logout" stepKey="logout"/>
         </after>
         <actionGroup ref="AdminAdobeStockExpandFiltersActionGroup" stepKey="expandFilters"/>


### PR DESCRIPTION
### Description

-  Added MFTF test for Adobe Stock panel bookmarks view, create, edit and delete functionality

### Fixed Issues

-  magento/adobe-stock-integration#860: [MFTF] Cover Adobe Stock grid bookmarks functionality

### Manual testing scenarios

-  Run `vendor/bin/mftf run:test AdminAdobeStockGridBookmarksTest --remove`