### PR TITLE
Issue 1052 fix view details image size

### DIFF
--- a/MediaGalleryUi/view/adminhtml/web/css/source/_module.less
+++ b/MediaGalleryUi/view/adminhtml/web/css/source/_module.less
@@ -213,6 +213,10 @@
                 width: auto;
                 max-width: 70%;
                 float: left;
+
+                img {
+                    max-height: 650px;
+                }
             }
 
             .image-details-sidebar {


### PR DESCRIPTION
### Description (*)
This PR fixes image size for details image.
The maximum height was limited to 650px, it's about like the height of the image details sidebar. The height limitation for an image fixes the issue with empty white space on the right side while scrolling image details with a large image.
<img width="1440" alt="Screenshot 2020-03-30 at 09 53 56" src="https://user-images.githubusercontent.com/31502344/77900336-976e6500-7286-11ea-9770-613d4d10061e.png">

### Fixed Issues (if relevant)

1. magento/adobe-stock-integration#1052: The image size is not limited in View Details window. A "big" licensed image causes a lot of empty white space

### Manual testing scenarios (*)

1. From Admin go to Content - Pages, click Add New Page
2. Expand Content, click Show / Hide Editor, click Insert Image...
3. Select a licensed image added from Adobe Stock
4. Click on three dots near the image and select View Details
three_dots
5. Observe the Image Details window