### PR TITLE
[TRACK] 1.0.1 release scope

### DIFF
--- a/AdobeIms/composer.json
+++ b/AdobeIms/composer.json
@@ -22,5 +22,6 @@
         "psr-4": {
             "Magento\\AdobeIms\\": ""
         }
-    }
+    },
+    "version": "1.0.0"
 }

--- a/AdobeIms/composer.json
+++ b/AdobeIms/composer.json
@@ -3,12 +3,12 @@
     "description": "Magento module responsible for authentication to Adobe services",
     "require": {
         "php": "~7.1.3||~7.2.0||~7.3.0",
-        "magento/framework": "*",
-        "magento/module-adobe-ims-api": "*",
-        "magento/module-authorization": "*",
-        "magento/module-backend": "*",
-        "magento/module-config": "*",
-        "magento/module-user": "*"
+        "magento/framework": "~102.0.4",
+        "magento/module-adobe-ims-api": "1.*.*",
+        "magento/module-authorization": "~100.3.4",
+        "magento/module-backend": "~101.0.4",
+        "magento/module-config": "~101.1.4",
+        "magento/module-user": "~101.1.4"
     },
     "type": "magento2-module",
     "license": [

--- a/AdobeImsApi/composer.json
+++ b/AdobeImsApi/composer.json
@@ -3,7 +3,7 @@
     "description": "Implementation of Magento module responsible for authentication to Adobe services",
     "require": {
         "php": "~7.1.3||~7.2.0||~7.3.0",
-        "magento/framework": "*"
+        "magento/framework": "~102.0.4"
     },
     "type": "magento2-module",
     "license": [

--- a/AdobeImsApi/composer.json
+++ b/AdobeImsApi/composer.json
@@ -17,5 +17,6 @@
         "psr-4": {
             "Magento\\AdobeImsApi\\": ""
         }
-    }
+    },
+    "version": "1.0.0"
 }

--- a/AdobeStockAdminUi/composer.json
+++ b/AdobeStockAdminUi/composer.json
@@ -24,5 +24,6 @@
         "psr-4": {
             "Magento\\AdobeStockAdminUi\\": ""
         }
-    }
+    },
+    "version": "1.0.0"
 }

--- a/AdobeStockAdminUi/composer.json
+++ b/AdobeStockAdminUi/composer.json
@@ -3,14 +3,14 @@
     "description": "Magento module responsible for the admin panel UI implementation",
     "require": {
         "php": "~7.1.3||~7.2.0||~7.3.0",
-        "magento/framework": "*",
-        "magento/module-adobe-ims-api": "*",
-        "magento/module-adobe-stock-client-api": "*",
-        "magento/module-backend": "*",
-        "magento/module-config": "*"
+        "magento/framework": "~102.0.4",
+        "magento/module-adobe-ims-api": "1.*.*",
+        "magento/module-adobe-stock-client-api": "1.*.*",
+        "magento/module-backend": "~101.0.4",
+        "magento/module-config": "~101.1.4"
     },
     "suggest": {
-        "magento/module-cms": "*"
+        "magento/module-cms": "~103.0.4"
     },
     "type": "magento2-module",
     "license": [

--- a/AdobeStockAsset/composer.json
+++ b/AdobeStockAsset/composer.json
@@ -3,12 +3,12 @@
     "description": "Magento module responsible for the Adobe Stock assets handling implementation on Magento side",
     "require": {
         "php": "~7.1.3||~7.2.0||~7.3.0",
-        "magento/framework": "*",
-        "magento/module-adobe-stock-asset-api": "*",
-        "magento/module-adobe-stock-client-api": "*",
-        "magento/module-media-gallery-api": "*",
-        "magento/module-media-gallery": "*",
-        "magento/module-config": "*"
+        "magento/framework": "~102.0.4",
+        "magento/module-adobe-stock-asset-api": "1.*.*",
+        "magento/module-adobe-stock-client-api": "1.*.*",
+        "magento/module-media-gallery-api": "~100.3.0",
+        "magento/module-media-gallery": "~100.3.0",
+        "magento/module-config": "~101.1.4"
     },
     "type": "magento2-module",
     "license": [
@@ -21,12 +21,6 @@
         ],
         "psr-4": {
             "Magento\\AdobeStockAsset\\": ""
-        }
-    },
-    "repositories": {
-        "stock-api-libphp": {
-            "type": "vcs",
-            "url": "git@github.com:adobe/stock-api-libphp.git"
         }
     },
     "version": "1.0.0"

--- a/AdobeStockAsset/composer.json
+++ b/AdobeStockAsset/composer.json
@@ -28,5 +28,6 @@
             "type": "vcs",
             "url": "git@github.com:adobe/stock-api-libphp.git"
         }
-    }
+    },
+    "version": "1.0.0"
 }

--- a/AdobeStockAssetApi/composer.json
+++ b/AdobeStockAssetApi/composer.json
@@ -17,5 +17,6 @@
         "psr-4": {
             "Magento\\AdobeStockAssetApi\\": ""
         }
-    }
+    },
+    "version": "1.0.0"
 }

--- a/AdobeStockAssetApi/composer.json
+++ b/AdobeStockAssetApi/composer.json
@@ -3,7 +3,7 @@
     "description": "Magento module responsible for Adobe Stock assets handling on Magento side",
     "require": {
         "php": "~7.1.3||~7.2.0||~7.3.0",
-        "magento/framework": "*"
+        "magento/framework": "~102.0.4"
     },
     "type": "magento2-module",
     "license": [

--- a/AdobeStockClient/composer.json
+++ b/AdobeStockClient/composer.json
@@ -26,5 +26,6 @@
             "type": "vcs",
             "url": "git@github.com:adobe/stock-api-libphp.git"
         }
-    }
+    },
+    "version": "1.0.0"
 }

--- a/AdobeStockClient/composer.json
+++ b/AdobeStockClient/composer.json
@@ -3,9 +3,9 @@
     "description": "Magento module responsible for interaction with Adobe Stock API implementation",
     "require": {
         "php": "~7.1.3||~7.2.0||~7.3.0",
-        "magento/framework": "*",
-        "magento/module-adobe-ims-api": "*",
-        "magento/module-adobe-stock-client-api": "*",
+        "magento/framework": "~102.0.4",
+        "magento/module-adobe-ims-api": "1.*.*",
+        "magento/module-adobe-stock-client-api": "1.*.*",
         "astock/stock-api-libphp": "^1.1.2"
     },
     "type": "magento2-module",
@@ -19,12 +19,6 @@
         ],
         "psr-4": {
             "Magento\\AdobeStockClient\\": ""
-        }
-    },
-    "repositories": {
-        "stock-api-libphp": {
-            "type": "vcs",
-            "url": "git@github.com:adobe/stock-api-libphp.git"
         }
     },
     "version": "1.0.0"

--- a/AdobeStockClientApi/composer.json
+++ b/AdobeStockClientApi/composer.json
@@ -17,5 +17,6 @@
         "psr-4": {
             "Magento\\AdobeStockClientApi\\": ""
         }
-    }
+    },
+    "version": "1.0.0"
 }

--- a/AdobeStockClientApi/composer.json
+++ b/AdobeStockClientApi/composer.json
@@ -3,7 +3,7 @@
     "description": "Magento module responsible for interaction with Adobe Stock API",
     "require": {
         "php": "~7.1.3||~7.2.0||~7.3.0",
-        "magento/framework": "*"
+        "magento/framework": "~102.0.4"
     },
     "type": "magento2-module",
     "license": [

--- a/AdobeStockImage/composer.json
+++ b/AdobeStockImage/composer.json
@@ -3,14 +3,14 @@
     "description": "Magento module responsible for the images handling implementation",
     "require": {
         "php": "~7.1.3||~7.2.0||~7.3.0",
-        "magento/framework": "*",
-        "magento/module-adobe-stock-client-api": "*",
-        "magento/module-adobe-stock-asset-api": "*",
-        "magento/module-adobe-stock-image-api": "*",
-        "magento/module-media-gallery-api": "*"
+        "magento/framework": "~102.0.4",
+        "magento/module-adobe-stock-client-api": "1.*.*",
+        "magento/module-adobe-stock-asset-api": "1.*.*",
+        "magento/module-adobe-stock-image-api": "1.*.*",
+        "magento/module-media-gallery-api": "~100.3.0"
     },
     "suggest": {
-        "magento/module-catalog": "*"
+        "magento/module-catalog": "~103.0.4"
     },
     "type": "magento2-module",
     "license": [

--- a/AdobeStockImage/composer.json
+++ b/AdobeStockImage/composer.json
@@ -24,5 +24,6 @@
         "psr-4": {
             "Magento\\AdobeStockImage\\": ""
         }
-    }
+    },
+    "version": "1.0.0"
 }

--- a/AdobeStockImageAdminUi/Test/Mftf/ActionGroup/AdminAdobeStockSaveLicensedActionGroup.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/ActionGroup/AdminAdobeStockSaveLicensedActionGroup.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="AdminAdobeStockSaveLicensedActionGroup">
+        <click selector="{{AdobeStockImagePreviewSection.saveLicensedImage}}" stepKey="clickOnSavePreview"/>
+        <waitForPageLoad stepKey="waitForPageLoad" />
+    </actionGroup>
+</actionGroups>

--- a/AdobeStockImageAdminUi/Test/Mftf/Section/AdobeStockImagePreviewSection.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Section/AdobeStockImagePreviewSection.xml
@@ -12,7 +12,7 @@
         <element name="licenseAndSave" type="button" selector="//button[@class='action-default primary']//span[text()='License and Save']"/>
         <element name="save" type="block" selector="//button[@class='action-secondary']//span[text()='Save Preview']"/>
         <element name="openInMediaGallery" type="block" selector="//button[@class='action-secondary']//span[text()='Open in Media Gallery']"/>
-        <element name="saveLicensedImage" type="button" selector="//div[@class='actions']/descendant::span[text()='Save']"/>
+        <element name="saveLicensedImage" type="button" selector="//button[@class='action-default primary']//span[text()='Save Licensed']"/>
         <element name="image" type="block" selector="//div[@class='masonry-image-preview']//img"/>
         <element name="navigation" type="button" selector="//div[@class='masonry-image-preview']//div[contains(@class, 'action-buttons')]/button[@class='action-{{type}}']" parameterized="true"/>
         <element name="attribute" type="block" selector="//*[@id='adobe-stock-images-search-modal']//div[@data-role='image-attributes-value']//span[text()='{{type}}']/parent::div//div[@class='value']//span" parameterized="true"/>

--- a/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockSaveLicenseWithSavedPreviewTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockSaveLicenseWithSavedPreviewTest.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+    <test name="AdminAdobeStockSaveLicenseWithSavedPreviewTest">
+        <annotations>
+            <features value="AdobeStockImagePanel"/>
+            <stories value="User saves licensed image for previously saved preview"/>
+            <title value="Adobe Stock Previewed Licensed Image Save"/>
+            <description value="User saves previously licensed image with saved preview into Magento Media Gallery"/>
+            <severity value="AVERAGE"/>
+            <group value="adobe_stock_integration_license"/>
+            <group value="adobe_stock_integration"/>
+        </annotations>
+        <before>
+            <actionGroup ref="LoginAsAdmin" stepKey="loginAsAdmin"/>
+            <actionGroup ref="AdminOpenMediaGalleryForPageNoEditorActionGroup" stepKey="openMediaGalleryForPage"/>
+            <actionGroup ref="AdminAdobeStockOpenPanelFromMediaGalleryActionGroup" stepKey="openAdobeStockPanel"/>
+        </before>
+        <after>
+            <actionGroup ref="AdminOpenMediaGalleryForPageNoEditorActionGroup" stepKey="openMediaGalleryForPage"/>
+            <actionGroup ref="AdminAdobeStockOpenPanelFromMediaGalleryActionGroup" stepKey="openAdobeStockPanel"/>
+            <actionGroup ref="AdminAdobeStockUserSignOutActionGroup" stepKey="adobeLogout"/>
+            <actionGroup ref="AdminAdobeStockAssertUserNotLoggedActionGroup" stepKey="assertUserLoggedOut"/>
+            <actionGroup ref="ResetAdminDataGridToDefaultViewActionGroup" stepKey="resetAdminDataGridToDefaultView"/>
+            <actionGroup ref="AdminOpenMediaGalleryForPageNoEditorActionGroup" stepKey="openMediaGalleryToRemoveImage"/>
+            <actionGroup ref="AdminMediaGalleryDeleteImage" stepKey="deleteImage">
+                <argument name="name" value="{{AdobeStockImageData.name}}"/>
+            </actionGroup>
+            <actionGroup ref="logout" stepKey="adminLogout"/>
+        </after>
+
+        <!-- Not logged in user opens an image that is supposed to be licensed -->
+        <actionGroup ref="AdminSearchImagesOnModalActionGroup" stepKey="searchForNotSavedLicensedImage">
+            <argument name="query" value="{{AdobeStockLicensedImage.id}}"/>
+        </actionGroup>
+        <actionGroup ref="AdminAdobeStockExpandImagePreviewActionGroup" stepKey="expandLicensedImageForPreviewSave"/>
+
+        <!-- Not logged in user saves the image preview -->
+        <actionGroup ref="AdminAdobeStockSavePreviewActionGroup" stepKey="openTheSaveImagePreviewPopup"/>
+        <actionGroup ref="AdminSaveAdobeStockImagePreviewActionGroup" stepKey="saveImagePreview"/>
+
+        <!-- User logs into Adobe IMS -->
+        <actionGroup ref="AdminAdobeStockOpenPanelFromMediaGalleryActionGroup" stepKey="openAdobeStockPanel"/>
+        <actionGroup ref="AdminAdobeStockClickSignInActionGroup" stepKey="clickOnSignIn"/>
+        <actionGroup ref="AdminAdobeStockImsPopupSignInFillUserDataActionGroup" stepKey="fillUserCredentials"/>
+        <actionGroup ref="AdminAdobeStockImsPopupClickSignInActionGroup" stepKey="clickSignInImsPopup"/>
+        <actionGroup ref="AdminAdobeStockAssertUserLoggedActionGroup" stepKey="assertUserLoggedIn"/>
+
+        <!-- The logged in user saves licensed image with previously saved preview -->
+        <actionGroup ref="AdminSearchImagesOnModalActionGroup" stepKey="searchForLicensedImageWithSavedPreview">
+            <argument name="query" value="{{AdobeStockLicensedImage.id}}"/>
+        </actionGroup>
+        <actionGroup ref="AdminAdobeStockSaveLicensedActionGroup" stepKey="saveLicensedImage"/>
+
+        <!-- User sees the saved image in media gallery without the name confirmation popup -->
+        <actionGroup ref="AssertAdminImageIsVisibleInMediaGalleryActionGroup" stepKey="seeImageInMediaGallery"/>
+    </test>
+</tests>

--- a/AdobeStockImageAdminUi/composer.json
+++ b/AdobeStockImageAdminUi/composer.json
@@ -28,5 +28,5 @@
             "Magento\\AdobeStockImageAdminUi\\": ""
         }
     },
-    "version": "1.0.0"
+    "version": "1.0.1"
 }

--- a/AdobeStockImageAdminUi/composer.json
+++ b/AdobeStockImageAdminUi/composer.json
@@ -27,5 +27,6 @@
         "psr-4": {
             "Magento\\AdobeStockImageAdminUi\\": ""
         }
-    }
+    },
+    "version": "1.0.1"
 }

--- a/AdobeStockImageAdminUi/composer.json
+++ b/AdobeStockImageAdminUi/composer.json
@@ -3,17 +3,17 @@
     "description": "Magento module responsible for the admin panel images UI implementation",
     "require": {
         "php": "~7.1.3||~7.2.0||~7.3.0",
-        "magento/framework": "*",
-        "magento/module-adobe-ims": "*",
-        "magento/module-adobe-ims-api": "*",
-        "magento/module-adobe-stock-asset-api": "*",
-        "magento/module-adobe-stock-image-api": "*",
-        "magento/module-adobe-stock-client-api": "*",
-        "magento/module-backend": "*",
-        "magento/module-ui": "*"
+        "magento/framework": "~102.0.4",
+        "magento/module-adobe-ims": "1.*.*",
+        "magento/module-adobe-ims-api": "1.*.*",
+        "magento/module-adobe-stock-asset-api": "1.*.*",
+        "magento/module-adobe-stock-image-api": "1.*.*",
+        "magento/module-adobe-stock-client-api": "1.*.*",
+        "magento/module-backend": "~101.0.4",
+        "magento/module-ui": "~101.1.4"
     },
     "suggest": {
-        "magento/module-cms": "*"
+        "magento/module-cms": "~103.0.4"
     },
     "type": "magento2-module",
     "license": [
@@ -28,5 +28,5 @@
             "Magento\\AdobeStockImageAdminUi\\": ""
         }
     },
-    "version": "1.0.1"
+    "version": "1.0.0"
 }

--- a/AdobeStockImageAdminUi/view/adminhtml/ui_component/adobe_stock_images_listing.xml
+++ b/AdobeStockImageAdminUi/view/adminhtml/ui_component/adobe_stock_images_listing.xml
@@ -35,7 +35,7 @@
     </dataSource>
     <listingToolbar name="listing_top" template="Magento_AdobeStockImageAdminUi/grid/toolbar">
         <settings>
-            <sticky>true</sticky>
+            <sticky>false</sticky>
         </settings>
         <bookmark name="bookmarks"/>
         <filterSearch name="words"/>

--- a/AdobeStockImageAdminUi/view/adminhtml/ui_component/adobe_stock_images_listing.xml
+++ b/AdobeStockImageAdminUi/view/adminhtml/ui_component/adobe_stock_images_listing.xml
@@ -34,9 +34,6 @@
         </dataProvider>
     </dataSource>
     <listingToolbar name="listing_top" template="Magento_AdobeStockImageAdminUi/grid/toolbar">
-        <settings>
-            <sticky>false</sticky>
-        </settings>
         <bookmark name="bookmarks"/>
         <filterSearch name="words"/>
         <paging name="listing_paging">

--- a/AdobeStockImageAdminUi/view/adminhtml/web/css/source/_module.less
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/css/source/_module.less
@@ -216,7 +216,8 @@
                         justify-content: center;
                         position: relative;
                         height: 100px;
-                        width: 150px;
+                        max-width: 130px;
+                        width: 100%;
                         overflow: hidden;
                         margin-right: 10px;
                         vertical-align: middle;
@@ -232,7 +233,7 @@
                         display: inline-block;
                         max-height: 100px;
                         text-align: center;
-                        max-width: 140px;
+                        max-width: 130px;
                         vertical-align: middle;
                         width: 100%;
                         cursor: pointer;

--- a/AdobeStockImageAdminUi/view/adminhtml/web/css/source/_module.less
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/css/source/_module.less
@@ -27,12 +27,15 @@
 
                 .container {
                     padding-top: 0;
+
                     .preview-buttons {
                         /* Align image preview actions uniformly to the right edge */
+
                         .action-previous, .action-next, .action-close {
                             padding: 30px 0 30px 30px;
                         }
                     }
+
                     .preview-row-content {
                         img.preview {
                             flex-basis: auto;
@@ -179,18 +182,21 @@
             .adobe-stock-tabs {
                 margin-top: 30px;
                 border-bottom: 1px solid @color-gray68;
+
                 .ui-state-default {
                     border-bottom: none;
                 }
             }
+
             .related-loader {
                 height: 100px;
                 width: 100px;
                 left: 50%;
                 margin-left: -50px;
                 top: 50%;
-                margin-top: 50px; 
-	    }
+                margin-top: 50px;
+            }
+
             .adobe-stock-related-images-tab-content {
                 max-height: 190px;
                 height: auto;
@@ -334,6 +340,7 @@
         .masonry-image-preview {
             .container {
                 margin: 0 60px;
+
                 .preview-row-content {
                     .info {
                         .actions {

--- a/AdobeStockImageAdminUi/view/adminhtml/web/css/source/_module.less
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/css/source/_module.less
@@ -184,24 +184,13 @@
                 }
             }
             .related-loader {
-               border: 16px solid #f3f3f3;
-               border-top: 16px solid #3498db;
-               border-radius: 50%;
-               width: 120px;
-               height: 120px;
-	       margin: auto;
-               animation: spin 2s linear infinite;
-	       -webkit-animation: spin 2s linear infinite;
-             }
-	     @-webkit-keyframes spin {
-               0% { -webkit-transform: rotate(0deg); }
-               100% { -webkit-transform: rotate(360deg); }
-            }
-
-            @keyframes spin {
-              0% { transform: rotate(0deg); }
-              100% { transform: rotate(360deg); }
-            }
+                height: 100px;
+                width: 100px;
+                left: 50%;
+                margin-left: -50px;
+                top: 50%;
+                margin-top: 50px; 
+	    }
             .adobe-stock-related-images-tab-content {
                 max-height: 190px;
                 height: auto;

--- a/AdobeStockImageAdminUi/view/adminhtml/web/css/source/_module.less
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/css/source/_module.less
@@ -183,7 +183,25 @@
                     border-bottom: none;
                 }
             }
+            .related-loader {
+               border: 16px solid #f3f3f3;
+               border-top: 16px solid #3498db;
+               border-radius: 50%;
+               width: 120px;
+               height: 120px;
+	       margin: auto;
+               animation: spin 2s linear infinite;
+	       -webkit-animation: spin 2s linear infinite;
+             }
+	     @-webkit-keyframes spin {
+               0% { -webkit-transform: rotate(0deg); }
+               100% { -webkit-transform: rotate(360deg); }
+            }
 
+            @keyframes spin {
+              0% { transform: rotate(0deg); }
+              100% { transform: rotate(360deg); }
+            }
             .adobe-stock-related-images-tab-content {
                 max-height: 190px;
                 height: auto;

--- a/AdobeStockImageAdminUi/view/adminhtml/web/css/source/_module.less
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/css/source/_module.less
@@ -216,7 +216,7 @@
                         justify-content: center;
                         position: relative;
                         height: 100px;
-                        max-width: 130px;
+                        max-width: 150px;
                         width: 100%;
                         overflow: hidden;
                         margin-right: 10px;
@@ -233,7 +233,7 @@
                         display: inline-block;
                         max-height: 100px;
                         text-align: center;
-                        max-width: 130px;
+                        max-width: 140px;
                         vertical-align: middle;
                         width: 100%;
                         cursor: pointer;
@@ -334,6 +334,23 @@
 
             .admin__field-tooltip {
                 margin: -5px 0 0 5px;
+            }
+        }
+    }
+}
+
+@media (max-width: 1400px) {
+    .adobe-stock-images-search-modal-content {
+        .masonry-image-preview {
+            .adobe-stock-related-images-tab-content {
+                .ui-tabs-panel {
+                    .thumbnail {
+                        max-width: 130px;
+                    }
+                    .see-more-wrapper {
+                        max-width: 130px;
+                    }
+                }
             }
         }
     }

--- a/AdobeStockImageAdminUi/view/adminhtml/web/css/source/_module.less
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/css/source/_module.less
@@ -82,10 +82,13 @@
             }
         }
 
-        .admin__data-grid-outer-wrap {
-            .admin__data-grid-header-row {
-                padding-right: 8rem;
-            }
+        .admin__action-dropdown-wrap._active .admin__action-dropdown-text::after {
+            margin-right: 6px;
+        }
+
+        .admin__data-grid-action-bookmarks .admin__action-dropdown-menu {
+            right: 0;
+            left: auto;
         }
 
         .masonry-image-grid {

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/actions.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/actions.js
@@ -378,10 +378,10 @@ define([
                      * On error
                      */
                     error: function (response) {
-                        var errorMessage = response.JSON ? response.JSON.meassage : '';
+                        var errorMessage = response.JSON ? response.JSON.meassage : 'Failed to fetch licensing information.';
 
                         if (response.status === 403) {
-                            errorMessage = $.mage.__('You have not enough permission to license images');
+                            errorMessage = $.mage.__('Your admin role does not have permissions to license an image');
                         }
 
                         messages.add('error', errorMessage);

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/actions.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/actions.js
@@ -378,11 +378,11 @@ define([
                      * On error
                      */
                     error: function (response) {
-			var errorMessage = response.JSON ? response.JSON.meassage : '';
+                        var errorMessage = response.JSON ? response.JSON.meassage : '';
 
-			if (response.status === 403) {
-				errorMessage = $.mage.__('You have not enough permission to license images');
-			}
+                        if (response.status === 403) {
+                            errorMessage = $.mage.__('You have not enough permission to license images');
+                        }
 
                         messages.add('error', errorMessage);
                         messages.scheduleCleanup(this.messageDelay);

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/actions.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/actions.js
@@ -320,6 +320,10 @@ define([
                                          * Confirm action
                                          */
                                         confirm: function (fileName) {
+                                            $.ajaxSetup({
+                                                async: true
+                                            });
+
                                             if (typeof fileName === 'undefined') {
                                                 fileName = filePathArray[imageIndex]
                                                  .substring(0, filePathArray[imageIndex].lastIndexOf('.'));

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/actions.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/actions.js
@@ -320,10 +320,6 @@ define([
                                          * Confirm action
                                          */
                                         confirm: function (fileName) {
-                                            // $.ajaxSetup({
-                                            //     async: true
-                                            // });
-
                                             if (typeof fileName === 'undefined') {
                                                 fileName = filePathArray[imageIndex]
                                                  .substring(0, filePathArray[imageIndex].lastIndexOf('.'));

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/actions.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/actions.js
@@ -182,6 +182,7 @@ define([
                     if (license || isLicensed) {
                         record['is_licensed'] = 1;
                         record['is_licensed_locally'] = 1;
+                        this.login().getUserQuota();
                     }
                     this.preview().displayedRecord(record);
                     this.source().reload({

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/actions.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/actions.js
@@ -303,8 +303,6 @@ define([
                             canPurchase = response.result.canLicense,
                             buyCreditsUrl = this.preview().buyCreditsUrl,
                             displayFieldName = !this.isDownloaded() ? '<b>' + $.mage.__('File Name') + '</b>' : '',
-                            filePathArray = record.path.split('/'),
-                            imageIndex = filePathArray.length - 1,
                             title = $.mage.__('License Adobe Stock Images?'),
                             cancelText = $.mage.__('Cancel'),
                             baseContent = '<p>' + confirmationContent + '</p><p><b>' + quotaMessage + '</b></p><br>';
@@ -321,8 +319,7 @@ define([
                                          */
                                         confirm: function (fileName) {
                                             if (typeof fileName === 'undefined') {
-                                                fileName = filePathArray[imageIndex]
-                                                 .substring(0, filePathArray[imageIndex].lastIndexOf('.'));
+                                                fileName = this.getImageNameFromPath(record.path);
                                             }
 
                                             this.licenseAndSave(record, fileName);
@@ -446,6 +443,8 @@ define([
          * Save licensed
          */
         saveLicensed: function () {
+            var imageName = '';
+
             if (!this.login().user().isAuthorized) {
                 return;
             }
@@ -454,6 +453,15 @@ define([
                 return;
             }
 
+            // If there's a copy of the image (preview), get the filename from the copy
+            if (this.preview().displayedRecord().path !== '') {
+                imageName = this.getImageNameFromPath(this.preview().displayedRecord().path);
+                this.save(this.preview().displayedRecord(), imageName, false, true);
+
+                return;
+            }
+
+            // Ask user for the image name otherwise
             this.getPrompt(
                 {
                     'title': $.mage.__('Save'),
@@ -492,6 +500,19 @@ define([
          */
         getLicenseButtonTitle: function () {
             return this.isDownloaded() ?  $.mage.__('License') : $.mage.__('License and Save');
+        },
+
+        /**
+         * Extracts image name from its path
+         *
+         * @param {String} path
+         * @returns {String}
+         */
+        getImageNameFromPath: function (path) {
+            var filePathArray = path.split('/'),
+                imageIndex = filePathArray.length - 1;
+
+            return filePathArray[imageIndex].substring(0, filePathArray[imageIndex].lastIndexOf('.'));
         }
     });
 });

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/actions.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/actions.js
@@ -27,7 +27,6 @@ define([
             confirmationUrl: 'adobe_stock/license/confirmation',
             buyCreditsUrl: 'https://stock.adobe.com/',
             messageDelay: 5,
-            IslicenseRequestStarted: false,
             listens: {
                 '${ $.provider }:data.items': 'updateActions'
             },
@@ -37,19 +36,6 @@ define([
                 overlay: '${ $.parentName }.overlay',
                 source: '${ $.provider }'
             }
-        },
-
-        /**
-         * Init observable variables
-         * @return {Object}
-         */
-        initObservable: function () {
-            this._super()
-                .observe([
-                    'isLicenseRequestStarted'
-                ]);
-
-            return this;
         },
 
         /**
@@ -295,11 +281,6 @@ define([
          * @param {Object} record
          */
         showLicenseConfirmation: function (record) {
-
-            if (this.isLicenseRequestStarted()) {
-                return;
-            }
-            this.isLicenseRequestStarted(true);
             $.ajax(
                 {
                     type: 'POST',
@@ -328,8 +309,6 @@ define([
                             cancelText = $.mage.__('Cancel'),
                             baseContent = '<p>' + confirmationContent + '</p><p><b>' + quotaMessage + '</b></p><br>';
 
-                        this.isLicenseRequestStarted(false);
-
                         if (canPurchase) {
                             this.getPrompt(
                                  {
@@ -341,9 +320,9 @@ define([
                                          * Confirm action
                                          */
                                         confirm: function (fileName) {
-                                            $.ajaxSetup({
-                                                async: true
-                                            });
+                                            // $.ajaxSetup({
+                                            //     async: true
+                                            // });
 
                                             if (typeof fileName === 'undefined') {
                                                 fileName = filePathArray[imageIndex]

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/actions.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/actions.js
@@ -378,7 +378,13 @@ define([
                      * On error
                      */
                     error: function (response) {
-                        messages.add('error', response.responseJSON.message);
+			var errorMessage = response.JSON ? response.JSON.meassage : '';
+
+			if (response.status === 403) {
+				errorMessage = $.mage.__('You have not enough permission to license images');
+			}
+
+                        messages.add('error', errorMessage);
                         messages.scheduleCleanup(this.messageDelay);
                     }
                 }

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/actions.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/actions.js
@@ -378,7 +378,8 @@ define([
                      * On error
                      */
                     error: function (response) {
-                        var errorMessage = response.JSON ? response.JSON.meassage : 'Failed to fetch licensing information.';
+                        var defaultMessage = 'Failed to fetch licensing information.',
+                            errorMessage = response.JSON ? response.JSON.meassage : defaultMessage;
 
                         if (response.status === 403) {
                             errorMessage = $.mage.__('Your admin role does not have permissions to license an image');

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/actions.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/actions.js
@@ -27,6 +27,7 @@ define([
             confirmationUrl: 'adobe_stock/license/confirmation',
             buyCreditsUrl: 'https://stock.adobe.com/',
             messageDelay: 5,
+            IslicenseRequestStarted: false,
             listens: {
                 '${ $.provider }:data.items': 'updateActions'
             },
@@ -36,6 +37,19 @@ define([
                 overlay: '${ $.parentName }.overlay',
                 source: '${ $.provider }'
             }
+        },
+
+        /**
+         * Init observable variables
+         * @return {Object}
+         */
+        initObservable: function () {
+            this._super()
+                .observe([
+                    'isLicenseRequestStarted'
+                ]);
+
+            return this;
         },
 
         /**
@@ -281,6 +295,11 @@ define([
          * @param {Object} record
          */
         showLicenseConfirmation: function (record) {
+
+            if (this.isLicenseRequestStarted()) {
+                return;
+            }
+            this.isLicenseRequestStarted(true);
             $.ajax(
                 {
                     type: 'POST',
@@ -308,6 +327,8 @@ define([
                             title = $.mage.__('License Adobe Stock Images?'),
                             cancelText = $.mage.__('Cancel'),
                             baseContent = '<p>' + confirmationContent + '</p><p><b>' + quotaMessage + '</b></p><br>';
+
+                        this.isLicenseRequestStarted(false);
 
                         if (canPurchase) {
                             this.getPrompt(

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/related.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/related.js
@@ -247,7 +247,7 @@ define([
          * @returns {boolean}
          */
         isSerieFilterApplied: function (record) {
-            return this.filterChips().get('applied').serie_id === record.id.toString();
+            return this.filterChips().get('applied')['serie_id'] === record.id.toString();
         },
 
         /**
@@ -257,7 +257,7 @@ define([
          * @returns {boolean}
          */
         isModelFilterApplied: function (record) {
-            return this.filterChips().get('applied').model_id === record.id.toString();
+            return this.filterChips().get('applied')['model_id'] === record.id.toString();
         },
 
         /**
@@ -268,7 +268,7 @@ define([
                 behavior: 'smooth',
                 block: 'center',
                 inline: 'nearest'
-            })
+            });
         },
 
         /**

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/related.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/related.js
@@ -244,7 +244,7 @@ define([
          * Checks if the filter is applied
          *
          * @param record
-         * @returns {boolean}
+         * @returns {Boolean}
          */
         isSerieFilterApplied: function (record) {
             return this.filterChips().get('applied')['serie_id'] === record.id.toString();
@@ -254,7 +254,7 @@ define([
          * Checks if the filter is applied
          *
          * @param record
-         * @returns {boolean}
+         * @returns {Boolean}
          */
         isModelFilterApplied: function (record) {
             return this.filterChips().get('applied')['model_id'] === record.id.toString();

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/related.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/related.js
@@ -122,9 +122,37 @@ define([
 
                 relatedImages.series[record.id] = data.result['same_series'];
                 relatedImages.model[record.id] = data.result['same_model'];
+
                 this.relatedImages(relatedImages);
                 this.preview().updateHeight();
+
+                /* Switch to the model tab if the series tab is hidden */
+                if (relatedImages.series[record.id].length === 0) {
+                    $('#adobe-stock-tabs').data().mageTabs.select(1);
+                }
             }.bind(this));
+        },
+
+        /**
+         * Returns true if the series tab should be show, false otherwise
+         *
+         * @param {Object} record
+         * @returns boolean
+         */
+        showSeriesTab: function (record) {
+            return typeof this.relatedImages().series[record.id] === 'undefined' ||
+                this.relatedImages().series[record.id].length !== 0;
+        },
+
+        /**
+         * Returns true if the model tab should be show, false otherwise
+         *
+         * @param {Object} record
+         * @returns boolean
+         */
+        showModelTab: function (record) {
+            return typeof this.relatedImages().model[record.id] === 'undefined' ||
+                this.relatedImages().model[record.id].length !== 0;
         },
 
         /**

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/related.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/related.js
@@ -14,6 +14,7 @@ define([
         defaults: {
             template: 'Magento_AdobeStockImageAdminUi/grid/column/preview/related',
             filterChipsProvider: 'componentType = filters, ns = ${ $.ns }',
+            filterTitleSelector: '.admin__current-filters-title-wrap',
             tabImagesLimit: 4,
             serieFilterValue: '',
             modelFilterValue: '',
@@ -207,6 +208,9 @@ define([
          * @param {Object} record
          */
         seeMoreFromSeries: function (record) {
+            if (this.isSerieFilterApplied(record)) {
+                this.scrollToFilter()
+            }
             this.serieFilterValue(record.id);
             this.filterChips().set(
                 'applied',
@@ -222,6 +226,9 @@ define([
          * @param {Object} record
          */
         seeMoreFromModel: function (record) {
+            if (this.isModelFilterApplied(record)) {
+                this.scrollToFilter()
+            }
             this.modelFilterValue(record.id);
             this.filterChips().set(
                 'applied',
@@ -229,6 +236,37 @@ define([
                     'model_id': record.id.toString()
                 }
             );
+        },
+
+        /**
+         * Checks if the filter is applied
+         *
+         * @param record
+         * @returns {boolean}
+         */
+        isSerieFilterApplied: function (record) {
+            return this.filterChips().get('applied').serie_id === record.id.toString();
+        },
+
+        /**
+         * Checks if the filter is applied
+         *
+         * @param record
+         * @returns {boolean}
+         */
+        isModelFilterApplied: function (record) {
+            return this.filterChips().get('applied').model_id === record.id.toString();
+        },
+
+        /**
+         * Scrolls user window to the filter title
+         */
+        scrollToFilter: function () {
+            $(this.filterTitleSelector).get(0).scrollIntoView({
+                behavior: 'smooth',
+                block: 'center',
+                inline: 'nearest'
+            })
         },
 
         /**

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/related.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/related.js
@@ -210,7 +210,7 @@ define([
         seeMoreFromSeries: function (record) {
             if (this.isSerieFilterApplied(record)) {
                 this.scrollToFilter();
-                
+
                 return;
             }
             this.serieFilterValue(record.id);

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/related.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/related.js
@@ -18,6 +18,7 @@ define([
             serieFilterValue: '',
             modelFilterValue: '',
             selectedTab: null,
+            loader: false,
             relatedImages: {
                 series: {},
                 model: {}
@@ -58,7 +59,8 @@ define([
                     'serieFilterValue',
                     'modelFilterValue',
                     'selectedTab',
-                    'relatedImages'
+                    'relatedImages',
+                    'loader'
                 ]);
 
             return this;
@@ -113,6 +115,9 @@ define([
                 type: 'GET',
                 url: this.preview().relatedImagesUrl,
                 dataType: 'json',
+                beforeSend: function () {
+                    this.loader(true);
+                }.bind(this),
                 data: {
                     'image_id': record.id,
                     'limit': this.tabImagesLimit
@@ -120,6 +125,7 @@ define([
             }).done(function (data) {
                 var relatedImages = this.relatedImages();
 
+                this.loader(false);
                 relatedImages.series[record.id] = data.result['same_series'];
                 relatedImages.model[record.id] = data.result['same_model'];
 

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/related.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/related.js
@@ -209,7 +209,8 @@ define([
          */
         seeMoreFromSeries: function (record) {
             if (this.isSerieFilterApplied(record)) {
-                this.scrollToFilter()
+                this.scrollToFilter();
+                return;
             }
             this.serieFilterValue(record.id);
             this.filterChips().set(
@@ -227,7 +228,8 @@ define([
          */
         seeMoreFromModel: function (record) {
             if (this.isModelFilterApplied(record)) {
-                this.scrollToFilter()
+                this.scrollToFilter();
+                return;
             }
             this.modelFilterValue(record.id);
             this.filterChips().set(

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/related.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/related.js
@@ -243,7 +243,7 @@ define([
         /**
          * Checks if the filter is applied
          *
-         * @param record
+         * @param {Object} record
          * @returns {Boolean}
          */
         isSerieFilterApplied: function (record) {
@@ -253,7 +253,7 @@ define([
         /**
          * Checks if the filter is applied
          *
-         * @param record
+         * @param {Object} record
          * @returns {Boolean}
          */
         isModelFilterApplied: function (record) {

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/related.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/related.js
@@ -210,6 +210,7 @@ define([
         seeMoreFromSeries: function (record) {
             if (this.isSerieFilterApplied(record)) {
                 this.scrollToFilter();
+                
                 return;
             }
             this.serieFilterValue(record.id);
@@ -229,6 +230,7 @@ define([
         seeMoreFromModel: function (record) {
             if (this.isModelFilterApplied(record)) {
                 this.scrollToFilter();
+
                 return;
             }
             this.modelFilterValue(record.id);

--- a/AdobeStockImageAdminUi/view/adminhtml/web/template/grid/column/preview/actions.html
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/template/grid/column/preview/actions.html
@@ -30,6 +30,6 @@
     <span data-bind="text: getLicenseButtonTitle()"></span>
 </button>
 <button class="action-default primary" type="button" data-bind="visible: isLicensed(), click: function () { saveLicensed(); }">
-    <span translate="'Save'"></span>
+    <span translate="'Save Licensed'"></span>
 </button>
 

--- a/AdobeStockImageAdminUi/view/adminhtml/web/template/grid/column/preview/related.html
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/template/grid/column/preview/related.html
@@ -5,23 +5,22 @@
  */
 -->
 <div if="isVisible($row())"
-    class="related-container">
+     class="related-container">
     <div id="adobe-stock-tabs"
          class="adobe-stock-tabs"
          data-bind="mageInit: {
                     'mage/backend/tabs': {
-                    active: 'series_content_' + $row().id,
                     destination: '#adobe-stock-tabs-content',
                     shadowTabs: [],
                 }
             }">
         <ul class="tabs-horiz">
-            <li>
+            <li if="showSeriesTab($row())">
                 <a id="series_tab" attr="'href': '#series_content_' + $row().id">
                     <span class="title" translate="'More from this series'"></span>
                 </a>
             </li>
-            <li>
+            <li if="showModelTab($row())">
                 <a id="model_tab" attr="'href': '#model_content_' + $row().id">
                     <span class="title" translate="'More from this model'"></span>
                 </a>
@@ -31,7 +30,7 @@
 
     <div id="adobe-stock-tabs-content"
          class="adobe-stock-related-images-tab-content">
-        <div attr="'id': 'series_content_' + $row().id">
+        <div if="showSeriesTab($row())" attr="'id': 'series_content_' + $row().id">
             <!-- ko foreach: getSeries($row()) -->
             <div class="thumbnail" data-bind="click: function(){ $parent.switchImagePreviewToSeriesImage($data) }">
                 <img attr="src: thumbnail_url, alt: title">
@@ -50,7 +49,7 @@
             </div>
             <!-- /ko -->
         </div>
-        <div attr="'id': 'model_content_' + $row().id">
+        <div if="showModelTab($row())" attr="'id': 'model_content_' + $row().id">
             <!-- ko foreach: getModel($row()) -->
             <div class="thumbnail" data-bind="click: function(){ $parent.switchImagePreviewToModelImage($data) }">
                 <img attr="src: thumbnail_url, alt: title">
@@ -71,4 +70,3 @@
         </div>
     </div>
 </div>
-

--- a/AdobeStockImageAdminUi/view/adminhtml/web/template/grid/column/preview/related.html
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/template/grid/column/preview/related.html
@@ -30,7 +30,10 @@
 
     <div id="adobe-stock-tabs-content"
          class="adobe-stock-related-images-tab-content">
-        <div class="related-loader" data-bind="visible: loader"></div>
+        <div class="spinner related-loader" data-bind="visible: loader">
+            <span></span><span></span><span></span><span></span>
+            <span></span><span></span><span></span><span></span>
+        </div>
         <div if="showSeriesTab($row())" attr="'id': 'series_content_' + $row().id">
             <!-- ko foreach: getSeries($row()) -->
             <div class="thumbnail" data-bind="click: function(){ $parent.switchImagePreviewToSeriesImage($data) }">

--- a/AdobeStockImageAdminUi/view/adminhtml/web/template/grid/column/preview/related.html
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/template/grid/column/preview/related.html
@@ -30,6 +30,7 @@
 
     <div id="adobe-stock-tabs-content"
          class="adobe-stock-related-images-tab-content">
+        <div class="related-loader" data-bind="visible: loader"></div>
         <div if="showSeriesTab($row())" attr="'id': 'series_content_' + $row().id">
             <!-- ko foreach: getSeries($row()) -->
             <div class="thumbnail" data-bind="click: function(){ $parent.switchImagePreviewToSeriesImage($data) }">

--- a/AdobeStockImageApi/composer.json
+++ b/AdobeStockImageApi/composer.json
@@ -17,5 +17,6 @@
         "psr-4": {
             "Magento\\AdobeStockImageApi\\": ""
         }
-    }
+    },
+    "version": "1.0.0"
 }

--- a/AdobeStockImageApi/composer.json
+++ b/AdobeStockImageApi/composer.json
@@ -3,7 +3,7 @@
     "description": "Magento module responsible for the images handling",
     "require": {
         "php": "~7.1.3||~7.2.0||~7.3.0",
-        "magento/framework": "*"
+        "magento/framework": "~102.0.4"
     },
     "type": "magento2-module",
     "license": [

--- a/_metapackage/composer.json
+++ b/_metapackage/composer.json
@@ -3,15 +3,16 @@
     "description": "Adobe Stock integration",
     "type": "metapackage",
     "require": {
-        "magento/module-adobe-stock-asset": "*",
-        "magento/module-adobe-stock-asset-api": "*",
-        "magento/module-adobe-stock-image": "*",
-        "magento/module-adobe-stock-image-admin-ui": "*",
-        "magento/module-adobe-stock-image-api": "*",
-        "magento/module-adobe-stock-client": "*",
-        "magento/module-adobe-stock-client-api": "*",
-        "magento/module-adobe-stock-admin-ui": "*",
-        "magento/module-adobe-ims": "*",
-        "magento/module-adobe-ims-api": "*"
-    }
+        "magento/module-adobe-stock-asset": "1.0.0",
+        "magento/module-adobe-stock-asset-api": "1.0.0",
+        "magento/module-adobe-stock-image": "1.0.0",
+        "magento/module-adobe-stock-image-admin-ui": "1.0.1",
+        "magento/module-adobe-stock-image-api": "1.0.0",
+        "magento/module-adobe-stock-client": "1.0.0",
+        "magento/module-adobe-stock-client-api": "1.0.0",
+        "magento/module-adobe-stock-admin-ui": "1.0.0",
+        "magento/module-adobe-ims": "1.0.0",
+        "magento/module-adobe-ims-api": "1.0.0"
+    },
+    "version": "1.0.1"
 }


### PR DESCRIPTION
## PR to track 1.0.1 Adobe Stock Integration Release Scope

### Pull Requests
https://github.com/magento/adobe-stock-integration/pull/818 Hide tabs with related images if result is empty by @rogyar 
https://github.com/magento/adobe-stock-integration/pull/820 Display loader in the allocated space while related images are loading by @Nazar65 
https://github.com/magento/adobe-stock-integration/pull/857 Grid header has extra space in right side by @Nazar65 
https://github.com/magento/adobe-stock-integration/pull/853 See more link can be overlapped by similar keywords by @konarshankar07 
https://github.com/magento/adobe-stock-integration/pull/859 Not enough permissions error message is not shown to Admin user on attempt to license image by @Nazar65 
https://github.com/magento/adobe-stock-integration/pull/870 Handling activation of related images filter that is already applied by @gabrieldagama 
https://github.com/magento/adobe-stock-integration/pull/875 Removed sticky toolbar by @konarshankar07 
https://github.com/magento/adobe-stock-integration/pull/855 Quantity of images is not updated after image was licensed && License and Save popup must be closed after confirm click immediately by @Nazar65 
<!-- public pull request placeholder -->

### Fixed Issues
https://github.com/magento/adobe-stock-integration/issues/677 See more from series/model tabs to hide if result is empty
https://github.com/magento/adobe-stock-integration/issues/796 Display loader in the allocated space while related images are loading
https://github.com/magento/adobe-stock-integration/issues/845 Grid header has extra space in right side
https://github.com/magento/adobe-stock-integration/issues/851 Rename "Save" image preview button to "Save Licensed"
https://github.com/magento/adobe-stock-integration/issues/827 Element '#adobe-stock-tabs-content .three-dots' can be overlapped by "Similar keywords"
https://github.com/magento/adobe-stock-integration/issues/856 Not enough permissions error message is not shown to Admin user on attempt to license image
https://github.com/magento/adobe-stock-integration/issues/850 The "See more" button doesn't work when More images are loaded and the same image is previewed again
https://github.com/magento/adobe-stock-integration/issues/862 "Found 2 elements with non-unique id" warning in browser console on Adobe Stock grid
https://github.com/magento/adobe-stock-integration/issues/826 Quantity of images on account profile is not updated after image was licensed
<!-- public issue placeholder -->