### PR TITLE
#issue-1027 Fixed broken Media gallery layout in Safari browser

### DIFF
--- a/MediaGalleryUi/view/adminhtml/web/css/source/_module.less
+++ b/MediaGalleryUi/view/adminhtml/web/css/source/_module.less
@@ -170,6 +170,10 @@
             width: 29px;
             margin-bottom: -6px;
         }
+
+        .masonry-image-grid {
+            margin: 10px 0;
+        }
     }
 
     .media-gallery-image-details-modal {


### PR DESCRIPTION
### Description (*)
This PR removes the negative margin for the media gallery block.
The issue with the negative margin is well known for the Safari browser and I think that the negative margin (right and left -10px) is not needed for the Media gallery.
After removing the negative margin I did not notice any visual layout changes for the Media gallery and this issue disappears for the Safari browser.
<img width="1440" alt="Screenshot 2020-03-25 at 11 22 14" src="https://user-images.githubusercontent.com/31502344/77523846-0a469d00-6e8f-11ea-8078-692b6b85a8b4.png">


### Fixed Issues (if relevant)

1. magento/adobe-stock-integration#1027: Media gallery layout is broken in Safari

### Preconditions
Use the Safari web browser.

### Manual testing scenarios (*)

1. Login to Admin panel
2. Go to Catalog -> Category
3. Select any category
4. Expand Content fieldset
5. Click "Select from Gallery" button next to "Category Image" field