### PR TITLE
Fixed the issue with length attribute for varchar column

### DIFF
--- a/MediaContent/etc/db_schema.xml
+++ b/MediaContent/etc/db_schema.xml
@@ -8,9 +8,9 @@
 <schema xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Setup/Declaration/Schema/etc/schema.xsd">
     <table name="media_content_asset" resource="default" engine="innodb" comment="Relation between media content and media asset">
         <column xsi:type="int" padding="10" name="asset_id" unsigned="true" nullable="false" identity="true" comment="Entity ID"/>
-        <column xsi:type="varchar" padding="255" name="type" nullable="false" comment="Content type"/>
-        <column xsi:type="varchar" padding="255" name="entity_id" nullable="false" comment="Content entity id"/>
-        <column xsi:type="varchar" padding="255" name="field" nullable="false" comment="Content field"/>
+        <column xsi:type="varchar" length="255" name="type" nullable="false" comment="Content type"/>
+        <column xsi:type="varchar" length="255" name="entity_id" nullable="false" comment="Content entity id"/>
+        <column xsi:type="varchar" length="255" name="field" nullable="false" comment="Content field"/>
         <constraint xsi:type="primary" referenceId="PRIMARY">
             <column name="asset_id"/>
         </constraint>


### PR DESCRIPTION
### Description (*)
The error occurs during the setup script for **Magento_MediaContent** module.
The `padding` attribute is not allowed for the `varchar` column and we should use `length` attribute instead.

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios (*)
1. Enable the **Magento_MediaContent** module
2. Run *$ bin/magento setup:upgrade* 

As a result, you will see the following error:
```
The XML in file "/home/dev/sites/bravo/masi/ext/magento/stock-integration/MediaContent/etc/db_schema.xml" is invalid:
Element 'column', attribute 'padding': The attribute 'padding' is not allowed.
Line: 11

Element 'column', attribute 'padding': The attribute 'padding' is not allowed.
Line: 12

Element 'column', attribute 'padding': The attribute 'padding' is not allowed.
Line: 13

Verify the XML and try again.
```