### PR TITLE
Removed sticky toolbar

### DIFF
--- a/AdobeStockImageAdminUi/view/adminhtml/ui_component/adobe_stock_images_listing.xml
+++ b/AdobeStockImageAdminUi/view/adminhtml/ui_component/adobe_stock_images_listing.xml
@@ -35,7 +35,7 @@
     </dataSource>
     <listingToolbar name="listing_top" template="Magento_AdobeStockImageAdminUi/grid/toolbar">
         <settings>
-            <sticky>true</sticky>
+            <sticky>false</sticky>
         </settings>
         <bookmark name="bookmarks"/>
         <filterSearch name="words"/>

--- a/AdobeStockImageAdminUi/view/adminhtml/ui_component/adobe_stock_images_listing.xml
+++ b/AdobeStockImageAdminUi/view/adminhtml/ui_component/adobe_stock_images_listing.xml
@@ -34,9 +34,6 @@
         </dataProvider>
     </dataSource>
     <listingToolbar name="listing_top" template="Magento_AdobeStockImageAdminUi/grid/toolbar">
-        <settings>
-            <sticky>false</sticky>
-        </settings>
         <bookmark name="bookmarks"/>
         <filterSearch name="words"/>
         <paging name="listing_paging">


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR will fix the duplicated id issue with admin grid toolbar. Currently, we are not using the sticky toolbar so we decided to remove from the grid
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/adobe-stock-integration#862: "Found 2 elements with non-unique id" warning in browser console on Adobe Stock grid

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Login to admin panel
2. Navigate to Cms Pages
3. User clicks Add New Page button
4. Expand "Content" section
5. User clicks "Insert Image..." button
6. Click "Search Adobe Stock" button to open images grid

### Expected result
No warning messages, all id's should be unique