### PR TITLE
Fix broked standalone media gallery, add conteiner class to match styles

### DIFF
--- a/MediaGalleryUi/view/adminhtml/layout/media_gallery_media_index.xml
+++ b/MediaGalleryUi/view/adminhtml/layout/media_gallery_media_index.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
-        <referenceContainer name="content">
+        <referenceContainer htmlTag="div" htmlClass="media-gallery-container" name="content">
             <uiComponent name="standalone_media_gallery_listing"/>
         </referenceContainer>
     </body>

--- a/MediaGalleryUi/view/adminhtml/web/css/source/_module.less
+++ b/MediaGalleryUi/view/adminhtml/web/css/source/_module.less
@@ -17,8 +17,7 @@
 
 & when (@media-common = true) {
 
-    .media-gallery-container,
-    .media_gallery-media-index {
+    .media-gallery-container {
 
         .page-main-actions {
             .page-actions {


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/adobe-stock-integration#1078>:Adobe Stock Image grid broken for standalone media grid layout
2. ...

### Manual testing scenarios (*)

1.     Login to Admin panel
2.     Go to Content -> Elements -> Media -> Media Gallery
3.     Click on "Search Adobe Stock" button

Layout should not be broken