### PR TITLE
Added check for Adobe sign in button visibility

### DIFF
--- a/AdobeStockImageAdminUi/Test/Mftf/Section/AdobeStockSection.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Section/AdobeStockSection.xml
@@ -24,6 +24,7 @@
         <element name="mediaGalleryImage" type="button" selector="//img[contains(@alt,'{{imageName}}')]" parameterized="true"/>
         <element name="mediaGalleryDeleteButton" type="button" selector="[data-ui-id=wysiwyg-images-content-delete-files-button]"/>
         <element name="systemAclActions" type="checkbox" selector="//a[text()='Adobe Stock']/parent::li[contains(.,'Actions')]//a"/>
+        <element name="adobeImsACL" type="checkbox" selector="//a[text()='Adobe IMS']"/>
         <element name="adobeSignIn" type="button" selector=".adobe-sign-in-button"/>
         <element name="adobeImsPopupUserEmail" type="button" selector="#adobeid_username"/>
         <element name="adobeImsPopUpUserPassword" type="button" selector="#adobeid_password"/>

--- a/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockSignInACLTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockSignInACLTest.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+    <test name="AdminAdobeStockSignInACLTest">
+        <annotations>
+            <features value="AdobeStockImagePanel"/>
+            <stories value="[Story #19] User controls access to Adobe Stock sign in from Admin Panel in ACL"/>
+            <useCaseId value="https://github.com/magento/adobe-stock-integration/issues/966"/>
+            <title value="User controls access to Adobe Stock sign in from Admin Panel in ACL"/>
+            <description value="User controls access to Adobe Stock sign in from Admin Panel in ACL"/>
+            <testCaseId value="https://app.hiptest.com/projects/131313/test-plan/folders/943908/scenarios/3218882"/>
+            <severity value="MAJOR"/>
+            <group value="adobe_stock_integration_configuration"/>
+            <group value="adobe_stock_integration"/>
+        </annotations>
+        <before>
+            <actionGroup ref="LoginAsAdmin" stepKey="loginAsAdminBefore"/>
+            <actionGroup ref="AdminAdobeStockSetConfigActionGroup" stepKey="setCorrectModuleConfig"/>
+        </before>
+        <after>
+            <actionGroup ref="LoginAsAdmin" stepKey="loginAsAdminAfter"/>
+            <amOnPage url="{{AdminRolesPage.url}}" stepKey="navigateToUserRoleGrid" />
+            <waitForPageLoad stepKey="waitForRolesGridLoad" />
+            <actionGroup ref="AdminDeleteRoleActionGroup" stepKey="deleteUserRole">
+                <argument name="role" value="adminRole"/>
+            </actionGroup>
+            <amOnPage url="{{AdminUsersPage.url}}" stepKey="goToAllUsersPage"/>
+            <waitForPageLoad stepKey="waitForUsersGridLoad" />
+            <actionGroup ref="AdminDeleteNewUserActionGroup" stepKey="deleteUser">
+                <argument name="userName" value="{{admin2.username}}"/>
+            </actionGroup>
+            <actionGroup ref="logout" stepKey="logoutFromAdmin"/>
+        </after>
+
+        <!-- Create user role -->
+        <actionGroup ref="AdminFillUserRoleRequiredDataActionGroup" stepKey="fillUserRoleRequiredData">
+            <argument name="User" value="adminRole"/>
+            <argument name="restrictedRole" value="Adobe Stock"/>
+        </actionGroup>
+        <click selector="{{AdminEditRoleInfoSection.roleResourcesTab}}" stepKey="clickRoleResourcesTab" />
+        <actionGroup ref="AdminAddRestrictedRoleActionGroup" stepKey="addRestrictedRoleAdobeStockPreview">
+            <argument name="User" value="adminRole"/>
+            <argument name="restrictedRole" value="Adobe Stock"/>
+        </actionGroup>
+
+        <!-- Select Adobe IMS role resource -->
+        <scrollTo selector="{{AdobeStockSection.adobeImsACL}}" x="0" y="-100" stepKey="scrollToResourceElement"/>
+        <click stepKey="clickAdobeIMSActions" selector="{{AdobeStockSection.adobeImsACL}}"/>
+
+        <actionGroup ref="AdminAddRestrictedRoleActionGroup" stepKey="addRestrictedRoleAddEditNewPages">
+            <argument name="User" value="adminRole"/>
+            <argument name="restrictedRole" value="Pages"/>
+        </actionGroup>
+        <click selector="{{AdminEditRoleInfoSection.saveButton}}" stepKey="clickSaveRoleButton" />
+
+        <!-- Create user and assign role to it -->
+        <actionGroup ref="AdminCreateUserActionGroup" stepKey="createAdminUser">
+            <argument name="role" value="adminRole"/>
+            <argument name="User" value="admin2"/>
+        </actionGroup>
+
+        <!-- Log out of admin and login with newly created user -->
+        <actionGroup ref="logout" stepKey="logoutOfAdmin"/>
+        <actionGroup ref="LoginAsAdmin" stepKey="loginAsNewUser">
+            <argument name="adminUser" value="admin2"/>
+        </actionGroup>
+
+        <!-- Verify that user can see Adobe Stock sign in button -->
+        <actionGroup ref="AdminOpenMediaGalleryForPageNoEditorActionGroup" stepKey="openMediaGalleryForPageWithIMSAccess"/>
+        <actionGroup ref="AdminAdobeStockOpenPanelFromMediaGalleryActionGroup" stepKey="openAdobeStockPanelWithIMSAccess"/>
+        <seeElement stepKey="seeAdobeStockSigninButton" selector="{{AdobeStockSection.adobeSignIn}}"/>
+
+        <!-- Remove Adobe IMS role access -->
+        <actionGroup ref="logout" stepKey="logout"/>
+        <actionGroup ref="LoginAsAdmin" stepKey="loginAsAdmin"/>
+        <wait stepKey="test" time="30"/>
+        <actionGroup ref="AdminNavigateToCreatedUserRoleActionGroup" stepKey="navigateToUserRoleEditPage">
+            <argument name="userRoleName" value="{{adminRole.name}}"/>
+        </actionGroup>
+        <actionGroup ref="AdminAddRestrictedRoleActionGroup" stepKey="removeRestrictedRole">
+            <argument name="User" value="adminRole"/>
+            <argument name="restrictedRole" value="Adobe IMS"/>
+        </actionGroup>
+        <click selector="{{AdminEditRoleInfoSection.saveButton}}" stepKey="saveRole" />
+        <actionGroup ref="logout" stepKey="logoutAdmin"/>
+        <actionGroup ref="LoginAsAdmin" stepKey="loginNewUserRole">
+            <argument name="adminUser" value="admin2"/>
+        </actionGroup>
+
+        <!-- Verify that user can't see to Adobe Stock sign in button -->
+        <actionGroup ref="AdminOpenMediaGalleryForPageNoEditorActionGroup" stepKey="openMediaGalleryForPageWithoutIMSAccess"/>
+        <actionGroup ref="AdminAdobeStockOpenPanelFromMediaGalleryActionGroup" stepKey="openAdobeStockPanelWithoutIMSAccess"/>
+        <dontSeeElement stepKey="doNotSeeAdobeStockSigninButton" selector="{{AdobeStockSection.adobeSignIn}}"/>
+        <actionGroup ref="logout" stepKey="logoutFromCreatedUser"/>
+    </test>
+</tests>

--- a/AdobeStockImageAdminUi/view/adminhtml/layout/cms_wysiwyg_images_index.xml
+++ b/AdobeStockImageAdminUi/view/adminhtml/layout/cms_wysiwyg_images_index.xml
@@ -8,7 +8,7 @@
 <layout xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/layout_generic.xsd">
     <referenceContainer name="root">
         <block class="Magento\Backend\Block\Template" name="stock.panel" template="Magento_AdobeStockImageAdminUi::panel.phtml" aclResource="Magento_AdobeStockImageAdminUi::save_preview_images">
-            <block class="Magento\AdobeIms\Block\Adminhtml\SignIn" name="adobe.signIn" template="Magento_AdobeIms::signIn.phtml" aclResource="Magento_AdobeStockImageAdminUi::save_preview_images">
+            <block class="Magento\AdobeIms\Block\Adminhtml\SignIn" name="adobe.signIn" template="Magento_AdobeIms::signIn.phtml" aclResource="Magento_AdobeIms::adobe_ims">
                 <arguments>
                     <argument name="configProviders" xsi:type="array">
                         <item name="adobe-stock" xsi:type="object">Magento\AdobeStockImageAdminUi\Model\SignInConfigProvider</item>


### PR DESCRIPTION
### Description

Added ACL check for rendering 'Sign In' button template content

### Fixed Issues
1. magento/adobe-stock-integration#966: Adobe Stock Sign In link is shown even if user does not have IMS login permissions

### Manual testing scenarios 
1. Sign in to Admin panel
2. Disable enhanced media gallery
3. Verify 'Sign In' button is visible in Adobe Stock panel for admin user _with_ permissions for Adobe IMS
4. Remove permission for Adobe IMS for admin user
5. Verify 'Sign In' button is not visible in Adobe Stock panel for admin user _without_ permissions for Adobe IMS