### PR TITLE
Search Adobe Stock button added

### DIFF
--- a/AdobeStockImageAdminUi/view/adminhtml/layout/media_gallery_index_index.xml
+++ b/AdobeStockImageAdminUi/view/adminhtml/layout/media_gallery_index_index.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<layout xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/layout_generic.xsd">
+    <referenceContainer name="root">
+        <block class="Magento\Backend\Block\Template" name="stock.panel" template="Magento_AdobeStockImageAdminUi::panel.phtml" aclResource="Magento_AdobeStockImageAdminUi::save_preview_images">
+            <block class="Magento\AdobeIms\Block\Adminhtml\SignIn" name="adobe.signIn" template="Magento_AdobeIms::signIn.phtml" aclResource="Magento_AdobeStockImageAdminUi::save_preview_images">
+                <arguments>
+                    <argument name="configProviders" xsi:type="array">
+                        <item name="adobe-stock" xsi:type="object">Magento\AdobeStockImageAdminUi\Model\SignInConfigProvider</item>
+                    </argument>
+                </arguments>
+            </block>
+            <uiComponent name="adobe_stock_images_listing"/>
+        </block>
+    </referenceContainer>
+</layout>

--- a/AdobeStockImageAdminUi/view/adminhtml/ui_component/media_gallery_listing.xml
+++ b/AdobeStockImageAdminUi/view/adminhtml/ui_component/media_gallery_listing.xml
@@ -7,6 +7,15 @@
 -->
 <listing xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Ui:etc/ui_configuration.xsd">
+    <settings>
+        <buttons>
+            <button name="search_adobe_stock">
+                <param name="on_click" xsi:type="string">jQuery(".adobe-search-images-modal").trigger("openModal");</param>
+                <class>action-secondary</class>
+                <label translate="true">Search Adobe Stock</label>
+            </button>
+        </buttons>
+    </settings>
     <listingToolbar name="listing_top">
         <filters name="listing_filters">
             <filterSelect name="licensed" provider="${ $.parentName }" sortOrder="50">

--- a/MediaGalleryUi/view/adminhtml/ui_component/media_gallery_listing.xml
+++ b/MediaGalleryUi/view/adminhtml/ui_component/media_gallery_listing.xml
@@ -15,11 +15,6 @@
     </argument>
     <settings>
         <buttons>
-            <button name="search_adobe_stock">
-                <param name="on_click" xsi:type="string">jQuery(".adobe-search-images-modal").trigger("openModal");</param>
-                <class>action-default primary add</class>
-                <label translate="true">Search Adobe Stock</label>
-            </button>
             <button name="cancel">
                 <param name="on_click" xsi:type="string">MediabrowserUtility.closeDialog();</param>
                 <class>cancel action-quaternary</class>

--- a/MediaGalleryUi/view/adminhtml/ui_component/media_gallery_listing.xml
+++ b/MediaGalleryUi/view/adminhtml/ui_component/media_gallery_listing.xml
@@ -15,6 +15,11 @@
     </argument>
     <settings>
         <buttons>
+            <button name="search_adobe_stock">
+                <param name="on_click" xsi:type="string">jQuery(".adobe-search-images-modal").trigger("openModal");</param>
+                <class>action-default primary add</class>
+                <label translate="true">Search Adobe Stock</label>
+            </button>
             <button name="cancel">
                 <param name="on_click" xsi:type="string">MediabrowserUtility.closeDialog();</param>
                 <class>cancel action-quaternary</class>


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR will introduce the search adobe stock button in enhanced media gallery grid
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/adobe-stock-integration#907: Add "Search Adobe Stock" button to the Media Gallery

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Login to Admin panel
2. Open Media Gallery (i.e. Catalog -> Category -> expand Content -> Select from Gallery button)

### Expected Result
![image](https://user-images.githubusercontent.com/39480008/74417526-dc704080-4e6c-11ea-90b1-2cd75b13bbed.png)
