### PR TITLE
#issue-990 Adjusted the logic of clicking on three dots and selecting highlighted image

### DIFF
--- a/MediaGalleryUi/view/adminhtml/web/template/grid/columns/image.html
+++ b/MediaGalleryUi/view/adminhtml/web/template/grid/columns/image.html
@@ -7,7 +7,10 @@
 <div class="media-gallery-wrap" collapsible>
     <div class="media-gallery-image">
         <div class="masonry-image-block media-gallery-image-block" attr="'data-id': $col.getId($row())" css="{ selected: isSelected($row()) }">
-            <img attr="src: $col.getUrl($row())" class="media-gallery-image-column" click="function(){ select($row()) }" data-role="thumbnail"/>
+            <img attr="src: $col.getUrl($row())"
+                 class="media-gallery-image-column"
+                 click="function(){ if (!$collapsible.opened()) {select($row())} }"
+                 data-role="thumbnail"/>
         </div>
         <ul class="action-menu" css="_active: $collapsible.opened">
             <!-- ko scope: actions -->
@@ -24,7 +27,9 @@
         </ul>
         <div class="media-gallery-image-actions">
             <div class="action-select-wrap">
-                <span class="three-dots" toggleCollapsible></span>
+                <span class="three-dots"
+                      toggleCollapsible
+                      click="function () {if (!isSelected($row()) || $collapsible.opened()) {select($row())}}"></span>
             </div>
         </div>
     </div>


### PR DESCRIPTION
### Description (*)
This PR fixes the issue with confusing behavior when a user clicks on three dots.
![Adobe Stock 990](https://user-images.githubusercontent.com/31502344/77540080-2821fb00-6eab-11ea-83a7-21f3485d964e.gif)


### Fixed Issues (if relevant)

1. magento/adobe-stock-integration#990: The image is not selected/highlighted when "three dots" action button is clicked [Media Gallery]

### Preconditions
Magento 2.4-develop
Adobe-Stock-Integration 1.1-develop

1. Installed Magento with Adobe Stock Integration
2. Configured integration in Stores -> Configuration -> Advanced-> System -> Adobe Stock Integration fieldset
3. Enable Enhanced Media Gallery in Stores -> Configuration -> Advanced -> System

### Manual testing scenarios (*)

1. From Admin go to Content - Pages, click Add New Page
2. Expand Content,click Show / Hide Editor, click Insert Image...
(all the images from Storage Root are displayed)
3. Click on the first image, so that it becomes highlighted/selected
4. Click on the three dots of the second image
