### PR TITLE
Added observer to role update and updated/created unit tests

### DIFF
--- a/AdobeIms/Model/FlushUserTokens.php
+++ b/AdobeIms/Model/FlushUserTokens.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 
 namespace Magento\AdobeIms\Model;
 
+use Magento\AdobeImsApi\Api\Data\UserProfileInterface;
 use Magento\AdobeImsApi\Api\FlushUserTokensInterface;
 use Magento\AdobeImsApi\Api\UserProfileRepositoryInterface;
 use Magento\Authorization\Model\UserContextInterface;
@@ -48,11 +49,24 @@ class FlushUserTokens implements FlushUserTokensInterface
         try {
             $adminUserId = $adminUserId ?? (int) $this->userContext->getUserId();
             $userProfile = $this->userProfileRepository->getByUserId($adminUserId);
-            $userProfile->setAccessToken('');
-            $userProfile->setRefreshToken('');
-            $this->userProfileRepository->save($userProfile);
+            if (!$this->isTokenDataEmpty($userProfile)) {
+                $userProfile->setAccessToken('');
+                $userProfile->setRefreshToken('');
+                $this->userProfileRepository->save($userProfile);
+            }
         } catch (\Exception $e) { //phpcs:ignore Magento2.CodeAnalysis.EmptyBlock.DetectedCatch
             // User profile and tokens are not present in the system
         }
+    }
+
+    /**
+     * Checks if the tokens are empty
+     *
+     * @param UserProfileInterface $userProfile
+     * @return bool
+     */
+    private function isTokenDataEmpty(UserProfileInterface $userProfile) : bool
+    {
+        return empty($userProfile->getRefreshToken()) && empty($userProfile->getAccessToken());
     }
 }

--- a/AdobeIms/Observer/FlushUsersTokensObserver.php
+++ b/AdobeIms/Observer/FlushUsersTokensObserver.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\AdobeIms\Observer;
+
+use Magento\AdobeIms\Controller\Adminhtml\User\Logout;
+use Magento\AdobeIms\Model\FlushUserTokens;
+use Magento\Authorization\Model\Role;
+use Magento\Framework\App\RequestInterface;
+use Magento\Framework\Event\ObserverInterface;
+
+/**
+ * Observer to flush admin user token when user's role been changed.
+ */
+class FlushUsersTokensObserver implements ObserverInterface
+{
+    /**
+     * @var FlushUserTokens
+     */
+    private $flushUserTokens;
+
+    /**
+     * FlushUsersTokensObserver constructor.
+     * @param FlushUserTokens $flushUserTokens
+     */
+    public function __construct(
+        FlushUserTokens $flushUserTokens
+    ) {
+        $this->flushUserTokens = $flushUserTokens;
+    }
+
+    /**
+     * Flushes admin user tokens
+     *
+     * @param \Magento\Framework\Event\Observer $observer
+     */
+    public function execute(\Magento\Framework\Event\Observer $observer): void
+    {
+        /** @var RequestInterface $request */
+        $request = $observer->getDataByKey('request');
+        $resources = $request->getParam('resource', false);
+        if (is_array($resources) && !$this->roleHasImsLogoutResource($resources)) {
+            /** @var Role $role */
+            $role = $observer->getDataByKey('object');
+            $users = $role->getRoleUsers();
+            foreach ($users as $userId) {
+                $this->flushUserTokens->execute((int) $userId);
+            }
+        }
+    }
+
+    /**
+     * Checks if the role has IMS Logout resource
+     *
+     * @param array $resources
+     * @return bool
+     */
+    private function roleHasImsLogoutResource(array $resources): bool
+    {
+        return in_array(Logout::ADMIN_RESOURCE, $resources);
+    }
+}

--- a/AdobeIms/Test/Unit/Model/FlushUserTokensTest.php
+++ b/AdobeIms/Test/Unit/Model/FlushUserTokensTest.php
@@ -56,13 +56,35 @@ class FlushUserTokensTest extends TestCase
     {
         $this->userContext->expects($this->once())->method('getUserId')->willReturn(1);
         $userProfileMock = $this->createMock(UserProfileInterface::class);
+        $userProfileMock->method('getAccessToken')->willReturn('access-token');
+        $userProfileMock->method('getRefreshToken')->willReturn('request-token');
+        $this->userProfileRepository->expects($this->exactly(1))
+            ->method('getByUserId')
+            ->willReturn($userProfileMock);
+        $userProfileMock->expects($this->once())->method('setAccessToken')->willReturnSelf();
+        $userProfileMock->expects($this->once())->method('setRefreshToken')->willReturnSelf();
+        $this->userProfileRepository->expects($this->once())->method('save')
+            ->with($userProfileMock)->willReturnSelf();
+        $this->flushTokens->execute();
+    }
+
+    /**
+     * Test execute with empty tokens
+     */
+    public function testExecuteEmptyTokens(): void
+    {
+        $this->userContext->expects($this->once())->method('getUserId')->willReturn(1);
+        $userProfileMock = $this->createMock(UserProfileInterface::class);
+        $userProfileMock->method('getAccessToken')->willReturn('');
+        $userProfileMock->method('getRefreshToken')->willReturn('');
         $this->userProfileRepository->expects($this->exactly(1))
             ->method('getByUserId')
             ->willReturn($userProfileMock);
 
-        $userProfileMock->expects($this->once())->method('setAccessToken')->willReturnSelf();
-        $userProfileMock->expects($this->once())->method('setRefreshToken')->willReturnSelf();
-        $this->userProfileRepository->expects($this->once())->method('save')->with($userProfileMock)->willReturnSelf();
+        $userProfileMock->expects($this->never())->method('setAccessToken')->willReturnSelf();
+        $userProfileMock->expects($this->never())->method('setRefreshToken')->willReturnSelf();
+        $this->userProfileRepository->expects($this->never())->method('save')
+            ->with($userProfileMock)->willReturnSelf();
         $this->flushTokens->execute();
     }
 }

--- a/AdobeIms/Test/Unit/Observer/FlushUsersTokensObserverTest.php
+++ b/AdobeIms/Test/Unit/Observer/FlushUsersTokensObserverTest.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\AdobeIms\Test\Unit\Observer;
+
+use Magento\Authorization\Model\Role;
+use Magento\Framework\App\RequestInterface;
+
+/**
+ * Flush users tokens observer tests
+ */
+class FlushUsersTokensObserverTest extends \PHPUnit\Framework\TestCase
+{
+    /** @var \Magento\AdobeIms\Model\FlushUserTokens|\PHPUnit_Framework_MockObject_MockObject */
+    protected $flushUserTokens;
+
+    /** @var \Magento\AdobeIms\Observer\FlushUsersTokensObserver */
+    protected $model;
+
+    protected function setUp()
+    {
+        $this->flushUserTokens = $this->createMock(\Magento\AdobeIms\Model\FlushUserTokens::class);
+        $helper = new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($this);
+        $this->model = $helper->getObject(
+            \Magento\AdobeIms\Observer\FlushUsersTokensObserver::class,
+            [
+                'flushUserTokens' => $this->flushUserTokens
+            ]
+        );
+    }
+
+    /**
+     * Test flush tokens observer
+     */
+    public function testFlushUsersTokensObserver()
+    {
+        /** @var \Magento\Framework\Event\Observer|\PHPUnit_Framework_MockObject_MockObject $eventObserverMock */
+        $eventObserverMock = $this->createMock(\Magento\Framework\Event\Observer::class);
+        $requestMock = $this->createMock(RequestInterface::class);
+        $requestMock->expects($this->once())->method("getParam")->willReturn(["Magento_AnyModule::anything"]);
+        $roleMock = $this->createMock(Role::class);
+        $roleMock->expects($this->once())->method("getRoleUsers")->willReturn([1,2,3]);
+        $eventObserverMock->expects($this->exactly(2))->method("getDataByKey")
+            ->will($this->returnValueMap([["request", $requestMock],["object", $roleMock]]));
+        $this->flushUserTokens->expects($this->exactly(3))->method("execute")->willReturnSelf();
+        $this->model->execute($eventObserverMock);
+    }
+}

--- a/AdobeIms/Test/Unit/Observer/FlushUsersTokensObserverTest.php
+++ b/AdobeIms/Test/Unit/Observer/FlushUsersTokensObserverTest.php
@@ -3,6 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
 namespace Magento\AdobeIms\Test\Unit\Observer;
 

--- a/AdobeIms/etc/adminhtml/events.xml
+++ b/AdobeIms/etc/adminhtml/events.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Event/etc/events.xsd">
+    <event name="admin_permissions_role_prepare_save">
+        <observer name="flushUsersTokensObserver" instance="Magento\AdobeIms\Observer\FlushUsersTokensObserver" />
+    </event>
+</config>


### PR DESCRIPTION
### Description (*)
Created an observer to flush the Access and Refresh tokens from the DB when an updated Role had Magento_AdobeIms::logout removed from the resources list.

Also updated the FlushUserTokens class to just flush the tokens when the tokens aren't empty, to avoid unnecessary savings.

Updated and created unit tests for the changes mentioned above.

### Fixed Issues (if relevant)
1. magento/adobe-stock-integration#864: User is not Signed Out from IMS after the User Role was changed

### Manual testing scenarios (*)
Follow the steps described here: https://github.com/magento/adobe-stock-integration/issues/864