### PR TITLE
Implement HTTP action interface in controllers

### DIFF
--- a/AdobeIms/Controller/Adminhtml/OAuth/Callback.php
+++ b/AdobeIms/Controller/Adminhtml/OAuth/Callback.php
@@ -13,6 +13,7 @@ use Magento\AdobeImsApi\Api\Data\UserProfileInterfaceFactory;
 use Magento\AdobeImsApi\Api\GetTokenInterface;
 use Magento\AdobeImsApi\Api\UserProfileRepositoryInterface;
 use Magento\Backend\App\Action;
+use Magento\Framework\App\Action\HttpPostActionInterface;
 use Magento\Framework\Controller\Result\Raw;
 use Magento\Framework\Controller\ResultFactory;
 use Magento\Framework\Controller\ResultInterface;
@@ -27,7 +28,7 @@ use Magento\AdobeImsApi\Api\GetImageInterface;
 /**
  * Callback action for managing user authentication with the Adobe services
  */
-class Callback extends Action
+class Callback extends Action implements HttpPostActionInterface
 {
     /**
      * @see _isAllowed()

--- a/AdobeIms/Controller/Adminhtml/OAuth/Callback.php
+++ b/AdobeIms/Controller/Adminhtml/OAuth/Callback.php
@@ -13,7 +13,7 @@ use Magento\AdobeImsApi\Api\Data\UserProfileInterfaceFactory;
 use Magento\AdobeImsApi\Api\GetTokenInterface;
 use Magento\AdobeImsApi\Api\UserProfileRepositoryInterface;
 use Magento\Backend\App\Action;
-use Magento\Framework\App\Action\HttpPostActionInterface;
+use Magento\Framework\App\Action\HttpGetActionInterface;
 use Magento\Framework\Controller\Result\Raw;
 use Magento\Framework\Controller\ResultFactory;
 use Magento\Framework\Controller\ResultInterface;
@@ -28,7 +28,7 @@ use Magento\AdobeImsApi\Api\GetImageInterface;
 /**
  * Callback action for managing user authentication with the Adobe services
  */
-class Callback extends Action implements HttpPostActionInterface
+class Callback extends Action implements HttpGetActionInterface
 {
     /**
      * @see _isAllowed()

--- a/AdobeIms/Controller/Adminhtml/User/Logout.php
+++ b/AdobeIms/Controller/Adminhtml/User/Logout.php
@@ -10,13 +10,15 @@ namespace Magento\AdobeIms\Controller\Adminhtml\User;
 use Magento\AdobeImsApi\Api\LogOutInterface;
 use Magento\Backend\App\Action;
 use Magento\Backend\App\Action\Context;
+use Magento\Framework\App\Action\HttpGetActionInterface;
+use Magento\Framework\App\Action\HttpPostActionInterface;
 use Magento\Framework\Controller\Result\Json;
 use Magento\Framework\Controller\ResultFactory;
 
 /**
  * Logout action from the Adobe account
  */
-class Logout extends Action
+class Logout extends Action implements HttpGetActionInterface, HttpPostActionInterface
 {
     private const HTTP_INTERNAL_SUCCESS = 200;
     private const HTTP_INTERNAL_ERROR = 500;

--- a/AdobeIms/Controller/Adminhtml/User/Logout.php
+++ b/AdobeIms/Controller/Adminhtml/User/Logout.php
@@ -10,7 +10,6 @@ namespace Magento\AdobeIms\Controller\Adminhtml\User;
 use Magento\AdobeImsApi\Api\LogOutInterface;
 use Magento\Backend\App\Action;
 use Magento\Backend\App\Action\Context;
-use Magento\Framework\App\Action\HttpGetActionInterface;
 use Magento\Framework\App\Action\HttpPostActionInterface;
 use Magento\Framework\Controller\Result\Json;
 use Magento\Framework\Controller\ResultFactory;
@@ -18,7 +17,7 @@ use Magento\Framework\Controller\ResultFactory;
 /**
  * Logout action from the Adobe account
  */
-class Logout extends Action implements HttpGetActionInterface, HttpPostActionInterface
+class Logout extends Action implements HttpPostActionInterface
 {
     private const HTTP_INTERNAL_SUCCESS = 200;
     private const HTTP_INTERNAL_ERROR = 500;

--- a/AdobeIms/Controller/Adminhtml/User/Profile.php
+++ b/AdobeIms/Controller/Adminhtml/User/Profile.php
@@ -10,6 +10,8 @@ namespace Magento\AdobeIms\Controller\Adminhtml\User;
 use Magento\AdobeImsApi\Api\UserProfileRepositoryInterface;
 use Magento\Authorization\Model\UserContextInterface;
 use Magento\Backend\App\Action;
+use Magento\Framework\App\Action\HttpGetActionInterface;
+use Magento\Framework\App\Action\HttpPostActionInterface;
 use Magento\Framework\Controller\ResultFactory;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Psr\Log\LoggerInterface;
@@ -17,7 +19,7 @@ use Psr\Log\LoggerInterface;
 /**
  * Get Adobe services user account action
  */
-class Profile extends Action
+class Profile extends Action implements HttpGetActionInterface, HttpPostActionInterface
 {
     /**
      * Successful result code.

--- a/AdobeIms/Controller/Adminhtml/User/Profile.php
+++ b/AdobeIms/Controller/Adminhtml/User/Profile.php
@@ -10,7 +10,7 @@ namespace Magento\AdobeIms\Controller\Adminhtml\User;
 use Magento\AdobeImsApi\Api\UserProfileRepositoryInterface;
 use Magento\Authorization\Model\UserContextInterface;
 use Magento\Backend\App\Action;
-use Magento\Framework\App\Action\HttpPostActionInterface;
+use Magento\Framework\App\Action\HttpGetActionInterface;
 use Magento\Framework\Controller\ResultFactory;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Psr\Log\LoggerInterface;
@@ -18,7 +18,7 @@ use Psr\Log\LoggerInterface;
 /**
  * Get Adobe services user account action
  */
-class Profile extends Action implements HttpPostActionInterface
+class Profile extends Action implements HttpGetActionInterface
 {
     /**
      * Successful result code.

--- a/AdobeIms/Controller/Adminhtml/User/Profile.php
+++ b/AdobeIms/Controller/Adminhtml/User/Profile.php
@@ -10,7 +10,6 @@ namespace Magento\AdobeIms\Controller\Adminhtml\User;
 use Magento\AdobeImsApi\Api\UserProfileRepositoryInterface;
 use Magento\Authorization\Model\UserContextInterface;
 use Magento\Backend\App\Action;
-use Magento\Framework\App\Action\HttpGetActionInterface;
 use Magento\Framework\App\Action\HttpPostActionInterface;
 use Magento\Framework\Controller\ResultFactory;
 use Magento\Framework\Exception\NoSuchEntityException;
@@ -19,7 +18,7 @@ use Psr\Log\LoggerInterface;
 /**
  * Get Adobe services user account action
  */
-class Profile extends Action implements HttpGetActionInterface, HttpPostActionInterface
+class Profile extends Action implements HttpPostActionInterface
 {
     /**
      * Successful result code.

--- a/AdobeIms/view/adminhtml/web/js/signIn.js
+++ b/AdobeIms/view/adminhtml/web/js/signIn.js
@@ -80,7 +80,7 @@ define([
          */
         loadUserProfile: function () {
             $.ajax({
-                type: 'POST',
+                type: 'GET',
                 url: this.profileUrl,
                 showLoader: true,
                 data: {

--- a/AdobeIms/view/adminhtml/web/js/signIn.js
+++ b/AdobeIms/view/adminhtml/web/js/signIn.js
@@ -83,9 +83,6 @@ define([
                 type: 'GET',
                 url: this.profileUrl,
                 showLoader: true,
-                data: {
-                    'form_key': window.FORM_KEY
-                },
                 dataType: 'json',
                 context: this,
 

--- a/AdobeStockAdminUi/Controller/Adminhtml/System/Config/TestConnection.php
+++ b/AdobeStockAdminUi/Controller/Adminhtml/System/Config/TestConnection.php
@@ -12,6 +12,7 @@ use Magento\AdobeStockClientApi\Api\ClientInterface;
 use Magento\AdobeImsApi\Api\ConfigInterface;
 use Magento\Backend\App\Action;
 use Magento\Backend\App\Action\Context;
+use Magento\Framework\App\Action\HttpPostActionInterface;
 use Magento\Framework\Controller\Result\Json;
 use Magento\Framework\Controller\Result\JsonFactory;
 use Magento\Framework\Controller\ResultInterface;
@@ -19,7 +20,7 @@ use Magento\Framework\Controller\ResultInterface;
 /**
  * Controller used for testing connection to Adobe Stock API from stores configuration
  */
-class TestConnection extends Action
+class TestConnection extends Action implements HttpPostActionInterface
 {
     /**
      * Authorization level of a basic admin session.

--- a/AdobeStockAdminUi/Controller/Adminhtml/System/Config/TestConnection.php
+++ b/AdobeStockAdminUi/Controller/Adminhtml/System/Config/TestConnection.php
@@ -12,7 +12,7 @@ use Magento\AdobeStockClientApi\Api\ClientInterface;
 use Magento\AdobeImsApi\Api\ConfigInterface;
 use Magento\Backend\App\Action;
 use Magento\Backend\App\Action\Context;
-use Magento\Framework\App\Action\HttpPostActionInterface;
+use Magento\Framework\App\Action\HttpGetActionInterface;
 use Magento\Framework\Controller\Result\Json;
 use Magento\Framework\Controller\Result\JsonFactory;
 use Magento\Framework\Controller\ResultInterface;
@@ -20,7 +20,7 @@ use Magento\Framework\Controller\ResultInterface;
 /**
  * Controller used for testing connection to Adobe Stock API from stores configuration
  */
-class TestConnection extends Action implements HttpPostActionInterface
+class TestConnection extends Action implements HttpGetActionInterface
 {
     /**
      * Authorization level of a basic admin session.

--- a/AdobeStockAdminUi/view/adminhtml/web/js/connection.js
+++ b/AdobeStockAdminUi/view/adminhtml/web/js/connection.js
@@ -75,7 +75,7 @@ define([
             this.visible(false);
 
             $.ajax({
-                type: 'POST',
+                type: 'GET',
                 url: this.url,
                 dataType: 'json',
                 data: {

--- a/AdobeStockImageAdminUi/Controller/Adminhtml/License/Confirmation.php
+++ b/AdobeStockImageAdminUi/Controller/Adminhtml/License/Confirmation.php
@@ -10,7 +10,7 @@ namespace Magento\AdobeStockImageAdminUi\Controller\Adminhtml\License;
 
 use Magento\AdobeStockClientApi\Api\ClientInterface;
 use Magento\Backend\App\Action;
-use Magento\Framework\App\Action\HttpPostActionInterface;
+use Magento\Framework\App\Action\HttpGetActionInterface;
 use Magento\Framework\Controller\Result\Json;
 use Magento\Framework\Controller\ResultFactory;
 use Psr\Log\LoggerInterface;
@@ -18,7 +18,7 @@ use Psr\Log\LoggerInterface;
 /**
  * Backend controller for retrieving license confirmation before purchasing an asset
  */
-class Confirmation extends Action implements HttpPostActionInterface
+class Confirmation extends Action implements HttpGetActionInterface
 {
     private const HTTP_OK = 200;
     private const HTTP_INTERNAL_ERROR = 500;

--- a/AdobeStockImageAdminUi/Controller/Adminhtml/License/Confirmation.php
+++ b/AdobeStockImageAdminUi/Controller/Adminhtml/License/Confirmation.php
@@ -10,6 +10,7 @@ namespace Magento\AdobeStockImageAdminUi\Controller\Adminhtml\License;
 
 use Magento\AdobeStockClientApi\Api\ClientInterface;
 use Magento\Backend\App\Action;
+use Magento\Framework\App\Action\HttpPostActionInterface;
 use Magento\Framework\Controller\Result\Json;
 use Magento\Framework\Controller\ResultFactory;
 use Psr\Log\LoggerInterface;
@@ -17,7 +18,7 @@ use Psr\Log\LoggerInterface;
 /**
  * Backend controller for retrieving license confirmation before purchasing an asset
  */
-class Confirmation extends Action
+class Confirmation extends Action implements HttpPostActionInterface
 {
     private const HTTP_OK = 200;
     private const HTTP_INTERNAL_ERROR = 500;

--- a/AdobeStockImageAdminUi/Controller/Adminhtml/License/GetList.php
+++ b/AdobeStockImageAdminUi/Controller/Adminhtml/License/GetList.php
@@ -9,6 +9,7 @@ namespace Magento\AdobeStockImageAdminUi\Controller\Adminhtml\License;
 
 use Magento\AdobeStockClientApi\Api\Client\FilesInterface;
 use Magento\Backend\App\Action;
+use Magento\Framework\App\Action\HttpPostActionInterface;
 use Magento\Framework\Controller\Result\Json;
 use Magento\Framework\Controller\ResultFactory;
 use Psr\Log\LoggerInterface;
@@ -16,7 +17,7 @@ use Psr\Log\LoggerInterface;
 /**
  * Identify if images are licensed in adobe stock
  */
-class GetList extends Action
+class GetList extends Action implements HttpPostActionInterface
 {
     private const HTTP_OK = 200;
     private const HTTP_INTERNAL_ERROR = 500;

--- a/AdobeStockImageAdminUi/Controller/Adminhtml/License/GetList.php
+++ b/AdobeStockImageAdminUi/Controller/Adminhtml/License/GetList.php
@@ -9,7 +9,7 @@ namespace Magento\AdobeStockImageAdminUi\Controller\Adminhtml\License;
 
 use Magento\AdobeStockClientApi\Api\Client\FilesInterface;
 use Magento\Backend\App\Action;
-use Magento\Framework\App\Action\HttpPostActionInterface;
+use Magento\Framework\App\Action\HttpGetActionInterface;
 use Magento\Framework\Controller\Result\Json;
 use Magento\Framework\Controller\ResultFactory;
 use Psr\Log\LoggerInterface;
@@ -17,7 +17,7 @@ use Psr\Log\LoggerInterface;
 /**
  * Identify if images are licensed in adobe stock
  */
-class GetList extends Action implements HttpPostActionInterface
+class GetList extends Action implements HttpGetActionInterface
 {
     private const HTTP_OK = 200;
     private const HTTP_INTERNAL_ERROR = 500;

--- a/AdobeStockImageAdminUi/Controller/Adminhtml/License/License.php
+++ b/AdobeStockImageAdminUi/Controller/Adminhtml/License/License.php
@@ -11,6 +11,7 @@ namespace Magento\AdobeStockImageAdminUi\Controller\Adminhtml\License;
 use Magento\AdobeStockClientApi\Api\ClientInterface;
 use Magento\AdobeStockImageApi\Api\SaveLicensedImageInterface;
 use Magento\Backend\App\Action;
+use Magento\Framework\App\Action\HttpPostActionInterface;
 use Magento\Framework\Controller\Result\Json;
 use Magento\Framework\Controller\ResultFactory;
 use Magento\Framework\Exception\LocalizedException;
@@ -19,7 +20,7 @@ use Psr\Log\LoggerInterface;
 /**
  * Backend controller for licensing and downloading an image
  */
-class License extends Action
+class License extends Action implements HttpPostActionInterface
 {
     private const HTTP_OK = 200;
     private const HTTP_INTERNAL_ERROR = 500;

--- a/AdobeStockImageAdminUi/Controller/Adminhtml/License/Quota.php
+++ b/AdobeStockImageAdminUi/Controller/Adminhtml/License/Quota.php
@@ -10,13 +10,14 @@ namespace Magento\AdobeStockImageAdminUi\Controller\Adminhtml\License;
 
 use Magento\AdobeStockClientApi\Api\ClientInterface;
 use Magento\Backend\App\Action;
+use Magento\Framework\App\Action\HttpPostActionInterface;
 use Magento\Framework\Controller\ResultFactory;
 use Psr\Log\LoggerInterface;
 
 /**
  * Backend controller for retrieving license quota for the current user
  */
-class Quota extends Action
+class Quota extends Action implements HttpPostActionInterface
 {
     private const HTTP_OK = 200;
     private const HTTP_INTERNAL_ERROR = 500;

--- a/AdobeStockImageAdminUi/Controller/Adminhtml/License/Quota.php
+++ b/AdobeStockImageAdminUi/Controller/Adminhtml/License/Quota.php
@@ -10,14 +10,15 @@ namespace Magento\AdobeStockImageAdminUi\Controller\Adminhtml\License;
 
 use Magento\AdobeStockClientApi\Api\ClientInterface;
 use Magento\Backend\App\Action;
-use Magento\Framework\App\Action\HttpPostActionInterface;
+use Magento\Framework\App\Action\HttpGetActionInterface;
+use Magento\Framework\Controller\Result\Json;
 use Magento\Framework\Controller\ResultFactory;
 use Psr\Log\LoggerInterface;
 
 /**
  * Backend controller for retrieving license quota for the current user
  */
-class Quota extends Action implements HttpPostActionInterface
+class Quota extends Action implements HttpGetActionInterface
 {
     private const HTTP_OK = 200;
     private const HTTP_INTERNAL_ERROR = 500;
@@ -80,7 +81,7 @@ class Quota extends Action implements HttpPostActionInterface
             ];
         }
 
-        /** @var \Magento\Framework\Controller\Result\Json $resultJson */
+        /** @var Json $resultJson */
         $resultJson = $this->resultFactory->create(ResultFactory::TYPE_JSON);
         $resultJson->setHttpResponseCode($responseCode);
         $resultJson->setData($responseContent);

--- a/AdobeStockImageAdminUi/Controller/Adminhtml/License/SaveLicensed.php
+++ b/AdobeStockImageAdminUi/Controller/Adminhtml/License/SaveLicensed.php
@@ -10,6 +10,7 @@ namespace Magento\AdobeStockImageAdminUi\Controller\Adminhtml\License;
 
 use Magento\AdobeStockImageApi\Api\SaveLicensedImageInterface;
 use Magento\Backend\App\Action;
+use Magento\Framework\App\Action\HttpPostActionInterface;
 use Magento\Framework\Controller\Result\Json;
 use Magento\Framework\Controller\ResultFactory;
 use Magento\Framework\Exception\LocalizedException;
@@ -18,7 +19,7 @@ use Psr\Log\LoggerInterface;
 /**
  * Backend controller for saving licensed image
  */
-class SaveLicensed extends Action
+class SaveLicensed extends Action implements HttpPostActionInterface
 {
     private const HTTP_OK = 200;
     private const HTTP_INTERNAL_ERROR = 500;

--- a/AdobeStockImageAdminUi/Controller/Adminhtml/Preview/Download.php
+++ b/AdobeStockImageAdminUi/Controller/Adminhtml/Preview/Download.php
@@ -11,6 +11,7 @@ namespace Magento\AdobeStockImageAdminUi\Controller\Adminhtml\Preview;
 use Magento\AdobeStockAssetApi\Api\GetAssetByIdInterface;
 use Magento\AdobeStockImageApi\Api\SaveImageInterface;
 use Magento\Backend\App\Action;
+use Magento\Framework\App\Action\HttpPostActionInterface;
 use Magento\Framework\Controller\Result\Json;
 use Magento\Framework\Controller\ResultFactory;
 use Magento\Framework\Exception\LocalizedException;
@@ -19,7 +20,7 @@ use Psr\Log\LoggerInterface;
 /**
  * Controller for downloading the Adobe Stock asset preview by the id
  */
-class Download extends Action
+class Download extends Action implements HttpPostActionInterface
 {
     private const HTTP_OK = 200;
     private const HTTP_BAD_REQUEST = 400;

--- a/AdobeStockImageAdminUi/Controller/Adminhtml/Preview/RelatedImages.php
+++ b/AdobeStockImageAdminUi/Controller/Adminhtml/Preview/RelatedImages.php
@@ -9,6 +9,7 @@ namespace Magento\AdobeStockImageAdminUi\Controller\Adminhtml\Preview;
 
 use Magento\AdobeStockImageApi\Api\GetRelatedImagesInterface;
 use Magento\Backend\App\Action;
+use Magento\Framework\App\Action\HttpGetActionInterface;
 use Magento\Framework\Controller\Result\Json;
 use Magento\Framework\Controller\ResultFactory;
 use Psr\Log\LoggerInterface;
@@ -16,7 +17,7 @@ use Psr\Log\LoggerInterface;
 /**
  * Controller providing related images (same model and same series) for the provided Adobe Stock asset id
  */
-class RelatedImages extends Action
+class RelatedImages extends Action implements HttpGetActionInterface
 {
     private const HTTP_OK = 200;
     private const HTTP_INTERNAL_ERROR = 500;

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/actions.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/actions.js
@@ -24,7 +24,6 @@ define([
             downloadImagePreviewUrl: 'adobe_stock/preview/download',
             licenseAndDownloadUrl: 'adobe_stock/license/license',
             saveLicensedAndDownloadUrl: 'adobe_stock/license/saveLicensed',
-            confirmationUrl: 'adobe_stock/license/confirmation',
             buyCreditsUrl: 'https://stock.adobe.com/',
             messageDelay: 5,
             listens: {
@@ -283,7 +282,7 @@ define([
         showLicenseConfirmation: function (record) {
             $.ajax(
                 {
-                    type: 'POST',
+                    type: 'GET',
                     url: this.preview().confirmationUrl,
                     dataType: 'json',
                     data: {

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/signIn.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/signIn.js
@@ -126,7 +126,7 @@ define([
          */
         getUserQuota: function () {
             $.ajax({
-                type: 'POST',
+                type: 'GET',
                 url: this.quotaUrl,
                 data: {
                     'form_key': window.FORM_KEY
@@ -157,7 +157,7 @@ define([
          */
         loadUserProfile: function () {
             $.ajax({
-                type: 'POST',
+                type: 'GET',
                 url: this.profileUrl,
                 data: {
                     'form_key': window.FORM_KEY

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/signIn.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/signIn.js
@@ -128,9 +128,6 @@ define([
             $.ajax({
                 type: 'GET',
                 url: this.quotaUrl,
-                data: {
-                    'form_key': window.FORM_KEY
-                },
                 dataType: 'json',
                 context: this,
 
@@ -159,9 +156,6 @@ define([
             $.ajax({
                 type: 'GET',
                 url: this.profileUrl,
-                data: {
-                    'form_key': window.FORM_KEY
-                },
                 dataType: 'json',
                 context: this,
 

--- a/MediaGalleryUi/Controller/Adminhtml/Directories/GetTree.php
+++ b/MediaGalleryUi/Controller/Adminhtml/Directories/GetTree.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 namespace Magento\MediaGalleryUi\Controller\Adminhtml\Directories;
 
 use Magento\Backend\App\Action;
+use Magento\Framework\App\Action\HttpPostActionInterface;
 use Magento\Framework\Controller\Result\Json;
 use Magento\Framework\Controller\ResultFactory;
 use Magento\MediaGalleryUi\Model\Directories\FolderTree;
@@ -16,7 +17,7 @@ use Psr\Log\LoggerInterface;
 /**
  * Returns all available directories
  */
-class GetTree extends Action
+class GetTree extends Action implements HttpPostActionInterface
 {
     private const HTTP_OK = 200;
     private const HTTP_INTERNAL_ERROR = 500;

--- a/MediaGalleryUi/Controller/Adminhtml/Directories/GetTree.php
+++ b/MediaGalleryUi/Controller/Adminhtml/Directories/GetTree.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
 namespace Magento\MediaGalleryUi\Controller\Adminhtml\Directories;
 
 use Magento\Backend\App\Action;
-use Magento\Framework\App\Action\HttpPostActionInterface;
+use Magento\Framework\App\Action\HttpGetActionInterface;
 use Magento\Framework\Controller\Result\Json;
 use Magento\Framework\Controller\ResultFactory;
 use Magento\MediaGalleryUi\Model\Directories\FolderTree;
@@ -17,7 +17,7 @@ use Psr\Log\LoggerInterface;
 /**
  * Returns all available directories
  */
-class GetTree extends Action implements HttpPostActionInterface
+class GetTree extends Action implements HttpGetActionInterface
 {
     private const HTTP_OK = 200;
     private const HTTP_INTERNAL_ERROR = 500;

--- a/MediaGalleryUi/Controller/Adminhtml/Index/Index.php
+++ b/MediaGalleryUi/Controller/Adminhtml/Index/Index.php
@@ -9,13 +9,14 @@ namespace Magento\MediaGalleryUi\Controller\Adminhtml\Index;
 
 use Magento\Backend\App\Action;
 use Magento\Backend\App\Action\Context;
+use Magento\Framework\App\Action\HttpGetActionInterface;
 use Magento\Framework\View\Result\LayoutFactory;
 use Magento\Framework\View\Result\Layout;
 
 /**
  * Controller serving the media gallery content
  */
-class Index extends Action
+class Index extends Action implements HttpGetActionInterface
 {
     const ADMIN_RESOURCE = 'Magento_Cms::media_gallery';
 

--- a/MediaGalleryUi/view/adminhtml/web/js/directory/directoryTree.js
+++ b/MediaGalleryUi/view/adminhtml/web/js/directory/directoryTree.js
@@ -84,12 +84,8 @@ define([
                 url: this.getDirectoryTreeUrl,
                 type: 'GET',
                 dataType: 'json',
-                data: {
-                    'form_key': FORM_KEY
-                },
-
                 /**
-                 * Succes handler for request
+                 * Success handler for request
                  *
                  * @param {Object} data
                  */

--- a/MediaGalleryUi/view/adminhtml/web/js/directory/directoryTree.js
+++ b/MediaGalleryUi/view/adminhtml/web/js/directory/directoryTree.js
@@ -3,7 +3,6 @@
  * See COPYING.txt for license details.
  */
 
-/* global FORM_KEY */
 define([
     'jquery',
     'uiComponent',
@@ -84,6 +83,7 @@ define([
                 url: this.getDirectoryTreeUrl,
                 type: 'GET',
                 dataType: 'json',
+
                 /**
                  * Success handler for request
                  *

--- a/MediaGalleryUi/view/adminhtml/web/js/directory/directoryTree.js
+++ b/MediaGalleryUi/view/adminhtml/web/js/directory/directoryTree.js
@@ -82,7 +82,7 @@ define([
         getJsonTree: function () {
             $.ajax({
                 url: this.getDirectoryTreeUrl,
-                type: 'POST',
+                type: 'GET',
                 dataType: 'json',
                 data: {
                     'form_key': FORM_KEY


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR will enhance the security for the controllers. As per Magento Architecure, To improve security and logistics we need to allow limiting Actions to processing only requests with certain HTTP methods and add those limitations to as many existing Actions as possible. There are many vulnerabilities caused by actions processing both GET and POST requests and thus allowing bypassing security validations like form key validation. Also limiting actions to processing only requests with certain methods would serve as self-documentation for Action classes and improve consistency of server side for client code and functional tests.
More Information:- https://github.com/magento/architecture/blob/514952e8883234140071ec70f3b696d8267d52d0/design-documents/allowed-http-methods-for-actions.md

