### PR TITLE
[MFTF] Adobe Stock grid doesn't load with disabled `Enhanced Media Gallery`

### DIFF
--- a/AdobeStockImageAdminUi/Test/Mftf/ActionGroup/AdminAdobeStockImsPopupClickSignInActionGroup.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/ActionGroup/AdminAdobeStockImsPopupClickSignInActionGroup.xml
@@ -11,6 +11,7 @@
     <actionGroup name="AdminAdobeStockImsPopupClickSignInActionGroup">
         <click selector="{{AdobeStockSection.adobeImsPopupUserSignIn}}" stepKey="clickOnSignInButton"/>
         <makeScreenshot stepKey="postIMSSignInClickScreenshot" userInput="SignInClick"/>
+        <conditionalClick selector="#acceptBtn" dependentSelector=".permission-message" visible="true" stepKey="allowApplicationToAccessAdobeProfile"/>
         <switchToNextTab stepKey="switchToTab"/>
         <waitForPageLoad stepKey="waitForGridToReload" time="20"/>
     </actionGroup>

--- a/AdobeStockImageAdminUi/Test/Mftf/ActionGroup/AdminAdobeStockImsPopupClickSignInActionGroup.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/ActionGroup/AdminAdobeStockImsPopupClickSignInActionGroup.xml
@@ -11,7 +11,6 @@
     <actionGroup name="AdminAdobeStockImsPopupClickSignInActionGroup">
         <click selector="{{AdobeStockSection.adobeImsPopupUserSignIn}}" stepKey="clickOnSignInButton"/>
         <makeScreenshot stepKey="postIMSSignInClickScreenshot" userInput="SignInClick"/>
-        <conditionalClick selector="#acceptBtn" dependentSelector=".permission-message" visible="true" stepKey="allowApplicationToAccessAdobeProfile"/>
         <switchToNextTab stepKey="switchToTab"/>
         <waitForPageLoad stepKey="waitForGridToReload" time="20"/>
     </actionGroup>

--- a/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockLocalizationTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockLocalizationTest.xml
@@ -22,6 +22,8 @@
         </annotations>
         <before>
             <actionGroup ref="LoginAsAdmin" stepKey="loginAsAdmin"/>
+            <!-- Deploy ru_RU locale static content -->
+            <magentoCLI command="setup:static-content:deploy" arguments="-f ru_RU --area adminhtml" stepKey="staticDeployBeforeChangeLocaleToRU"/>
             <!--Set Admin "Interface Locale" to ru_RU-->
             <actionGroup ref="SetAdminAccountActionGroup" stepKey="setAdminInterfaceLocaleToDefaultValue">
                 <argument name="InterfaceLocaleByValue" value="ru_RU"/>

--- a/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockLocalizationTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockLocalizationTest.xml
@@ -48,7 +48,7 @@
             <argument name="keyword" value="машина"/>
         </actionGroup>
         <actionGroup ref="AssertAdminAdobeStockImagePreviewAttributeVisibleActionGroup" stepKey="assertCategoryLocalized">
-            <argument name="attributeName" value="Транспорт"/>
+            <argument name="attributeName" value="Индустрия"/>
         </actionGroup>
     </test>
 </tests>

--- a/AdobeStockImageAdminUi/view/adminhtml/layout/media_gallery_index_index.xml
+++ b/AdobeStockImageAdminUi/view/adminhtml/layout/media_gallery_index_index.xml
@@ -9,7 +9,7 @@
         xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/layout_generic.xsd">
     <referenceContainer name="root">
         <block class="Magento\Backend\Block\Template" name="stock.panel" template="Magento_AdobeStockImageAdminUi::panel.phtml" aclResource="Magento_AdobeStockImageAdminUi::save_preview_images">
-            <block class="Magento\AdobeIms\Block\Adminhtml\SignIn" name="adobe.signIn" template="Magento_AdobeIms::signIn.phtml" aclResource="Magento_AdobeStockImageAdminUi::save_preview_images">
+            <block class="Magento\AdobeIms\Block\Adminhtml\SignIn" name="adobe.signIn" template="Magento_AdobeIms::signIn.phtml" aclResource="Magento_AdobeIms::adobe_ims">
                 <arguments>
                     <argument name="configProviders" xsi:type="array">
                         <item name="adobe-stock" xsi:type="object">Magento\AdobeStockImageAdminUi\Model\SignInConfigProvider</item>

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/overlay.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/overlay.js
@@ -6,8 +6,9 @@
 // jscs:enable
 define([
     'Magento_Ui/js/grid/columns/overlay',
-    'jquery'
-], function (overlay, $) {
+    'jquery',
+    'underscore'
+], function (overlay, $, _) {
     'use strict';
 
     return overlay.extend({
@@ -44,7 +45,7 @@ define([
          * Set Licensed images data.
          */
         updateLicensed: function () {
-            if (!this.login().user().isAuthorized) {
+            if (_.isUndefined(this.login()) || !this.login().user().isAuthorized) {
                 this.licensed({});
 
                 return;


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Fixed Adobe Stock grid loading on old images grid with restricted access. Also updated acl for new images grid.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/adobe-stock-integration#<1015>: Adobe Stock grid doesn't load with disabled `Enhanced Media Gallery`

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
Please see https://github.com/magento/adobe-stock-integration/issues/1015