### PR TITLE
Remove ability to multiselect nodes in directoryTree

### DIFF
--- a/MediaGalleryUi/view/adminhtml/web/js/directory/directoryTree.js
+++ b/MediaGalleryUi/view/adminhtml/web/js/directory/directoryTree.js
@@ -71,9 +71,19 @@ define([
         },
 
         /**
+         * Remove ability to multiple select on nodes
+         */
+        overrideMultiselectBehavior: function () {
+            $.jstree.defaults.ui['select_range_modifier'] = false;
+            $.jstree.defaults.ui['select_multiple_modifier'] = false;
+        },
+
+        /**
          *  Handle jstree events
          */
         initEvents: function () {
+            this.overrideMultiselectBehavior();
+
             $(this.directoryTreeSelector).on('select_node.jstree', function (element, data) {
                 var path = $(data.rslt.obj).data('path');
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/adobe-stock-integration#980: Bug: Possible to select multiple directories in Media Gallery
2. ...

### Manual testing scenarios (*)

1. Installed Magento with Adobe Stock Integration
     Configured integration in Stores -> Configuration -> Advanced-> System -> Adobe Stock Integration fieldset
Enable Enhanced Media Gallery in Stores -> Configuration -> Advanced -> System
2.     From Admin go to Content - Pages, click Add New Page
3.     Expand Content,click Show / Hide Editor, click Insert Image...
4.     Press and hold Ctrl key on keyboard and using left mouse click, select two or more folders

Not possible to select multiple folders