### PR TITLE
Fix PHPStan errors: return exception instead of throwing it in "handleException" method

### DIFF
--- a/AdobeStockClient/Model/ConnectionWrapper.php
+++ b/AdobeStockClient/Model/ConnectionWrapper.php
@@ -129,24 +129,22 @@ class ConnectionWrapper
      *
      * @param \Exception $exception
      * @param string $message
-     * @throws AuthenticationException
-     * @throws AuthorizationException
-     * @throws IntegrationException
+     * @return AuthenticationException | AuthorizationException | IntegrationException
      */
-    private function handleException(\Exception $exception, string $message): void
+    private function handleException(\Exception $exception, string $message): \Exception
     {
         if (strpos($exception->getMessage(), 'Api Key is invalid') !== false) {
-            throw new AuthenticationException(__('Adobe API Key is invalid!'));
+            return new AuthenticationException(__('Adobe API Key is invalid!'));
         }
         if (strpos($exception->getMessage(), 'Oauth token is not valid') !== false) {
             $this->flushUserTokens->execute();
-            throw new AuthorizationException(__('Adobe API login has expired!'));
+            return new AuthorizationException(__('Adobe API login has expired!'));
         }
         $phrase = __(
             $message . ': %error_message',
             ['error_message' => $exception->getMessage()]
         );
-        throw new IntegrationException($phrase, $exception, $exception->getCode());
+        return new IntegrationException($phrase, $exception, $exception->getCode());
     }
 
     /**
@@ -190,7 +188,7 @@ class ConnectionWrapper
         try {
             $this->getConnection()->searchFilesInitialize($request);
         } catch (\Exception $exception) {
-            $this->handleException($exception, 'Failed to initialize Adobe Stock search files request');
+            throw $this->handleException($exception, 'Failed to initialize Adobe Stock search files request');
         }
         return $this;
     }
@@ -208,7 +206,7 @@ class ConnectionWrapper
         try {
             return $this->getConnection()->getNextResponse();
         } catch (\Exception $exception) {
-            $this->handleException($exception, 'Failed to retrieve Adobe Stock search files results');
+            throw $this->handleException($exception, 'Failed to retrieve Adobe Stock search files results');
         }
     }
 
@@ -226,7 +224,7 @@ class ConnectionWrapper
         try {
             return $this->getConnection()->getMemberProfile($request, $this->getAccessToken());
         } catch (\Exception $exception) {
-            $this->handleException($exception, 'Failed to retrieve Adobe Stock member profile');
+            throw $this->handleException($exception, 'Failed to retrieve Adobe Stock member profile');
         }
     }
 
@@ -244,7 +242,7 @@ class ConnectionWrapper
         try {
             return $this->getConnection()->getContentLicense($request, $this->getAccessToken());
         } catch (\Exception $exception) {
-            $this->handleException($exception, 'Failed to retrieve Adobe Stock content license');
+            throw $this->handleException($exception, 'Failed to retrieve Adobe Stock content license');
         }
     }
 
@@ -262,7 +260,7 @@ class ConnectionWrapper
         try {
             return $this->getConnection()->downloadAssetUrl($request, $this->getAccessToken());
         } catch (\Exception $exception) {
-            $this->handleException($exception, 'Failed to retrieve Adobe Stock asset download URL');
+            throw $this->handleException($exception, 'Failed to retrieve Adobe Stock asset download URL');
         }
     }
 }


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
This merge request fixes current PHPStan errors without changing logic.
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->