### PR TITLE
The Uploaded Date filter doesn't find any records if From and To date are set as Today's date

### DIFF
--- a/MediaGalleryUi/view/adminhtml/ui_component/media_gallery_listing.xml
+++ b/MediaGalleryUi/view/adminhtml/ui_component/media_gallery_listing.xml
@@ -45,7 +45,7 @@
                 </settings>
             </filterSelect>
             <filterRange name="created_at"
-                         class="Magento\Ui\Component\Filters\Type\DateRange"
+                         class="Magento\Ui\Component\Filters\Type\Date"
                          provider="${ $.parentName }"
                          template="ui/grid/filters/elements/group" sortOrder="20">
                 <settings>
@@ -55,7 +55,7 @@
                 </settings>
             </filterRange>
             <filterRange name="updated_at"
-                         class="Magento\Ui\Component\Filters\Type\DateRange"
+                         class="Magento\Ui\Component\Filters\Type\Date"
                          provider="${ $.parentName }"
                          template="ui/grid/filters/elements/group" sortOrder="30">
                 <settings>


### PR DESCRIPTION


<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
The Uploaded Date filter doesn't find any records if From and To date are set as Today's date

### Fixed Issues (if relevant)

1. magento/adobe-stock-integration#882: The Uploaded Date filter doesn't find any records if From and To date are set as Today's date
2. magento/adobe-stock-integration#883 The "Uploaded date" and "Modification date" filters do not find images uploaded or modified in the past (Media Gallery)
3. magento/adobe-stock-integration#881 500 (Internal server error) appears in Developer Console if try to apply not valid data in date field (Media Gallery, Uploaded Date or Modification Date filters) 

### Manual testing scenarios (*)

1.  Go to Media Gallery Development, click Filters
2.  Set Uploaded Date filter from - Go Today
3.  Set Uploaded Date filter to - Go Today
4.  Click Apply Filters

The Image, that was uploaded today is shown in the grid