### PR TITLE
Remove redundant field key from IMS UserRepository::get method

### DIFF
--- a/AdobeIms/Model/UserProfileRepository.php
+++ b/AdobeIms/Model/UserProfileRepository.php
@@ -21,7 +21,6 @@ use Psr\Log\LoggerInterface;
  */
 class UserProfileRepository implements UserProfileRepositoryInterface
 {
-    private const ID = 'id';
     private const ADMIN_USER_ID = 'admin_user_id';
 
     /**
@@ -89,7 +88,7 @@ class UserProfileRepository implements UserProfileRepositoryInterface
         }
 
         $entity = $this->entityFactory->create();
-        $this->resource->load($entity, $entityId, self::ID);
+        $this->resource->load($entity, $entityId);
         if (!$entity->getId()) {
             $message = __('User profile with id %id not found.', ['id' => $entityId]);
             throw new NoSuchEntityException($message);


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
Removed redundant field key from IMS UserRepository::get method
It's set in the resource model and taken automatically.

The current implementation to change the DB ID key will require making a change in both the resource model and repository, which could be considered as a bug or hardcode.
