### PR TITLE
Provide functionality to create folders in media gallery

### DIFF
--- a/MediaContent/composer.json
+++ b/MediaContent/composer.json
@@ -5,7 +5,7 @@
         "php": "~7.1.3||~7.2.0||~7.3.0",
         "magento/framework": "*",
         "magento/module-media-content-api": "*",
-        "magento/module-adobe-stock-asset-api": "*"
+        "magento/module-media-gallery": "*"
     },
     "type": "magento2-module",
     "license": [

--- a/MediaGalleryUi/Controller/Adminhtml/Directories/Create.php
+++ b/MediaGalleryUi/Controller/Adminhtml/Directories/Create.php
@@ -45,7 +45,7 @@ class Create extends Action implements HttpPostActionInterface
      * Delete constructor.
      *
      * @param Context $context
-     * @param CreateByPath $deleteFolderByPath
+     * @param CreateByPath $createFolderByPath
      * @param LoggerInterface $logger
      */
     public function __construct(

--- a/MediaGalleryUi/Controller/Adminhtml/Directories/Create.php
+++ b/MediaGalleryUi/Controller/Adminhtml/Directories/Create.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\MediaGalleryUi\Controller\Adminhtml\Directories;
+
+use Exception;
+use Magento\Backend\App\Action;
+use Magento\Backend\App\Action\Context;
+use Magento\Framework\Controller\Result\Json;
+use Magento\Framework\Controller\ResultFactory;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\MediaGalleryUi\Model\Directories\CreateByPath;
+use Psr\Log\LoggerInterface;
+use Magento\Framework\App\Action\HttpPostActionInterface;
+
+/**
+ * Controller to create the folders
+ */
+class Create extends Action implements HttpPostActionInterface
+{
+    private const HTTP_OK = 200;
+    private const HTTP_INTERNAL_ERROR = 500;
+    private const HTTP_BAD_REQUEST = 400;
+
+    /**
+     * @see _isAllowed()
+     */
+    public const ADMIN_RESOURCE = 'Magento_Cms::media_gallery';
+
+    /**
+     * @var CreateByPath
+     */
+    private $createFolderByPath;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * Delete constructor.
+     *
+     * @param Context $context
+     * @param CreateByPath $deleteFolderByPath
+     * @param LoggerInterface $logger
+     */
+    public function __construct(
+        Context $context,
+        CreateByPath $createFolderByPath,
+        LoggerInterface $logger
+    ) {
+        parent::__construct($context);
+
+        $this->createFolderByPath = $createFolderByPath;
+        $this->logger = $logger;
+    }
+
+    /**
+     * Create folder by provided path.
+     */
+    public function execute()
+    {
+        /** @var Json $resultJson */
+        $resultJson = $this->resultFactory->create(ResultFactory::TYPE_JSON);
+        $path = $this->getRequest()->getParam('path');
+        $name = $this->getRequest()->getParam('name');
+        
+        if (!$path && !$name) {
+            $responseContent = [
+                'success' => false,
+                'message' => __('Folder path and name parameter is required.'),
+            ];
+            $resultJson->setHttpResponseCode(self::HTTP_BAD_REQUEST);
+            $resultJson->setData($responseContent);
+
+            return $resultJson;
+        }
+
+        try {
+            $this->createFolderByPath->execute($path, $name);
+
+            $responseCode = self::HTTP_OK;
+            $responseContent = [
+                'success' => true,
+                'message' => __('You have successfully created the folder.'),
+            ];
+        } catch (LocalizedException $exception) {
+            $responseCode = self::HTTP_BAD_REQUEST;
+            $responseContent = [
+                'success' => false,
+                'message' => $exception->getMessage(),
+            ];
+        } catch (Exception $exception) {
+            $this->logger->critical($exception);
+            $responseCode = self::HTTP_INTERNAL_ERROR;
+            $responseContent = [
+                'success' => false,
+                'message' => __('An error occurred on attempt to cerate folder.'),
+            ];
+        }
+
+        $resultJson->setHttpResponseCode($responseCode);
+        $resultJson->setData($responseContent);
+
+        return $resultJson;
+    }
+}

--- a/MediaGalleryUi/Model/Directories/CreateByPath.php
+++ b/MediaGalleryUi/Model/Directories/CreateByPath.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\MediaGalleryUi\Model\Directories;
+
+use Magento\Cms\Model\Wysiwyg\Images\Storage;
+use Magento\Framework\Exception\CouldNotSaveException;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Create folder by provided path
+ */
+class CreateByPath
+{
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @var Storage
+     */
+    private $storage;
+
+    /**
+     * @param LoggerInterface $logger
+     * @param Storage $storage
+     */
+    public function __construct(
+        LoggerInterface $logger,
+        Storage $storage
+    ) {
+        $this->logger = $logger;
+        $this->storage = $storage;
+    }
+
+    /**
+     * Create new directory by provided path
+     *
+     * @param string $path
+     * @param string $name
+     * @throws CouldNotSaveException
+     */
+    public function execute(string $path, string $name): void
+    {
+        try {
+            $this->storage->createDirectory($name, $this->storage->getCmsWysiwygImages()->getStorageRoot() . $path);
+        } catch (\Exception $exception) {
+            $this->logger->critical($exception);
+            $message = __('Failed to create the folder: %error', ['error' => $exception->getMessage()]);
+            throw new CouldNotSaveException($message, $exception);
+        }
+    }
+}

--- a/MediaGalleryUi/Ui/Component/DirectoriesTree.php
+++ b/MediaGalleryUi/Ui/Component/DirectoriesTree.php
@@ -51,7 +51,8 @@ class DirectoriesTree extends Container
                 (array) $this->getData('config'),
                 [
                     'getDirectoryTreeUrl' => $this->url->getUrl("media_gallery/directories/gettree"),
-                    'deleteDirectoryUrl' => $this->url->getUrl("media_gallery/directories/delete")
+                    'deleteDirectoryUrl' => $this->url->getUrl("media_gallery/directories/delete"),
+                    'createDirectoryUrl' => $this->url->getUrl("media_gallery/directories/create")
                 ]
             )
         );

--- a/MediaGalleryUi/view/adminhtml/ui_component/media_gallery_listing.xml
+++ b/MediaGalleryUi/view/adminhtml/ui_component/media_gallery_listing.xml
@@ -32,6 +32,11 @@
                 <class>action-default scalable action-quaternary</class>
                 <label translate="true">Delete Folder</label>
             </button>
+            <button name="create_folder">
+                <param name="on_click" xsi:type="string">jQuery('#create_folder').trigger('create_folder');</param>
+                <class>action-default scalable add</class>
+                <label translate="true">Create Folder</label>
+            </button> 
         </buttons>
         <spinner>media_gallery_columns</spinner>
         <deps>

--- a/MediaGalleryUi/view/adminhtml/web/js/directory/directories.js
+++ b/MediaGalleryUi/view/adminhtml/web/js/directory/directories.js
@@ -42,7 +42,7 @@ define([
           */
         initEvents: function () {
             $(this.deleteButtonSelector).on('delete_folder', function () {
-                this.getComfirmationPopup();
+                this.getComfirmationPopupDeleteFolder();
             }.bind(this));
 
             $(this.createFolderButtonSelector).on('create_folder', function () {
@@ -124,13 +124,12 @@ define([
         createFolder: function (path, subPath) {
             var folder = _.isUndefined(subPath) ? '/' : subPath,
                 data = {
-                path: folder,
-                name: path
-            },
+                    path: folder,
+                    name: path
+                },
                 errorMessage = 'There was an error on attempt to create folder!',
                 callback = function () {
-                    this.directoryTree().getJsonTree();
-                    this.directoryTree().initEvents();
+                    this.directoryTree().reloadJsTee();
                 }.bind(this);
 
             this.sendPostRequest(this.directoryTree().createDirectoryUrl, data, errorMessage, callback);
@@ -158,9 +157,9 @@ define([
             },
 
         /**
-          * Confirmation popup template.
+          * Confirmation popup for delete folder action.
           */
-        getComfirmationPopup: function () {
+        getComfirmationPopupDeleteFolder: function () {
             confirm({
                 title: $.mage.__('Are you sure you want to delete ?'),
                 content: 'Are you sure you want to delete folder: ' + this.selectedFolder(),

--- a/MediaGalleryUi/view/adminhtml/web/js/directory/directories.js
+++ b/MediaGalleryUi/view/adminhtml/web/js/directory/directories.js
@@ -129,7 +129,7 @@ define([
                 },
                 errorMessage = 'There was an error on attempt to create folder!',
                 callback = function () {
-                    this.directoryTree().reloadJsTee();
+                    this.directoryTree().reloadJsTree();
                 }.bind(this);
 
             this.sendPostRequest(this.directoryTree().createDirectoryUrl, data, errorMessage, callback);

--- a/MediaGalleryUi/view/adminhtml/web/js/directory/directoryTree.js
+++ b/MediaGalleryUi/view/adminhtml/web/js/directory/directoryTree.js
@@ -32,7 +32,7 @@ define([
          * @returns {Sticky} Chainable.
          */
         initialize: function () {
-            this._super().observe(['selectedNode']).initView();
+            this._super().initView();
 
             this.waitForContainer(function () {
                 this.getJsonTree();
@@ -71,10 +71,8 @@ define([
          */
         initEvents: function () {
             $(this.directoryTreeSelector).on('select_node.jstree', function (element, data) {
-                var path = $(data.rslt.obj).data('path'),
-                    nodeId = $(data.rslt.obj).id;
+                var path = $(data.rslt.obj).data('path');
 
-                this.selectedNode(nodeId);
                 this.directories().setActive(path);
                 this.applyFilter(path);
 
@@ -101,6 +99,22 @@ define([
                     'directory': path
                 }
             );
+        },
+
+        /**
+         * Reload jstree and update jstreeevents
+         */
+        reloadJsTee: function () {
+            $.ajaxSetup({
+                async: false
+            });
+
+            this.getJsonTree();
+            this.initEvents();
+
+            $.ajaxSetup({
+                async: true
+            });
         },
 
         /**

--- a/MediaGalleryUi/view/adminhtml/web/js/directory/directoryTree.js
+++ b/MediaGalleryUi/view/adminhtml/web/js/directory/directoryTree.js
@@ -32,7 +32,7 @@ define([
          * @returns {Sticky} Chainable.
          */
         initialize: function () {
-            this._super().initView();
+            this._super().observe(['selectedNode']).initView();
 
             this.waitForContainer(function () {
                 this.getJsonTree();
@@ -71,8 +71,10 @@ define([
          */
         initEvents: function () {
             $(this.directoryTreeSelector).on('select_node.jstree', function (element, data) {
-                var path = $(data.rslt.obj).data('path');
+                var path = $(data.rslt.obj).data('path'),
+                    nodeId = $(data.rslt.obj).id;
 
+                this.selectedNode(nodeId);
                 this.directories().setActive(path);
                 this.applyFilter(path);
 

--- a/MediaGalleryUi/view/adminhtml/web/js/directory/directoryTree.js
+++ b/MediaGalleryUi/view/adminhtml/web/js/directory/directoryTree.js
@@ -104,7 +104,7 @@ define([
         /**
          * Reload jstree and update jstreeevents
          */
-        reloadJsTee: function () {
+        reloadJsTree: function () {
             $.ajaxSetup({
                 async: false
             });


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/adobe-stock-integration#915: Create Folder
2. ...

### Manual testing scenarios (*)

1. nstall Magento and Adobe Stock Integration [See documentation](https://github.com/magento/adobe-stock-integration/wiki/Installation-Guide)
2.  Login to Admin panel
3.  Open Media Gallery (i.e. Catalog -> Category -> expand Content -> Select from Gallery button)

"Create Folder" button is present on the grid. Click on the button opens a dialog that allows to specify the folder name, validates that the name does not contain special characters and is not in use and creates a requested folder as a subfolder of currently selected folder of the media gallery