### PR TITLE
Fixed the issue with unknown characters are displayed instead of three dots

### DIFF
--- a/MediaGalleryUi/view/adminhtml/web/css/source/_module.less
+++ b/MediaGalleryUi/view/adminhtml/web/css/source/_module.less
@@ -101,9 +101,15 @@
 
             .three-dots {
                 &:before {
-                    content: '•••';
+                    content: "\2807";
                     cursor: pointer;
                     color: #9e9e9e;
+                    display: inline-block;
+                    font-size: 26px;
+
+                    .lib-rotate(
+                        @_rotation: 90deg;
+                    );
                 }
             }
         }


### PR DESCRIPTION
### Description (*)
This PR fixes the issue with unknown characters that are displayed instead of three dots.
<img width="1293" alt="Screenshot 2020-03-27 at 15 10 00" src="https://user-images.githubusercontent.com/31502344/77759618-af9f7380-703d-11ea-8667-fbe0669b7b00.png">

### Fixed Issues (if relevant)

1. magento/adobe-stock-integration#1041: Unknown characters are displayed instead of three dots near an image [Media Gallery]

### Manual testing scenarios (*)

1. From Admin go to Content - Pages, click Add New Page
2. Expand Content, click Show / Hide Editor, click Insert Image...
3. Click Search Adobe Stock and Sign In Adobe Stock
4. Open any image Preview and click Save Preview button
5. Close X the Save Preview window
6. Refresh the web page, using F5 key for example
(CMS New page is displayed )
7. Expand Content, click Show / Hide Editor, click Insert Image...
8. Pay attention to the images in Media Gallery