### PR TITLE
#issue-1042 Fixed sort order of media gallery grid buttons

### DIFF
--- a/AdobeStockImageAdminUi/view/adminhtml/ui_component/media_gallery_listing.xml
+++ b/AdobeStockImageAdminUi/view/adminhtml/ui_component/media_gallery_listing.xml
@@ -11,6 +11,7 @@
         <buttons>
             <button name="search_adobe_stock">
                 <param name="on_click" xsi:type="string">jQuery(".adobe-search-images-modal").trigger("openModal");</param>
+                <param name="sort_order" xsi:type="number">100</param>
                 <class>action-secondary</class>
                 <label translate="true">Search Adobe Stock</label>
             </button>

--- a/MediaGalleryUi/view/adminhtml/ui_component/media_gallery_listing.xml
+++ b/MediaGalleryUi/view/adminhtml/ui_component/media_gallery_listing.xml
@@ -18,27 +18,32 @@
         <buttons>
             <button name="add_selected">
                 <param name="on_click" xsi:type="string">return false;</param>
-                <class>action-primary no-display</class>
+                <param name="sort_order" xsi:type="number">50</param>
+                <class>action-primary no-display media-gallery-add-selected</class>
                 <label translate="true">Add Selected</label>
             </button>
             <button name="cancel">
                 <param name="on_click" xsi:type="string">MediabrowserUtility.closeDialog();</param>
+                <param name="sort_order" xsi:type="number">10</param>
                 <class>cancel action-quaternary</class>
                 <label translate="true">Cancel</label>
             </button>
             <button name="delete_folder">
                 <param name="on_click" xsi:type="string">jQuery('#delete_folder').trigger('delete_folder');</param>
                 <param name="disabled" xsi:type="string">disabled</param>
+                <param name="sort_order" xsi:type="number">20</param>
                 <class>action-default scalable action-quaternary</class>
                 <label translate="true">Delete Folder</label>
             </button>
             <button name="create_folder">
                 <param name="on_click" xsi:type="string">jQuery('#create_folder').trigger('create_folder');</param>
+                <param name="sort_order" xsi:type="number">40</param>
                 <class>action-default scalable add</class>
                 <label translate="true">Create Folder</label>
             </button>
             <button name="delete_selected">
                 <param name="on_click" xsi:type="string">return false;</param>
+                <param name="sort_order" xsi:type="number">30</param>
                 <class>action-default scalable action-quaternary no-display</class>
                 <label translate="true">Delete Selected</label>
             </button>

--- a/MediaGalleryUi/view/adminhtml/web/css/source/_module.less
+++ b/MediaGalleryUi/view/adminhtml/web/css/source/_module.less
@@ -7,8 +7,18 @@
 
     .media-gallery-container {
 
-        .page-main-actions > .page-actions > button.no-display {
-            display: none;
+        .page-main-actions {
+            .page-actions {
+                .media-gallery-add-selected {
+                    order: unset;
+                }
+            }
+
+            & > .page-actions {
+                & > button.no-display {
+                    display: none;
+                }
+            }
         }
 
         .jstree-default .jstree-hovered {


### PR DESCRIPTION
### Description (*)
This PR fixes the sort order of the media gallery buttons.
<img width="1292" alt="Screenshot 2020-03-27 at 11 30 12" src="https://user-images.githubusercontent.com/31502344/77741973-64299d00-701e-11ea-9392-bd36e2771cb8.png">


### Fixed Issues

1. magento/adobe-stock-integration#1042: Wrong button order when an image is selected [Media Gallery]

### Manual testing scenarios (*)

1. From Admin go to Content - Pages, click Add New Page
2. Expand Content, click Show / Hide Editor, click Insert Image...
3. Select an image from Media Gallery (left mouse click)
(Add Selected button appeared)