### PR TITLE
#891: [Bug] Attempt to license image the second time if user is not logged in when initiating the licensing process 

### DIFF
--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/actions.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/actions.js
@@ -426,9 +426,20 @@ define([
          * Process of license
          */
         licenseProcess: function () {
+            $.ajaxSetup({
+                async: false
+            });
             this.login().login()
                 .then(function () {
-                    this.showLicenseConfirmation(this.preview().displayedRecord());
+                    if (this.isLicensed()) {
+                        this.saveLicensed();
+                    }
+                    else {
+                        this.showLicenseConfirmation(this.preview().displayedRecord());
+                    }
+                    $.ajaxSetup({
+                        async: true
+                    });
                 }.bind(this))
                 .catch(function (error) {
                     this.messages().add('error', error);

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/actions.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/actions.js
@@ -433,8 +433,7 @@ define([
                 .then(function () {
                     if (this.isLicensed()) {
                         this.saveLicensed();
-                    }
-                    else {
+                    } else {
                         this.showLicenseConfirmation(this.preview().displayedRecord());
                     }
                     $.ajaxSetup({


### PR DESCRIPTION


<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR will fix the issue with the licensing quota dialog box will not visible to the user if the image is licensed outside adobe stock integration or already licensed before
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/adobe-stock-integration#891: [Bug] Attempt to license image the second time if user is not logged in when initiating the licensing process 

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. From Admin go to **Content** - **Pages**, click **Add New Page**
2. Expand **Content**,click **Show / Hide Editor**, click **Insert Image...**
3. Click **Search Adobe Stock**, do NOT Sign In
4. Select an image that you know is already Licensed, and not saved to the Gallery 
5.  Click **License and Save** and Sign in with Adobe ID

### Expected Result
If Image preview is not saved
![image](https://user-images.githubusercontent.com/39480008/75546701-2f421e80-5a4f-11ea-9d26-902a3213e259.png)