### PR TITLE
Issue 1051 Added Add Image functionality for Media Gallery View Details popup

### DIFF
--- a/MediaGalleryUi/Model/GetImageDetailsByAssetId.php
+++ b/MediaGalleryUi/Model/GetImageDetailsByAssetId.php
@@ -102,6 +102,7 @@ class GetImageDetailsByAssetId
         $assetGridData = $this->getAssetGridDataById($assetId);
         $tags = isset($assetGridData['keywords']) ? explode(',', $assetGridData['keywords']) : [];
         $type = $assetGridData['content_type'] ?? '';
+        $size = $this->getImageSize($asset->getPath());
 
         return [
             'image_url' => $this->getUrl($asset->getPath()),
@@ -126,9 +127,10 @@ class GetImageDetailsByAssetId
                 ],
                 [
                     'title' => __('Size'),
-                    'value' => $this->getImageSize($asset->getPath())
+                    'value' => $this->formatImageSize($size)
                 ]
             ],
+            'size' => $size,
             'tags' => $tags,
             'source' => $asset->getSource() ? $this->sourceIconProvider->getSourceIconUrl($asset->getSource()) : null,
             'content_type' => $type
@@ -189,20 +191,31 @@ class GetImageDetailsByAssetId
      *
      * @param string $path
      *
-     * @return string
+     * @return int
      *
      * @throws FileSystemException
      */
-    private function getImageSize(string $path): string
+    private function getImageSize(string $path): int
     {
         $mediaDirectory = $this->filesystem->getDirectoryWrite(DirectoryList::MEDIA);
         $imageStatistics = $mediaDirectory->stat($path);
-        $size = $imageStatistics['size'] ?? 0;
 
-        if (!$size) {
+        return (int) ($imageStatistics['size'] ?? 0);
+    }
+
+    /**
+     * Format image size
+     *
+     * @param int $imageSize
+     *
+     * @return string
+     */
+    private function formatImageSize(int $imageSize): string
+    {
+        if (!$imageSize) {
             return '';
         }
 
-        return sprintf('%sKb', $size / 1000);
+        return sprintf('%sKb', $imageSize / 1000);
     }
 }

--- a/MediaGalleryUi/view/adminhtml/layout/media_gallery_index_index.xml
+++ b/MediaGalleryUi/view/adminhtml/layout/media_gallery_index_index.xml
@@ -19,6 +19,9 @@
             <block name="image.details" class="Magento\Backend\Block\Template" template="Magento_MediaGalleryUi::image_details.phtml">
                 <arguments>
                     <argument name="imageDetailsUrl" xsi:type="url" path="media_gallery/image/details"/>
+                    <argument name="targetElementId" xsi:type="helper" helper="Magento\Framework\App\RequestInterface::getParam">
+                        <param name="key">target_element_id</param>
+                    </argument>
                 </arguments>
             </block>
         </block>

--- a/MediaGalleryUi/view/adminhtml/templates/image_details.phtml
+++ b/MediaGalleryUi/view/adminhtml/templates/image_details.phtml
@@ -65,12 +65,20 @@ use Magento\Backend\Block\Template;
                     "mediaGalleryImageActions": {
                         "component": "Magento_MediaGalleryUi/js/image/image-actions",
                         "modalSelector": ".media-gallery-image-details-modal",
+                        "mediaGalleryImageDetailsName": "mediaGalleryImageDetails",
+                        "targetElementId": "<?= $block->escapeJs($block->getData('targetElementId')); ?>",
                         "actionsList": [
                             {
                                 "title": "<?= $block->escapeJs(__('Cancel')); ?>",
                                 "handler": "closeModal",
                                 "name": "cancel",
                                 "classes": "action-default scalable cancel action-quaternary"
+                            },
+                            {
+                                "title": "<?= $block->escapeJs(__('Add Image')); ?>",
+                                "handler": "addImage",
+                                "name": "add-image",
+                                "classes": "scalable action-primary add-image-action"
                             }
                         ]
                     }

--- a/MediaGalleryUi/view/adminhtml/web/js/image/image-actions.js
+++ b/MediaGalleryUi/view/adminhtml/web/js/image/image-actions.js
@@ -6,14 +6,20 @@
 define([
     'jquery',
     'underscore',
-    'uiElement'
-], function ($, _, Element) {
+    'uiElement',
+    'mage/translate'
+], function ($, _, Element, $t) {
     'use strict';
 
     return Element.extend({
         defaults: {
             modalSelector: '',
-            template: 'Magento_MediaGalleryUi/image/actions'
+            template: 'Magento_MediaGalleryUi/image/actions',
+            targetElementId: null,
+            mediaGalleryImageDetailsName: 'mediaGalleryImageDetails',
+            modules: {
+                mediaGalleryImageDetails: '${ $.mediaGalleryImageDetailsName }'
+            }
         },
 
         /**
@@ -27,6 +33,67 @@ define([
             }
 
             modalElement.modal('closeModal');
+        },
+
+        /**
+         * Add Image
+         */
+        addImage: function () {
+            var targetElement = this.getTargetElement(),
+                imageDetails = this.getImageData();
+
+            if (!targetElement.length) {
+                this.getMediaGalleryModal().closeDialog();
+                throw $t('Target element not found for content update');
+            }
+
+            targetElement.val(imageDetails['image_url'])
+                .data('size', imageDetails.size)
+                .data('mime-type', imageDetails['content_type'])
+                .trigger('change');
+            this.closeModal();
+            this.getMediaGalleryModal().closeDialog();
+            targetElement.focus();
+        },
+
+        /**
+         * Get image data
+         *
+         * @return {Object}
+         */
+        getImageData: function () {
+            if (!this.mediaGalleryImageDetails) {
+                return {};
+            }
+
+            return this.mediaGalleryImageDetails().getImageData();
+        },
+
+        /**
+         * Close media gallery grid modal
+         */
+        closeMediaGalleryGridModal: function () {
+            this.getMediaGalleryModal().closeDialog();
+        },
+
+        /**
+         * Get target element
+         *
+         * @return {HTMLElement}
+         */
+        getTargetElement: function () {
+            var targetElementSelector = "#{targetElementId}".replace('{targetElementId}', this.targetElementId);
+
+            return $(targetElementSelector);
+        },
+
+        /**
+         * Get media gallery modal
+         *
+         * @return {Object}
+         */
+        getMediaGalleryModal: function () {
+            return window.MediabrowserUtility;
         }
     });
 });

--- a/MediaGalleryUi/view/adminhtml/web/js/image/image-actions.js
+++ b/MediaGalleryUi/view/adminhtml/web/js/image/image-actions.js
@@ -82,7 +82,7 @@ define([
          * @return {HTMLElement}
          */
         getTargetElement: function () {
-            var targetElementSelector = "#{targetElementId}".replace('{targetElementId}', this.targetElementId);
+            var targetElementSelector = '#{targetElementId}'.replace('{targetElementId}', this.targetElementId);
 
             return $(targetElementSelector);
         },

--- a/MediaGalleryUi/view/adminhtml/web/js/image/image-details.js
+++ b/MediaGalleryUi/view/adminhtml/web/js/image/image-details.js
@@ -160,6 +160,15 @@ define([
          */
         showMoreImageTags: function () {
             this.showAllTags(true);
+        },
+
+        /**
+         * Get image data
+         *
+         * @return {Object}
+         */
+        getImageData: function () {
+            return this.image();
         }
     });
 });


### PR DESCRIPTION
### Description (*)

This PR adds the `Add Image` button for the `View Details` popup with appropriate functionality.
<img width="1440" alt="Screenshot 2020-03-31 at 12 58 54" src="https://user-images.githubusercontent.com/31502344/78014544-c18c5980-7350-11ea-9aa5-253cdd891cef.png">
<img width="1440" alt="Screenshot 2020-03-31 at 12 59 10" src="https://user-images.githubusercontent.com/31502344/78014558-c6510d80-7350-11ea-8f59-0355c069f154.png">


### Fixed Issues (if relevant)

1. magento/adobe-stock-integration#1051: Feature request. Add the "Add selected" button to View Details [Media Gallery]

### Manual testing scenarios (*)

1. From Admin go to Content - Pages, click Add New Page
2. Expand Content,click Show / Hide Editor, click Insert Image.
3. Select an image added from Adobe Stock
4. Click on three dots near the image and select View Details
5. Click on `Add Image` button