### PR TITLE
1048: adjust folder create error message to the Magento standard mesages

### DIFF
--- a/MediaGalleryUi/Controller/Adminhtml/Directories/Create.php
+++ b/MediaGalleryUi/Controller/Adminhtml/Directories/Create.php
@@ -68,7 +68,7 @@ class Create extends Action implements HttpPostActionInterface
         $resultJson = $this->resultFactory->create(ResultFactory::TYPE_JSON);
         $path = $this->getRequest()->getParam('path');
         $name = $this->getRequest()->getParam('name');
-        
+
         if (!$path && !$name) {
             $responseContent = [
                 'success' => false,

--- a/MediaGalleryUi/view/adminhtml/web/js/directory/directories.js
+++ b/MediaGalleryUi/view/adminhtml/web/js/directory/directories.js
@@ -7,9 +7,10 @@ define([
     'jquery',
     'uiComponent',
     'Magento_Ui/js/modal/confirm',
+    'Magento_Ui/js/modal/alert',
     'underscore',
     'Magento_Ui/js/modal/prompt'
-], function ($, Component, confirm, _, prompt) {
+], function ($, Component, confirm, uiAlert, _, prompt) {
     'use strict';
 
     return Component.extend({
@@ -108,8 +109,9 @@ define([
                     } else {
                         message = response.responseJSON.message;
                     }
-                    this.messages().add('error', message);
-                    this.messages().scheduleCleanup(this.messageDelay);
+                    uiAlert({
+                        content: message
+                    });
                 }
             });
 


### PR DESCRIPTION
### Description (*)
This PR provides adjustments of the error message appears during MediaGalleryUi folders manipulation to the Magento standards.

### Fixed Issues (if relevant)
#1048 

### Manual testing scenarios (*)
#1048 