### PR TITLE
Handle DB Storage and thumbnails when deleting a preview image

### DIFF
--- a/AdobeStockImage/Model/Storage/Delete.php
+++ b/AdobeStockImage/Model/Storage/Delete.php
@@ -9,9 +9,7 @@ declare(strict_types=1);
 namespace Magento\AdobeStockImage\Model\Storage;
 
 use Magento\Cms\Model\Wysiwyg\Images\Storage;
-use Magento\Framework\App\Filesystem\DirectoryList;
 use Magento\Framework\Exception\CouldNotDeleteException;
-use Magento\Framework\Filesystem;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -19,11 +17,6 @@ use Psr\Log\LoggerInterface;
  */
 class Delete
 {
-    /**
-     * @var Filesystem
-     */
-    private $filesystem;
-
     /**
      * @var LoggerInterface
      */
@@ -37,16 +30,13 @@ class Delete
     /**
      * Constructor
      *
-     * @param Filesystem $filesystem
      * @param LoggerInterface $logger
      * @param Storage $storage
      */
     public function __construct(
-        Filesystem $filesystem,
         LoggerInterface $logger,
         Storage $storage
     ) {
-        $this->filesystem = $filesystem;
         $this->logger = $logger;
         $this->storage = $storage;
     }
@@ -60,10 +50,7 @@ class Delete
     public function execute(string $path): void
     {
         try {
-            $mediaDirectory = $this->filesystem->getDirectoryWrite(DirectoryList::MEDIA);
-            if ($mediaDirectory->isFile($path)) {
-                $this->storage->deleteFile($mediaDirectory->getAbsolutePath($path));
-            }
+            $this->storage->deleteFile($this->storage->getCmsWysiwygImages()->getStorageRoot() . $path);
         } catch (\Exception $exception) {
             $this->logger->critical($exception);
             $message = __('Failed to delete the image: %error', ['error' => $exception->getMessage()]);

--- a/AdobeStockImage/Model/Storage/Delete.php
+++ b/AdobeStockImage/Model/Storage/Delete.php
@@ -35,9 +35,11 @@ class Delete
     private $storage;
 
     /**
-     * Storage constructor.
+     * Constructor
+     *
      * @param Filesystem $filesystem
      * @param LoggerInterface $logger
+     * @param Storage $storage
      */
     public function __construct(
         Filesystem $filesystem,

--- a/AdobeStockImage/Model/Storage/Delete.php
+++ b/AdobeStockImage/Model/Storage/Delete.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace Magento\AdobeStockImage\Model\Storage;
 
+use Magento\Cms\Model\Wysiwyg\Images\Storage;
 use Magento\Framework\App\Filesystem\DirectoryList;
 use Magento\Framework\Exception\CouldNotDeleteException;
 use Magento\Framework\Filesystem;
@@ -29,16 +30,23 @@ class Delete
     private $logger;
 
     /**
+     * @var Storage
+     */
+    private $storage;
+
+    /**
      * Storage constructor.
      * @param Filesystem $filesystem
      * @param LoggerInterface $logger
      */
     public function __construct(
         Filesystem $filesystem,
-        LoggerInterface $logger
+        LoggerInterface $logger,
+        Storage $storage
     ) {
         $this->filesystem = $filesystem;
         $this->logger = $logger;
+        $this->storage = $storage;
     }
 
     /**
@@ -52,7 +60,7 @@ class Delete
         try {
             $mediaDirectory = $this->filesystem->getDirectoryWrite(DirectoryList::MEDIA);
             if ($mediaDirectory->isFile($path)) {
-                $mediaDirectory->delete($path);
+                $this->storage->deleteFile($mediaDirectory->getAbsolutePath($path));
             }
         } catch (\Exception $exception) {
             $this->logger->critical($exception);

--- a/AdobeStockImage/Test/Unit/Model/Storage/DeleteTest.php
+++ b/AdobeStockImage/Test/Unit/Model/Storage/DeleteTest.php
@@ -8,6 +8,8 @@ declare(strict_types=1);
 namespace Magento\AdobeStockImage\Test\Unit\Model\Storage;
 
 use Exception;
+use Magento\AdobeStockImage\Model\Storage\Delete;
+use Magento\Cms\Model\Wysiwyg\Images\Storage;
 use Magento\Framework\App\Filesystem\DirectoryList;
 use Magento\Framework\Exception\CouldNotDeleteException;
 use Magento\Framework\Filesystem;
@@ -15,7 +17,6 @@ use Magento\Framework\Filesystem\Directory\Write;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Magento\AdobeStockImage\Model\Storage\Delete;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -24,7 +25,7 @@ use Psr\Log\LoggerInterface;
 class DeleteTest extends TestCase
 {
     /**
-     * @var MockObject | Write
+     * @var MockObject|Write
      */
     private $mediaDirectoryMock;
 
@@ -34,12 +35,17 @@ class DeleteTest extends TestCase
     private $delete;
 
     /**
-     * @var MockObject | Filesystem
+     * @var MockObject|Filesystem
      */
-    public $fileSystemMock;
+    private $fileSystemMock;
 
     /**
-     * @var MockObject | LoggerInterface
+     * @var MockObject|Storage
+     */
+    private $storageMock;
+
+    /**
+     * @var MockObject|LoggerInterface
      */
     private $logger;
 
@@ -51,68 +57,99 @@ class DeleteTest extends TestCase
         $this->fileSystemMock = $this->createMock(Filesystem::class);
         $this->logger = $this->createMock(LoggerInterface::class);
         $this->mediaDirectoryMock = $this->createMock(Write::class);
+        $this->storageMock = $this->createMock(Storage::class);
 
         $this->delete = (new ObjectManager($this))->getObject(
             Delete::class,
             [
-                'filesystem'   => $this->fileSystemMock,
-                'logger'          => $this->logger,
+                'filesystem' => $this->fileSystemMock,
+                'logger' => $this->logger,
+                'storage' => $this->storageMock
             ]
         );
     }
 
     /**
      * Test storage delete action
+     *
+     * @param string $path
+     * @param string $absolutePath
+     * @dataProvider getPathDataProvider
+     * @return void
      */
-    public function testExecute(): void
+    public function testExecute(string $path, string $absolutePath): void
     {
         $path = 'path';
+        $absolutePath = '/home/instance/path';
 
         $this->fileSystemMock->expects($this->once())
             ->method('getDirectoryWrite')
             ->with(DirectoryList::MEDIA)
             ->willReturn($this->mediaDirectoryMock);
-
         $this->mediaDirectoryMock->expects($this->once())
             ->method('isFile')
             ->with($path)
             ->willReturn(true);
-
         $this->mediaDirectoryMock->expects($this->once())
-            ->method('delete')
+            ->method('getAbsolutePath')
             ->with($path)
+            ->willReturn($absolutePath);
+        $this->storageMock->expects($this->once())
+            ->method('deleteFile')
+            ->with($absolutePath)
             ->willReturn(true);
 
         $this->delete->execute($path);
     }
 
     /**
-     * Assume that delete action will thrown an Exception
+     * Assume that delete action wilyyl thrown an Exception
+     *
+     * @dataProvider getPathDataProvider
+     * @param string $path
+     * @param string $absolutePath
+     * @return void
      */
-    public function testExceptionOnDeleteExecution(): void
+    public function testExceptionOnDeleteExecution(string $path, string $absolutePath): void
     {
-        $path = 'path';
-
         $this->fileSystemMock->expects($this->once())
             ->method('getDirectoryWrite')
             ->with(DirectoryList::MEDIA)
             ->willReturn($this->mediaDirectoryMock);
-
         $this->mediaDirectoryMock->expects($this->once())
             ->method('isFile')
             ->with($path)
             ->willReturn(true);
-
         $this->mediaDirectoryMock->expects($this->once())
-            ->method('delete')
+            ->method('getAbsolutePath')
             ->with($path)
+            ->willReturn($absolutePath);
+        $this->storageMock->expects($this->once())
+            ->method('deleteFile')
+            ->with($absolutePath)
             ->willThrowException(new Exception());
 
         $this->expectException(CouldNotDeleteException::class);
+
         $this->logger->expects($this->once())
             ->method('critical')
             ->willReturnSelf();
 
         $this->delete->execute($path);
+    }
+
+    /**
+     * Path data provider for tests
+     *
+     * @return array
+     */
+    public function getPathDataProvider(): array
+    {
+        return [
+            [
+                'path',
+                '/home/instance/path'
+            ]
+        ];
     }
 }

--- a/AdobeStockImage/composer.json
+++ b/AdobeStockImage/composer.json
@@ -9,7 +9,8 @@
         "magento/module-adobe-stock-image-api": "*",
         "magento/module-media-gallery-api": "*",
         "magento/module-media-gallery-ui-api": "*",
-        "magento/module-media-gallery-ui": "*"
+        "magento/module-media-gallery-ui": "*",
+        "magento/module-cms": "*"
     },
     "suggest": {
         "magento/module-catalog": "*"


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
Database storage and thumbnails are not handled when deleting a preview image

### Fixed Issues (if relevant)

1. magento/adobe-stock-integration#903: Handle DB STorage ant thumbnails when deleting a preview image

### Manual testing scenarios (*)

1. Login to Admin panel
2. Open Media Gallery (i.e. Catalog -> Category -> expand Content -> Select from Gallery button)
3. Click "Search Adobe Stock"
4. Save preview of one of the images
5. License the same image
