### PR TITLE
Add folders functionality && image-details actions to standalone media gallery page

### DIFF
--- a/AdobeStockImageAdminUi/view/adminhtml/ui_component/standalone_media_gallery_listing.xml
+++ b/AdobeStockImageAdminUi/view/adminhtml/ui_component/standalone_media_gallery_listing.xml
@@ -11,6 +11,7 @@
         <buttons>
             <button name="search_adobe_stock">
                 <param name="on_click" xsi:type="string">jQuery(".adobe-search-images-modal").trigger("openModal");</param>
+		<param name="sort_order" xsi:type="number">100</param>
                 <class>action-secondary</class>
                 <label translate="true">Search Adobe Stock</label>
             </button>

--- a/AdobeStockImageAdminUi/view/adminhtml/ui_component/standalone_media_gallery_listing.xml
+++ b/AdobeStockImageAdminUi/view/adminhtml/ui_component/standalone_media_gallery_listing.xml
@@ -11,7 +11,7 @@
         <buttons>
             <button name="search_adobe_stock">
                 <param name="on_click" xsi:type="string">jQuery(".adobe-search-images-modal").trigger("openModal");</param>
-		<param name="sort_order" xsi:type="number">100</param>
+                <param name="sort_order" xsi:type="number">100</param>
                 <class>action-secondary</class>
                 <label translate="true">Search Adobe Stock</label>
             </button>

--- a/MediaGalleryUi/view/adminhtml/layout/media_gallery_media_index.xml
+++ b/MediaGalleryUi/view/adminhtml/layout/media_gallery_media_index.xml
@@ -10,6 +10,14 @@
     <body>
         <referenceContainer htmlTag="div" htmlClass="media-gallery-container" name="content">
             <uiComponent name="standalone_media_gallery_listing"/>
+	    <block name="image.details" class="Magento\Backend\Block\Template" template="Magento_MediaGalleryUi::image_details.phtml">
+                <arguments>
+                    <argument name="imageDetailsUrl" xsi:type="url" path="media_gallery/image/details"/>
+                    <argument name="targetElementId" xsi:type="helper" helper="Magento\Framework\App\RequestInterface::getParam">
+                        <param name="key">target_element_id</param>
+                    </argument>
+                </arguments>
+	    </block>
         </referenceContainer>
     </body>
 </page>

--- a/MediaGalleryUi/view/adminhtml/ui_component/standalone_media_gallery_listing.xml
+++ b/MediaGalleryUi/view/adminhtml/ui_component/standalone_media_gallery_listing.xml
@@ -19,6 +19,21 @@
         <deps>
             <dep>standalone_media_gallery_listing.media_gallery_listing_data_source</dep>
         </deps>
+        <buttons>
+            <button name="delete_folder">
+                <param name="on_click" xsi:type="string">jQuery('#delete_folder').trigger('delete_folder');</param>
+                <param name="disabled" xsi:type="string">disabled</param>
+                <param name="sort_order" xsi:type="number">30</param>
+                <class>action-default scalable action-quaternary</class>
+                <label translate="true">Delete Folder</label>
+            </button>
+            <button name="create_folder">
+                <param name="on_click" xsi:type="string">jQuery('#create_folder').trigger('create_folder');</param>
+                <param name="sort_order" xsi:type="number">40</param>
+                <class>action-default scalable add</class>
+                <label translate="true">Create Folder</label>
+            </button>
+        </buttons>
     </settings>
     <dataSource name="media_gallery_listing_data_source" component="Magento_Ui/js/grid/provider">
         <settings>

--- a/MediaGalleryUi/view/adminhtml/web/js/directory/directories.js
+++ b/MediaGalleryUi/view/adminhtml/web/js/directory/directories.js
@@ -9,7 +9,8 @@ define([
     'Magento_Ui/js/modal/confirm',
     'Magento_Ui/js/modal/alert',
     'underscore',
-    'Magento_Ui/js/modal/prompt'
+    'Magento_Ui/js/modal/prompt',
+    'validation'
 ], function ($, Component, confirm, uiAlert, _, prompt) {
     'use strict';
 
@@ -151,6 +152,10 @@ define([
                         name: 'folder_name',
                         'data-validate': '{required:true, validate-alphanum}',
                         maxlength: '128'
+                    },
+                    attributesForm: {
+                        novalidate: 'novalidate',
+                        action: ''
                     },
                     context: this,
                     actions: data.actions,


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Add folders functionality to standalone media gallery page
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
#1089 Add "Create Folder" "Delete Folder" "View Details" functionality in Content - Media Gallery. 

### Manual testing scenarios (*)
1. Folder created from standalone page
2. Folder deleted from standalone page
3. View details actions open vied details page
4. Delete image actions works as well