### PR TITLE
Wait for directory tree container instead of timeout

### DIFF
--- a/MediaGalleryUi/view/adminhtml/web/js/directory/directoryTree.js
+++ b/MediaGalleryUi/view/adminhtml/web/js/directory/directoryTree.js
@@ -29,13 +29,25 @@ define([
         initialize: function () {
             this._super();
 
-            // wait one second for template render
-            setTimeout(function () {
+            this.waitForContainer(function () {
                 this.getJsonTree();
                 this.initEvents();
-            }.bind(this), 100);
+            }.bind(this));
 
             return this;
+        },
+
+        /**
+         * Wait for container to initialize
+         */
+        waitForContainer: function (callback) {
+            if ($(this.directoryTreeSelector).length === 0) {
+                setTimeout(function () {
+                    this.waitForContainer(callback);
+                }.bind(this), 100);
+            } else {
+                setTimeout(callback, 0);
+            }
         },
 
         /**

--- a/MediaGalleryUi/view/adminhtml/web/js/directory/directoryTree.js
+++ b/MediaGalleryUi/view/adminhtml/web/js/directory/directoryTree.js
@@ -46,7 +46,7 @@ define([
                     this.waitForContainer(callback);
                 }.bind(this), 100);
             } else {
-                setTimeout(callback, 0);
+                callback();
             }
         },
 


### PR DESCRIPTION


<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
Wait div element to be rendered before initialize jstree

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/adobe-stock-integration#<issue_number>: Issue title
2. ...

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...