### PR TITLE
Refactored MFTF schema paths

### DIFF
--- a/AdobeStockImageAdminUi/Test/Mftf/Suite/adobe-stock-integration-configuration.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Suite/adobe-stock-integration-configuration.xml
@@ -7,7 +7,7 @@
 -->
 
 <suites xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="../../../../../../vendor/magento/magento2-functional-testing-framework/src/Magento/FunctionalTestingFramework/Suite/etc/suiteSchema.xsd">
+        xsi:noNamespaceSchemaLocation="urn:magento:mftf:Suite/etc/suiteSchema.xsd">
     <suite name="adobe_stock_integration_suite_configuration">
         <before>
             <actionGroup ref="LoginAsAdmin" stepKey="loginAsAdmin"/>

--- a/AdobeStockImageAdminUi/Test/Mftf/Suite/adobe-stock-integration-filters.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Suite/adobe-stock-integration-filters.xml
@@ -7,7 +7,7 @@
 -->
 
 <suites xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="../../../../../../vendor/magento/magento2-functional-testing-framework/src/Magento/FunctionalTestingFramework/Suite/etc/suiteSchema.xsd">
+        xsi:noNamespaceSchemaLocation="urn:magento:mftf:Suite/etc/suiteSchema.xsd">
     <suite name="adobe_stock_integration_suite_filters">
         <before>
             <actionGroup ref="LoginAsAdmin" stepKey="loginAsAdmin"/>

--- a/AdobeStockImageAdminUi/Test/Mftf/Suite/adobe-stock-integration-grid.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Suite/adobe-stock-integration-grid.xml
@@ -7,7 +7,7 @@
 -->
 
 <suites xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="../../../../../../vendor/magento/magento2-functional-testing-framework/src/Magento/FunctionalTestingFramework/Suite/etc/suiteSchema.xsd">
+        xsi:noNamespaceSchemaLocation="urn:magento:mftf:Suite/etc/suiteSchema.xsd">
     <suite name="adobe_stock_integration_suite_grid">
         <before>
             <actionGroup ref="LoginAsAdmin" stepKey="loginAsAdmin"/>

--- a/AdobeStockImageAdminUi/Test/Mftf/Suite/adobe-stock-integration-ims.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Suite/adobe-stock-integration-ims.xml
@@ -7,7 +7,7 @@
 -->
 
 <suites xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="../../../../../../vendor/magento/magento2-functional-testing-framework/src/Magento/FunctionalTestingFramework/Suite/etc/suiteSchema.xsd">
+        xsi:noNamespaceSchemaLocation="urn:magento:mftf:Suite/etc/suiteSchema.xsd">
     <suite name="adobe_stock_integration_suite_ims">
         <before>
             <actionGroup ref="LoginAsAdmin" stepKey="loginAsAdmin"/>

--- a/AdobeStockImageAdminUi/Test/Mftf/Suite/adobe-stock-integration-keywords.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Suite/adobe-stock-integration-keywords.xml
@@ -7,7 +7,7 @@
 -->
 
 <suites xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="../../../../../../vendor/magento/magento2-functional-testing-framework/src/Magento/FunctionalTestingFramework/Suite/etc/suiteSchema.xsd">
+        xsi:noNamespaceSchemaLocation="urn:magento:mftf:Suite/etc/suiteSchema.xsd">
     <suite name="adobe_stock_integration_suite_keywords">
         <before>
             <actionGroup ref="LoginAsAdmin" stepKey="loginAsAdmin"/>

--- a/AdobeStockImageAdminUi/Test/Mftf/Suite/adobe-stock-integration-license.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Suite/adobe-stock-integration-license.xml
@@ -7,7 +7,7 @@
 -->
 
 <suites xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="../../../../../../vendor/magento/magento2-functional-testing-framework/src/Magento/FunctionalTestingFramework/Suite/etc/suiteSchema.xsd">
+        xsi:noNamespaceSchemaLocation="urn:magento:mftf:Suite/etc/suiteSchema.xsd">
     <suite name="adobe_stock_integration_suite_license">
         <before>
             <actionGroup ref="LoginAsAdmin" stepKey="loginAsAdmin"/>

--- a/AdobeStockImageAdminUi/Test/Mftf/Suite/adobe-stock-integration-preview.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Suite/adobe-stock-integration-preview.xml
@@ -7,7 +7,7 @@
 -->
 
 <suites xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="../../../../../../vendor/magento/magento2-functional-testing-framework/src/Magento/FunctionalTestingFramework/Suite/etc/suiteSchema.xsd">
+        xsi:noNamespaceSchemaLocation="urn:magento:mftf:Suite/etc/suiteSchema.xsd">
     <suite name="adobe_stock_integration_suite_preview">
         <before>
             <actionGroup ref="LoginAsAdmin" stepKey="loginAsAdmin"/>

--- a/AdobeStockImageAdminUi/Test/Mftf/Suite/adobe-stock-integration-see-more.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Suite/adobe-stock-integration-see-more.xml
@@ -7,7 +7,7 @@
 -->
 
 <suites xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="../../../../../../vendor/magento/magento2-functional-testing-framework/src/Magento/FunctionalTestingFramework/Suite/etc/suiteSchema.xsd">
+        xsi:noNamespaceSchemaLocation="urn:magento:mftf:Suite/etc/suiteSchema.xsd">
     <suite name="adobe_stock_integration_suite_see_more">
         <before>
             <actionGroup ref="LoginAsAdmin" stepKey="loginAsAdmin"/>

--- a/AdobeStockImageAdminUi/Test/Mftf/Suite/adobe-stock-integration.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Suite/adobe-stock-integration.xml
@@ -7,7 +7,7 @@
 -->
 
 <suites xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="../../../../../../vendor/magento/magento2-functional-testing-framework/src/Magento/FunctionalTestingFramework/Suite/etc/suiteSchema.xsd">
+        xsi:noNamespaceSchemaLocation="urn:magento:mftf:Suite/etc/suiteSchema.xsd">
     <suite name="adobe_stock_integration_suite">
         <before>
             <actionGroup ref="LoginAsAdmin" stepKey="loginAsAdmin"/>


### PR DESCRIPTION
### Description

-  Refactored MFTF Suite schema paths from instance relative paths to Magento URN standards

### Manual testing scenarios

No functional change. Must be able to resolve Suite schema file paths in any local instance.