### PR TITLE
Added keyword population to media-gallery:index

### DIFF
--- a/MediaGalleryUi/Model/UpdateAssetInGrid.php
+++ b/MediaGalleryUi/Model/UpdateAssetInGrid.php
@@ -10,7 +10,9 @@ namespace Magento\MediaGalleryUi\Model;
 use Magento\Framework\App\ResourceConnection;
 use Magento\Framework\Exception\CouldNotSaveException;
 use Magento\Framework\Filesystem\DriverInterface;
+use Magento\MediaGallery\Model\Keyword\Command\GetAssetKeywords;
 use Magento\MediaGalleryApi\Api\Data\AssetInterface;
+use Magento\MediaGalleryApi\Api\Data\KeywordInterface;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -34,20 +36,28 @@ class UpdateAssetInGrid
     private $logger;
 
     /**
+     * @var GetAssetKeywords
+     */
+    private $assetKeywords;
+
+    /**
      * Constructor
      *
      * @param ResourceConnection $resource
      * @param DriverInterface $file
      * @param LoggerInterface $logger
+     * @param GetAssetKeywords $assetKeywords
      */
     public function __construct(
         ResourceConnection $resource,
         DriverInterface $file,
-        LoggerInterface $logger
+        LoggerInterface $logger,
+        GetAssetKeywords $assetKeywords
     ) {
         $this->resource = $resource;
         $this->file = $file;
         $this->logger = $logger;
+        $this->assetKeywords = $assetKeywords;
     }
 
     /**
@@ -61,6 +71,12 @@ class UpdateAssetInGrid
     public function execute(AssetInterface $asset): void
     {
         try {
+
+            /* Get all keywords from media_gallery_keyword table for current asset */
+            $keywords = array_map(function (KeywordInterface $keyword) {
+                return $keyword->getKeyword();
+            }, $this->assetKeywords->execute($asset->getId()));
+
             $this->resource->getConnection()->insertOnDuplicate(
                 $this->resource->getTableName('media_gallery_asset_grid'),
                 [
@@ -75,6 +91,7 @@ class UpdateAssetInGrid
                     'height' => $asset->getHeight(),
                     'created_at' => $asset->getCreatedAt(),
                     'updated_at' => $asset->getUpdatedAt(),
+                    'keywords' => implode(",", $keywords) ?: null
                 ]
             );
         } catch (\Exception $exception) {


### PR DESCRIPTION
### Description

Added keyword population to `media-gallery:index` command

### Fixed Issues

1. magento/adobe-stock-integration#960: Keywords of Adobe Stock assets should be added to Media Gallery grid table during reindex

### Manual testing scenarios

1. Login to Admin panel
2. Disable Enhanced Media Gallery (Sores -> Configuration -> Advanced -> System -> Enhanced Media Gallery fieldset)
3. Open Media Gallery (i.e. Catalog -> Category -> expand Content -> Select from Gallery button)
4. Click Search Adobe Stock
5. Save any image preview
6. Ensure that keywords for the saved asset are present in `media_gallery_asset_grid` table
7. Clean the media gallery grid table by executing `delete from media_gallery_asset_grid;`
8. Run media gallery index by executing `bin/magento media-gallery:index`
