### PR TITLE
Handling activation of related images filter that is already applied

### DIFF
--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/related.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/related.js
@@ -247,7 +247,7 @@ define([
          * @returns {boolean}
          */
         isSerieFilterApplied: function (record) {
-            return this.filterChips().get('applied').serie_id === record.id.toString();
+            return this.filterChips().get('applied')['serie_id'] === record.id.toString();
         },
 
         /**
@@ -257,7 +257,7 @@ define([
          * @returns {boolean}
          */
         isModelFilterApplied: function (record) {
-            return this.filterChips().get('applied').model_id === record.id.toString();
+            return this.filterChips().get('applied')['model_id'] === record.id.toString();
         },
 
         /**
@@ -268,7 +268,7 @@ define([
                 behavior: 'smooth',
                 block: 'center',
                 inline: 'nearest'
-            })
+            });
         },
 
         /**

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/related.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/related.js
@@ -243,7 +243,7 @@ define([
         /**
          * Checks if the filter is applied
          *
-         * @param record
+         * @param {Object} record
          * @returns {boolean}
          */
         isSerieFilterApplied: function (record) {
@@ -253,7 +253,7 @@ define([
         /**
          * Checks if the filter is applied
          *
-         * @param record
+         * @param {Object} record
          * @returns {boolean}
          */
         isModelFilterApplied: function (record) {

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/related.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/related.js
@@ -244,7 +244,7 @@ define([
          * Checks if the filter is applied
          *
          * @param record
-         * @returns {boolean}
+         * @returns {Boolean}
          */
         isSerieFilterApplied: function (record) {
             return this.filterChips().get('applied')['serie_id'] === record.id.toString();
@@ -254,7 +254,7 @@ define([
          * Checks if the filter is applied
          *
          * @param record
-         * @returns {boolean}
+         * @returns {Boolean}
          */
         isModelFilterApplied: function (record) {
             return this.filterChips().get('applied')['model_id'] === record.id.toString();

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/related.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/related.js
@@ -14,6 +14,7 @@ define([
         defaults: {
             template: 'Magento_AdobeStockImageAdminUi/grid/column/preview/related',
             filterChipsProvider: 'componentType = filters, ns = ${ $.ns }',
+            filterTitleSelector: '.admin__current-filters-title-wrap',
             tabImagesLimit: 4,
             serieFilterValue: '',
             modelFilterValue: '',
@@ -207,6 +208,9 @@ define([
          * @param {Object} record
          */
         seeMoreFromSeries: function (record) {
+            if (this.isSerieFilterApplied(record)) {
+                this.scrollToFilter()
+            }
             this.serieFilterValue(record.id);
             this.filterChips().set(
                 'applied',
@@ -222,6 +226,9 @@ define([
          * @param {Object} record
          */
         seeMoreFromModel: function (record) {
+            if (this.isModelFilterApplied(record)) {
+                this.scrollToFilter()
+            }
             this.modelFilterValue(record.id);
             this.filterChips().set(
                 'applied',
@@ -229,6 +236,37 @@ define([
                     'model_id': record.id.toString()
                 }
             );
+        },
+
+        /**
+         * Checks if the filter is applied
+         *
+         * @param record
+         * @returns {boolean}
+         */
+        isSerieFilterApplied: function (record) {
+            return this.filterChips().get('applied').serie_id === record.id.toString();
+        },
+
+        /**
+         * Checks if the filter is applied
+         *
+         * @param record
+         * @returns {boolean}
+         */
+        isModelFilterApplied: function (record) {
+            return this.filterChips().get('applied').model_id === record.id.toString();
+        },
+
+        /**
+         * Scrolls user window to the filter title
+         */
+        scrollToFilter: function () {
+            $(this.filterTitleSelector).get(0).scrollIntoView({
+                behavior: 'smooth',
+                block: 'center',
+                inline: 'nearest'
+            })
         },
 
         /**

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/related.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/related.js
@@ -210,7 +210,7 @@ define([
         seeMoreFromSeries: function (record) {
             if (this.isSerieFilterApplied(record)) {
                 this.scrollToFilter();
-                
+
                 return;
             }
             this.serieFilterValue(record.id);

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/related.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/related.js
@@ -209,7 +209,8 @@ define([
          */
         seeMoreFromSeries: function (record) {
             if (this.isSerieFilterApplied(record)) {
-                this.scrollToFilter()
+                this.scrollToFilter();
+                return;
             }
             this.serieFilterValue(record.id);
             this.filterChips().set(
@@ -227,7 +228,8 @@ define([
          */
         seeMoreFromModel: function (record) {
             if (this.isModelFilterApplied(record)) {
-                this.scrollToFilter()
+                this.scrollToFilter();
+                return;
             }
             this.modelFilterValue(record.id);
             this.filterChips().set(

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/related.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/related.js
@@ -210,6 +210,7 @@ define([
         seeMoreFromSeries: function (record) {
             if (this.isSerieFilterApplied(record)) {
                 this.scrollToFilter();
+                
                 return;
             }
             this.serieFilterValue(record.id);
@@ -229,6 +230,7 @@ define([
         seeMoreFromModel: function (record) {
             if (this.isModelFilterApplied(record)) {
                 this.scrollToFilter();
+
                 return;
             }
             this.modelFilterValue(record.id);


### PR DESCRIPTION
### Description
This PR fixes the #850 issue, an if was added to the seeMoreFromSeries and seeMoreFromModel functions to check if the filter requested is the applied, if so, scrolls the customer to the filter title. 

### Fixed Issues
1. magento/adobe-stock-integration#850: The "See more" button doesn't work when More images are loaded and the same image is previewed again

### Manual testing scenarios
1. From Admin go to Content - Pages, click Add New Page
2. Expand Content,click Show / Hide Editor, select Insert Image...
3. Click Search Adobe Stock
4. Click, for example on the first image to open the Preview
5. Click See more
6. From the updated grid, select the same image you've opened previously, and click See more
