### PR TITLE
Fixed failing localized image preview keyword assertion

### DIFF
--- a/AdobeStockImageAdminUi/Test/Mftf/ActionGroup/AssertAdminAdobeStockImageKeywordActionGroup.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/ActionGroup/AssertAdminAdobeStockImageKeywordActionGroup.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="AssertAdminAdobeStockImageKeywordActionGroup">
+        <arguments>
+            <argument name="keyword" type="string"/>
+        </arguments>
+        <seeElement selector="{{AdobeStockImagePreviewSection.keyword(keyword)}}" stepKey="seeKeyword"/>
+    </actionGroup>
+</actionGroups>

--- a/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockLocalizationTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockLocalizationTest.xml
@@ -41,8 +41,12 @@
             <argument name="query" value="Автомобили"/>
         </actionGroup>
         <actionGroup ref="AdminAdobeStockExpandImagePreviewActionGroup" stepKey="expandImagePreview"/>
-        <!-- TODO: the following assertion/requirement on the specific keyword we expect wont work as we have no guarantee on the exact keyword to use as the image could be random -->
-        <seeElement selector="{{AdobeStockImagePreviewSection.keyword('Авто')}}" stepKey="assertAttributeLocalized"/>
-        <seeElement selector="{{AdobeStockImagePreviewSection.attributeTitle('Транспорт')}}" stepKey="assertCategoryLocalized"/>
+        <!-- The following assertion/requirement on the specific keyword we expect may not be stable as we have no guarantee on the exact keyword to use as the image could be random -->
+        <actionGroup ref="AssertAdminAdobeStockImageKeywordActionGroup" stepKey="assertKeywordLocalized">
+            <argument name="keyword" value="машина"/>
+        </actionGroup>
+        <actionGroup ref="AssertVisibleImagePreviewAttributesActionGroup" stepKey="assertCategoryLocalized">
+            <argument name="attributeName" value="Транспорт"/>
+        </actionGroup>
     </test>
 </tests>


### PR DESCRIPTION
### Description (*)
This PR introduces a fix for failing keyword localization MFTF test. It also refactors the test body in order to meet the best MFTF development practices.

### Fixed Issues (if relevant)
1. #685 : AdminAdobeStockLocalizationTest fails consistently

### Manual testing scenarios (*)
1. Run `vendor/bin/mftf run:test AdminAdobeStockLocalizationTest --remove`.
2. Go and make some tea.
3. The test should pass successfully.