### PR TITLE
Add follow symlinks to support linked folders

### DIFF
--- a/MediaGalleryUi/Model/ImagesIndexer.php
+++ b/MediaGalleryUi/Model/ImagesIndexer.php
@@ -62,7 +62,9 @@ class ImagesIndexer implements ImagesIndexerInterface
         $this->filesIndexer->execute(
             $this->mediaDirectory->getAbsolutePath(),
             $this->indexers,
-            \FilesystemIterator::SKIP_DOTS | \FilesystemIterator::UNIX_PATHS,
+            \FilesystemIterator::SKIP_DOTS |
+            \FilesystemIterator::UNIX_PATHS |
+            \RecursiveDirectoryIterator::FOLLOW_SYMLINKS,
             self::IMAGE_FILE_NAME_PATTERN
         );
     }


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/adobe-stock-integration#1005: Media gallery indexer not working for linked directories in pub

### Manual testing scenarios (*)
AdobeStock 1.1-develop

1. Installed Magento with Adobe Stock Integration
2. Configured integration in Stores -> Configuration -> Advanced-> System -> Adobe Stock Integration fieldset
3. Sample data installed and linked from another folder

4. Run command php bin/magento media-gallery:index
5. Open Media Gallery images grid

 Catalog folder with images