### PR TITLE
Added license status filter to Media Gallery

### DIFF
--- a/AdobeStockImage/Ui/Options/Licensed.php
+++ b/AdobeStockImage/Ui/Options/Licensed.php
@@ -9,6 +9,9 @@ namespace Magento\AdobeStockImage\Ui\Options;
 
 use Magento\Framework\Data\OptionSourceInterface;
 
+/**
+ * Licensed status filter options
+ */
 class Licensed implements OptionSourceInterface
 {
     /**

--- a/AdobeStockImage/Ui/Options/Licensed.php
+++ b/AdobeStockImage/Ui/Options/Licensed.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\AdobeStockImage\Ui\Options;
+
+use Magento\Framework\Data\OptionSourceInterface;
+
+class Licensed implements OptionSourceInterface
+{
+    /**
+     * @inheritdoc
+     */
+    public function toOptionArray(): array
+    {
+        return [
+            [
+                'value' => '1',
+                'label' => 'Licensed'
+            ],
+            [
+                'value' => '0',
+                'label' => 'Unlicensed'
+            ]
+        ];
+    }
+}

--- a/AdobeStockImage/view/adminhtml/ui_component/media_gallery_listing.xml
+++ b/AdobeStockImage/view/adminhtml/ui_component/media_gallery_listing.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<listing xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Ui:etc/ui_configuration.xsd">
+    <listingToolbar name="listing_top">
+        <filters name="listing_filters">
+            <filterSelect name="licensed" provider="${ $.parentName }" sortOrder="50">
+                <settings>
+                    <caption translate="true">All</caption>
+                    <options class="Magento\AdobeStockImage\Ui\Options\Licensed"/>
+                    <label translate="true">License Status</label>
+                    <dataScope>licensed</dataScope>
+                </settings>
+            </filterSelect>
+        </filters>
+    </listingToolbar>
+</listing>


### PR DESCRIPTION
### Description 

Added a License Status filter to the Media Gallery

### Fixed Issues
magento/adobe-stock-integration#901: Add license status filter

### Manual testing scenarios
1. Have licensed and unlicensed Adobe Stock images in your instance
1. Open Media Gallery -> Filters
2. Verify 'License Status' filter works as expected