### PR TITLE
Provide Delete Folder functionality for DirectoryTree

### DIFF
--- a/MediaContent/etc/module.xml
+++ b/MediaContent/etc/module.xml
@@ -8,7 +8,7 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
     <module name="Magento_MediaContent">
         <sequence>
-            <module name="Magento_AdobeStockAsset"/>
+            <module name="Magento_MediaGallery"/>
         </sequence>
     </module>
 </config>

--- a/MediaGalleryUi/Controller/Adminhtml/Directories/Delete.php
+++ b/MediaGalleryUi/Controller/Adminhtml/Directories/Delete.php
@@ -45,7 +45,7 @@ class Delete extends Action implements HttpPostActionInterface
      * Delete constructor.
      *
      * @param Context $context
-     * @param DeleteByPath $driver
+     * @param DeleteByPath $deleteFolderByPath
      * @param LoggerInterface $logger
      */
     public function __construct(

--- a/MediaGalleryUi/Controller/Adminhtml/Directories/Delete.php
+++ b/MediaGalleryUi/Controller/Adminhtml/Directories/Delete.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\MediaGalleryUi\Controller\Adminhtml\Directories;
+
+use Exception;
+use Magento\Backend\App\Action;
+use Magento\Backend\App\Action\Context;
+use Magento\Framework\Controller\Result\Json;
+use Magento\Framework\Controller\ResultFactory;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\MediaGalleryUi\Model\Directories\DeleteByPath;
+use Psr\Log\LoggerInterface;
+use Magento\Framework\App\Action\HttpPostActionInterface;
+
+/**
+ * Controller deleting the folders
+ */
+class Delete extends Action implements HttpPostActionInterface
+{
+    private const HTTP_OK = 200;
+    private const HTTP_INTERNAL_ERROR = 500;
+    private const HTTP_BAD_REQUEST = 400;
+
+    /**
+     * @see _isAllowed()
+     */
+    public const ADMIN_RESOURCE = 'Magento_Cms::media_gallery';
+
+    /**
+     * @var DeleteByPath
+     */
+    private $deleteFolderByPath;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * Delete constructor.
+     *
+     * @param Context $context
+     * @param DeleteByPath $driver
+     * @param LoggerInterface $logger
+     */
+    public function __construct(
+        Context $context,
+        DeleteByPath $deleteFolderByPath,
+        LoggerInterface $logger
+    ) {
+        parent::__construct($context);
+
+        $this->deleteFolderByPath = $deleteFolderByPath;
+        $this->logger = $logger;
+    }
+
+    /**
+     * Delete folder by provided path.
+     */
+    public function execute()
+    {
+        /** @var Json $resultJson */
+        $resultJson = $this->resultFactory->create(ResultFactory::TYPE_JSON);
+        $path = $this->getRequest()->getParam('path');
+
+        if (!$path) {
+            $responseContent = [
+                'success' => false,
+                'message' => __('Folder path parameter is required.'),
+            ];
+            $resultJson->setHttpResponseCode(self::HTTP_BAD_REQUEST);
+            $resultJson->setData($responseContent);
+
+            return $resultJson;
+        }
+
+        try {
+            $this->deleteFolderByPath->execute($path);
+
+            $responseCode = self::HTTP_OK;
+            $responseContent = [
+                'success' => true,
+                'message' => __('You have successfully removed the folder.'),
+            ];
+        } catch (LocalizedException $exception) {
+            $responseCode = self::HTTP_BAD_REQUEST;
+            $responseContent = [
+                'success' => false,
+                'message' => $exception->getMessage(),
+            ];
+        } catch (Exception $exception) {
+            $this->logger->critical($exception);
+            $responseCode = self::HTTP_INTERNAL_ERROR;
+            $responseContent = [
+                'success' => false,
+                'message' => __('An error occurred on attempt to remove folder.'),
+            ];
+        }
+
+        $resultJson->setHttpResponseCode($responseCode);
+        $resultJson->setData($responseContent);
+
+        return $resultJson;
+    }
+}

--- a/MediaGalleryUi/Model/Directories/DeleteByPath.php
+++ b/MediaGalleryUi/Model/Directories/DeleteByPath.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\MediaGalleryUi\Model\Directories;
+
+use Magento\Cms\Model\Wysiwyg\Images\Storage;
+use Magento\Framework\Exception\CouldNotDeleteException;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Delete folder by provided path
+ */
+class DeleteByPath
+{
+    /**
+      * @var LoggerInterface
+      */
+    private $logger;
+
+    /**
+     * @var Storage
+     */
+    private $storage;
+
+    /**
+     * @param LoggerInterface $logger
+     * @param Storage $storage
+     */
+    public function __construct(
+        LoggerInterface $logger,
+        Storage $storage
+    ) {
+        $this->logger = $logger;
+        $this->storage = $storage;
+    }
+
+    /**
+     * Deletes the existing folder
+     *
+     * @param string $path
+     * @throws CouldNotDeleteException
+     */
+    public function execute(string $path): void
+    {
+        try {
+            $this->storage->deleteDirectory($this->storage->getCmsWysiwygImages()->getStorageRoot() . $path);
+        } catch (\Exception $exception) {
+            $this->logger->critical($exception);
+            $message = __('Failed to delete the folder: %error', ['error' => $exception->getMessage()]);
+            throw new CouldNotDeleteException($message, $exception);
+        }
+    }
+}

--- a/MediaGalleryUi/Model/Directories/DeleteByPath.php
+++ b/MediaGalleryUi/Model/Directories/DeleteByPath.php
@@ -17,8 +17,8 @@ use Psr\Log\LoggerInterface;
 class DeleteByPath
 {
     /**
-      * @var LoggerInterface
-      */
+     * @var LoggerInterface
+     */
     private $logger;
 
     /**

--- a/MediaGalleryUi/Ui/Component/DirectoriesTree.php
+++ b/MediaGalleryUi/Ui/Component/DirectoriesTree.php
@@ -50,7 +50,8 @@ class DirectoriesTree extends Container
             array_replace_recursive(
                 (array) $this->getData('config'),
                 [
-                    'getDirectoryTreeUrl' => $this->url->getUrl("media_gallery/directories/gettree")
+                    'getDirectoryTreeUrl' => $this->url->getUrl("media_gallery/directories/gettree"),
+                    'deleteDirectoryUrl' => $this->url->getUrl("media_gallery/directories/delete")
                 ]
             )
         );

--- a/MediaGalleryUi/view/adminhtml/ui_component/media_gallery_listing.xml
+++ b/MediaGalleryUi/view/adminhtml/ui_component/media_gallery_listing.xml
@@ -26,6 +26,12 @@
                 <class>cancel action-quaternary</class>
                 <label translate="true">Cancel</label>
             </button>
+            <button name="delete_folder">
+                <param name="on_click" xsi:type="string">jQuery('#delete_folder').trigger('delete_folder');</param>
+		<param name="disabled" xsi:type="string">disabled</param>
+                <class>action-default scalable action-quaternary</class>
+                <label translate="true">Delete Folder</label>
+            </button>
         </buttons>
         <spinner>media_gallery_columns</spinner>
         <deps>

--- a/MediaGalleryUi/view/adminhtml/ui_component/media_gallery_listing.xml
+++ b/MediaGalleryUi/view/adminhtml/ui_component/media_gallery_listing.xml
@@ -28,7 +28,7 @@
             </button>
             <button name="delete_folder">
                 <param name="on_click" xsi:type="string">jQuery('#delete_folder').trigger('delete_folder');</param>
-		<param name="disabled" xsi:type="string">disabled</param>
+                <param name="disabled" xsi:type="string">disabled</param>
                 <class>action-default scalable action-quaternary</class>
                 <label translate="true">Delete Folder</label>
             </button>

--- a/MediaGalleryUi/view/adminhtml/web/js/directory/directories.js
+++ b/MediaGalleryUi/view/adminhtml/web/js/directory/directories.js
@@ -28,7 +28,7 @@ define([
          * @returns {Sticky} Chainable.
          */
         initialize: function () {
-            this._super().observe(['selectedFolder', 'activeNodeId']);
+            this._super().observe(['selectedFolder']);
             this.initEvents();
 
             return this;
@@ -80,10 +80,9 @@ define([
 
                 /**
                  * Success handler for Delete folder action
-                 *
                  */
                 success: function () {
-                    this.directoryTree().removeNode(this.activeNodeId());
+                    this.directoryTree().removeNode();
                 },
 
                 /**
@@ -111,11 +110,9 @@ define([
          * Set active node, remove disable state from Delete Forlder button
          *
          * @param {String} folderId
-         * @param {String} nodeId
          */
-        setActive: function (folderId, nodeId) {
+        setActive: function (folderId) {
             this.selectedFolder(folderId);
-            this.activeNodeId(nodeId);
             $(this.deleteButtonSelector).removeAttr('disabled').removeClass('disabled');
         }
     });

--- a/MediaGalleryUi/view/adminhtml/web/js/directory/directories.js
+++ b/MediaGalleryUi/view/adminhtml/web/js/directory/directories.js
@@ -108,9 +108,10 @@ define([
         },
 
         /**
-         * Set avtive delete button for selected folder
+         * Set active node, remove disable state from Delete Forlder button
          *
          * @param {String} folderId
+         * @param {String} nodeId
          */
         setActive: function (folderId, nodeId) {
             this.selectedFolder(folderId);

--- a/MediaGalleryUi/view/adminhtml/web/js/directory/directories.js
+++ b/MediaGalleryUi/view/adminhtml/web/js/directory/directories.js
@@ -1,0 +1,101 @@
+/**
+ * Copyright © Magento, Inc. All rights reserved.g
+ * See COPYING.txt for license details.
+ */
+
+define([
+    'jquery',
+    'uiComponent'
+], function ($, Component) {
+    'use strict';
+
+    return Component.extend({
+        defaults: {
+            directoryTreeSelector: '#media-gallery-directory-tree',
+            deleteButtonSelector: '#delete_folder',
+            messageDelay: 5,
+            messagesName: 'media_gallery_listing.media_gallery_listing.messages',
+            modules: {
+                directoryTree: '${ $.parentName }.media_gallery_directories',
+                messages: '${ $.messagesName }'
+            }
+        },
+
+        /**
+         * Initializes media gallery directories component.
+         *
+         * @returns {Sticky} Chainable.
+         */
+        initialize: function () {
+            this._super().observe(['selectedFolder']);
+            this.initEvents();
+
+            return this;
+        },
+
+        /**
+          * Initialize directories events
+          */
+        initEvents: function () {
+            $(this.deleteButtonSelector).on('delete_folder', function (path) {
+                this.deleteFolder(this.selectedFolder());
+            }.bind(this));
+        },
+
+        /**
+          * Delete folder action
+          *
+          * @param {String} path
+          * @param {Integer} nodeId
+          */
+        deleteFolder: function (path, nodeId) {
+            $.ajax({
+                type: 'POST',
+                url: this.directoryTree().deleteDirectoryUrl,
+                dataType: 'json',
+                showLoader: true,
+                data: {
+                    'path': path
+                },
+                context: this,
+
+                /**
+                 * Success handler for Delete folder action
+                 *
+                 */
+                success: function () {
+                    this.directoryTree().removeNode(nodeId);
+                },
+
+                /**
+                 * Error handler for Delete folder action
+                 *
+                 * @param {Object} response
+                 */
+                error: function (response) {
+                    var message;
+
+                    if (typeof response.responseJSON === 'undefined' ||
+                        typeof response.responseJSON.success === 'false'
+                    ) {
+                        message = 'There was an error on attempt to delete folder!';
+                    } else {
+                        message = response.responseJSON.message;
+                    }
+                    this.messages().add('error', message);
+                    this.messages().scheduleCleanup(this.messageDelay);
+                }
+            });
+        },
+
+        /**
+         * Set avtive delete button for selected folder
+         *
+         * @param {String} folderId
+         */
+        setActive: function (folderId) {
+            this.selectedFolder(folderId);
+            $(this.deleteButtonSelector).removeAttr('disabled').removeClass('disabled');
+        }
+    });
+});

--- a/MediaGalleryUi/view/adminhtml/web/js/directory/directoryTree.js
+++ b/MediaGalleryUi/view/adminhtml/web/js/directory/directoryTree.js
@@ -71,9 +71,10 @@ define([
          */
         initEvents: function () {
             $(this.directoryTreeSelector).on('select_node.jstree', function (element, data) {
-                var path = $(data.rslt.obj).data('path');
+                var path = $(data.rslt.obj).data('path'),
+                    nodeId = $(data.rslt.obj).data('id');
 
-                this.directories().setActive(path);
+                this.directories().setActive(path, nodeId);
                 this.applyFilter(path);
 
             }.bind(this));

--- a/MediaGalleryUi/view/adminhtml/web/js/directory/directoryTree.js
+++ b/MediaGalleryUi/view/adminhtml/web/js/directory/directoryTree.js
@@ -71,22 +71,19 @@ define([
          */
         initEvents: function () {
             $(this.directoryTreeSelector).on('select_node.jstree', function (element, data) {
-                var path = $(data.rslt.obj).data('path'),
-                    nodeId = $(data.rslt.obj).data('id');
+                var path = $(data.rslt.obj).data('path');
 
-                this.directories().setActive(path, nodeId);
+                this.directories().setActive(path);
                 this.applyFilter(path);
 
             }.bind(this));
         },
 
         /**
-          * Remove node from directory tree
-          *
-          * @param {String} nodeId
+          * Remove active node from directory tree, and select next
           */
-        removeNode: function (nodeId) {
-            $(this.directoryTreeSelector).jstree('remove', nodeId);
+        removeNode: function () {
+            $(this.directoryTreeSelector).jstree('remove');
         },
 
         /**

--- a/MediaGalleryUi/view/adminhtml/web/js/directory/directoryTree.js
+++ b/MediaGalleryUi/view/adminhtml/web/js/directory/directoryTree.js
@@ -6,8 +6,9 @@
 define([
     'jquery',
     'uiComponent',
+    'uiLayout',
     'jquery/jstree/jquery.jstree'
-], function ($, Component) {
+], function ($, Component, layout) {
     'use strict';
 
     return Component.extend({
@@ -16,8 +17,13 @@ define([
             directoryTreeSelector: '#media-gallery-directory-tree',
             getDirectoryTreeUrl: 'media_gallery/directories/gettree',
             modules: {
+                directories: '${ $.name }_directories',
                 filterChips: '${ $.filterChipsProvider }'
-            }
+            },
+            viewConfig: [{
+                component: 'Magento_MediaGalleryUi/js/directory/directories',
+                name: '${ $.name }_directories'
+            }]
         },
 
         /**
@@ -26,12 +32,23 @@ define([
          * @returns {Sticky} Chainable.
          */
         initialize: function () {
-            this._super();
+            this._super().initView();
 
             this.waitForContainer(function () {
                 this.getJsonTree();
                 this.initEvents();
             }.bind(this));
+
+            return this;
+        },
+
+        /**
+         * Initialize child components
+         *
+         * @returns {Object}
+         */
+        initView: function () {
+            layout(this.viewConfig);
 
             return this;
         },
@@ -54,10 +71,21 @@ define([
          */
         initEvents: function () {
             $(this.directoryTreeSelector).on('select_node.jstree', function (element, data) {
+                var path = $(data.rslt.obj).data('path');
 
-                this.applyFilter($(data.rslt.obj).data('path'));
+                this.directories().setActive(path);
+                this.applyFilter(path);
 
             }.bind(this));
+        },
+
+        /**
+          * Remove node from directory tree
+          *
+          * @param {String} nodeId
+          */
+        removeNode: function (nodeId) {
+            $(this.directoryTreeSelector).jstree('remove', nodeId);
         },
 
         /**


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->


"Delete Folder" button is present on the grid when a folder is selected. Click on the button opens a confirmation and once confirmed - deletes a selected folder with the contents
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/adobe-stock-integration#916:Provide Delete Folder functionality for DirectoryTree
2. ...

### Manual testing scenarios (*)
1. Install Magento and Adobe Stock Integration [See documentation](https://github.com/magento/adobe-stock-integration/wiki/Installation-Guide)
2. Login to Admin panel
3. Open Media Gallery (i.e. Catalog -> Category -> expand Content -> Select from Gallery button)
4. "Delete Folder" button is present on the grid when a folder is selected. Click on the button opens a confirmation and once confirmed - deletes a selected folder with the contents