### PR TITLE
#865 : Possible to open several "Sign In Adobe ID" windows

### DIFF
--- a/AdobeIms/view/adminhtml/web/js/action/authorization.js
+++ b/AdobeIms/view/adminhtml/web/js/action/authorization.js
@@ -32,6 +32,13 @@ define([], function () {
         var authWindow;
 
         /**
+         * Close authorization window if already opened
+         */
+        if (window.adobeIMSAuthWindow) {
+            window.adobeIMSAuthWindow.close();
+        }
+
+        /**
          * Opens authorization window with special parameters
          */
         authWindow = window.adobeIMSAuthWindow = window.open(


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR will fix the issue for opening several signin windows when user tries to login or licensing the image
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/adobe-stock-integration#865: Possible to open several "Sign In Adobe ID" windows
### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Login to Admin panel
1. Open media gallery (**Content** - **Pages**, click **Add New Page**, expand **Content**, select **Insert Image...**)
3. Click **Search Adobe Stock**
4. Click **Sign In** link in the top right corner
5. When the login window opens, switch back to Magento window and click "Sign in" link again or "License and save" button

### Expected Result
Previous window will close before opening new one