### PR TITLE
Added ru_RU locale deployment command for functional tests

### DIFF
--- a/dev/travis/before_script.sh
+++ b/dev/travis/before_script.sh
@@ -41,6 +41,8 @@ if [[ ${TEST_SUITE} = "functional" ]]; then
         --admin-password="${MAGENTO_ADMIN_PASSWORD}"
     echo "Enabling production mode"
     php bin/magento deploy:mode:set production
+    # deploy ru_RU locale for localization tests
+    php bin/magento setup:static-content:deploy ru_RU
     # prepare magento instance as per getting started docs
     # https://devdocs.magento.com/mftf/docs/getting-started.html#prepare-magento
     echo "Preparing magento instance for MFTF usage"


### PR DESCRIPTION
### Description (*)
This PR adds an additional command to Travis build for ru_RU locale deployment. This locale is required for performing some of the localization functional tests

### Fixed Issues (if relevant)
1. #754 : MFTF Locale Test (AdminAdobeStockLocalizationTestCest) errors out, failing Grid suite on Travis

### Manual testing scenarios (*)
1. Run the grid test suite `vendor/bin/mftf run:group adobe_stock_integration_suite_grid --remove -vvv`
2. Go and make some tea
3. All tests should be green