### PR TITLE
#1012 : Add Delete Selcted button to media gallery page actions

### DIFF
--- a/MediaGalleryUi/view/adminhtml/ui_component/media_gallery_listing.xml
+++ b/MediaGalleryUi/view/adminhtml/ui_component/media_gallery_listing.xml
@@ -32,6 +32,11 @@
                 <class>action-default scalable action-quaternary</class>
                 <label translate="true">Delete Folder</label>
             </button>
+            <button name="delete_selected">
+                <param name="on_click" xsi:type="string">return false;</param>
+                <class>action-default scalable action-quaternary no-display</class>
+                <label translate="true">Delete Selected</label>
+            </button>
         </buttons>
         <spinner>media_gallery_columns</spinner>
         <deps>

--- a/MediaGalleryUi/view/adminhtml/web/js/grid/columns/image.js
+++ b/MediaGalleryUi/view/adminhtml/web/js/grid/columns/image.js
@@ -14,6 +14,7 @@ define([
             bodyTmpl: 'Magento_MediaGalleryUi/grid/columns/image',
             deleteImageUrl: 'media_gallery/image/delete',
             addSelectedBtnSelector: '#add_selected',
+            deleteSelectedBtnSelector: '#delete_selected',
             targetElementId: null,
             selected: null,
             fields: {
@@ -126,8 +127,10 @@ define([
         toggleAddSelectedButton: function () {
             if (this.selected() === null) {
                 $(this.addSelectedBtnSelector).addClass('no-display');
+                $(this.deleteSelectedBtnSelector).addClass('no-display');
             } else {
                 $(this.addSelectedBtnSelector).removeClass('no-display');
+                $(this.deleteSelectedBtnSelector).removeClass('no-display');
             }
         }
     });

--- a/MediaGalleryUi/view/adminhtml/web/js/grid/columns/image/actions.js
+++ b/MediaGalleryUi/view/adminhtml/web/js/grid/columns/image/actions.js
@@ -38,7 +38,9 @@ define([
             $(this.imageModel().addSelectedBtnSelector).click(function () {
                 this.insertImage();
             }.bind(this));
-
+            $(this.imageModel().deleteSelectedBtnSelector).click(function () {
+                this.deleteImageAction(this.imageModel().selected());
+            }.bind(this));
             return this;
         },
 
@@ -146,6 +148,8 @@ define([
                     message = message || $.mage.__('You have successfully removed the image.');
                     this.reloadGrid();
                     this.addMessage('success', message);
+                    $(this.imageModel().deleteSelectedBtnSelector).addClass('no-display');
+                    $(this.imageModel().addSelectedBtnSelector).addClass('no-display');
                 }.bind(this),
 
                 /**


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR will introduce the delete functionality for the image in enhanced image gallery
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/adobe-stock-integration#1012: Add Delete Selcted button to media gallery page actions

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
**Please ensure Enhanced media gallery is enabled**
1. Login to Admin panel
2. Go to Catalog -> Category
3. Select any category
4. Expand Content fieldset
5. Click "Select from Gallery" button next to "Category Image" field
6. Select any image in the media gallery
7. Click "Delete Selected" button

### Expected Result
Selected Image will be deleted
![image](https://user-images.githubusercontent.com/39480008/77247920-9bcdc900-6c5b-11ea-9f9e-e2199229d30e.png)
