### PR TITLE
Improve directory filter when click on the same folder, or reset grid…

### DIFF
--- a/MediaGalleryUi/view/adminhtml/web/js/directory/directories.js
+++ b/MediaGalleryUi/view/adminhtml/web/js/directory/directories.js
@@ -193,6 +193,14 @@ define([
         },
 
         /**
+         * Set inactive all nodes, adds disable state to Delete Folder Button
+         */
+        setInActive: function () {
+            this.selectedFolder(null);
+            $(this.deleteButtonSelector).attr('disabled', true).addClass('disabled');
+        },
+
+        /**
          * Set active node, remove disable state from Delete Forlder button
          *
          * @param {String} folderId

--- a/MediaGalleryUi/view/adminhtml/web/js/directory/directoryTree.js
+++ b/MediaGalleryUi/view/adminhtml/web/js/directory/directoryTree.js
@@ -98,11 +98,16 @@ define([
          * @param {String} nodePath
          */
         setActiveNodeFilter: function (nodePath) {
+            var filters = {},
+                applied = this.filterChips().get('applied');
 
             if (this.activeNode() === nodePath) {
 
                 $(this.directoryTreeSelector).jstree('deselect_all');
-                this.filterChips().set('applied', {});
+
+                filters = $.extend(true, filters, applied);
+                delete filters.directory;
+                this.filterChips().set('applied', filters);
                 this.activeNode(null);
                 this.directories().setInActive();
             } else {
@@ -125,9 +130,13 @@ define([
          * @param {String} path
          */
         applyFilter: function (path) {
-            this.filterChips().set('applied', {
-                'directory': path
-            });
+            var filters = {},
+                applied = this.filterChips().get('applied');
+
+            filters = $.extend(true, filters, applied);
+            filters.directory = path;
+            this.filterChips().set('applied', filters);
+
         },
 
         /**

--- a/MediaGalleryUi/view/adminhtml/web/js/directory/directoryTree.js
+++ b/MediaGalleryUi/view/adminhtml/web/js/directory/directoryTree.js
@@ -7,8 +7,9 @@ define([
     'jquery',
     'uiComponent',
     'uiLayout',
+    'underscore',
     'jquery/jstree/jquery.jstree'
-], function ($, Component, layout) {
+], function ($, Component, layout, _) {
     'use strict';
 
     return Component.extend({
@@ -19,6 +20,9 @@ define([
             modules: {
                 directories: '${ $.name }_directories',
                 filterChips: '${ $.filterChipsProvider }'
+            },
+            listens: {
+                '${ $.provider }:params.filters.directory': 'clearFiltersHandle'
             },
             viewConfig: [{
                 component: 'Magento_MediaGalleryUi/js/directory/directories',
@@ -32,7 +36,7 @@ define([
          * @returns {Sticky} Chainable.
          */
         initialize: function () {
-            this._super().initView();
+            this._super().observe(['activeNode']).initView();
 
             this.waitForContainer(function () {
                 this.getJsonTree();
@@ -67,16 +71,45 @@ define([
         },
 
         /**
-         *  Hendle jstree events
+         *  Handle jstree events
          */
         initEvents: function () {
             $(this.directoryTreeSelector).on('select_node.jstree', function (element, data) {
                 var path = $(data.rslt.obj).data('path');
 
-                this.directories().setActive(path);
-                this.applyFilter(path);
-
+                this.setActiveNodeFilter(path);
             }.bind(this));
+        },
+
+        /**
+         * Listener to clear filters event
+         */
+        clearFiltersHandle: function () {
+            if (_.isUndefined(this.filterChips().filters.directory)) {
+                $(this.directoryTreeSelector).jstree('deselect_all');
+                this.activeNode(null);
+                this.directories().setInActive();
+            }
+        },
+
+        /**
+         * Set active node filter, or deselect if the same node clicked
+         *
+         * @param {String} nodePath
+         */
+        setActiveNodeFilter: function (nodePath) {
+
+            if (this.activeNode() === nodePath) {
+
+                $(this.directoryTreeSelector).jstree('deselect_all');
+                this.filterChips().set('applied', {});
+                this.activeNode(null);
+                this.directories().setInActive();
+            } else {
+                this.activeNode(nodePath);
+                this.directories().setActive(nodePath);
+                this.applyFilter(nodePath);
+            }
         },
 
         /**
@@ -92,17 +125,13 @@ define([
          * @param {String} path
          */
         applyFilter: function (path) {
-
-            this.filterChips().set(
-                'applied',
-                {
-                    'directory': path
-                }
-            );
+            this.filterChips().set('applied', {
+                'directory': path
+            });
         },
 
         /**
-         * Reload jstree and update jstreeevents
+         * Reload jstree and update jstree events
          */
         reloadJsTree: function () {
             $.ajaxSetup({
@@ -170,7 +199,7 @@ define([
                     'types': {
                         'disabled': {
                             'check_node': true,
-                            'uncheck_node': false
+                            'uncheck_node': true
                         }
                     }
                 }


### PR DESCRIPTION
… filters

<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/adobe-stock-integration#961: Clicking on a selected folder in directory tree or dropping directory folder should remove the selecion for the tree 
2. magento/adobe-stock-integration#989: The selection/highlight doesn't disappear from the folder  

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->

1.     Login to Admin panel
2.     Open Media Gallery (i.e. Catalog -> Category -> expand Content -> Select from Gallery button)
3.     Click on any directory to select it
4.     4a. Click on the same directory again
5.     4b. Click on (x) icon next to applied directory filter
6.     4c. Clear all filters
