### PR TITLE
Exclude dot directories and images in it from mediaGallery && Page builder doesn't load images from Enhanced Media gallery, instead the "old" Media Gallery is used

### DIFF
--- a/MediaGalleryIntegration/Plugin/UpdateOpenDialogUrlPageBuilder.php
+++ b/MediaGalleryIntegration/Plugin/UpdateOpenDialogUrlPageBuilder.php
@@ -52,5 +52,6 @@ class UpdateOpenDialogUrlPageBuilder
             }
             return $newItem;
         }
+        return $itemName;
     }
 }

--- a/MediaGalleryIntegration/Plugin/UpdateOpenDialogUrlPageBuilder.php
+++ b/MediaGalleryIntegration/Plugin/UpdateOpenDialogUrlPageBuilder.php
@@ -42,12 +42,13 @@ class UpdateOpenDialogUrlPageBuilder
      *
      * @param OpenDialogUrl $subject
      * @param array $itemName
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function afterGetData($subject, array $itemName)
     {
         $newItem = [];
         if ($this->config->isEnabled()) {
-            foreach ($itemName as $key => $item) {
+            foreach ($itemName as $key) {
                 $newItem[$key] = $this->url->getUrl('media_gallery/index/index');
             }
             return $newItem;

--- a/MediaGalleryIntegration/Plugin/UpdateOpenDialogUrlPageBuilder.php
+++ b/MediaGalleryIntegration/Plugin/UpdateOpenDialogUrlPageBuilder.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\MediaGalleryIntegration\Plugin;
+
+use Magento\Framework\UrlInterface;
+use Magento\Ui\Component\Form\Element\DataType\Media\Image;
+use Magento\MediaGalleryUiApi\Api\ConfigInterface;
+use Magento\PageBuilder\Model\Config\ContentType\AdditionalData\Provider\Uploader\OpenDialogUrl;
+
+/**
+ * Plugin to update open media gallery dialog URL for image-uploader component
+ */
+class UpdateOpenDialogUrlPageBuilder
+{
+    /**
+     * @var UrlInterface
+     */
+    private $url;
+
+    /**
+     * @var ConfigInterface
+     */
+    private $config;
+
+    /**
+     * @param UrlInterface $url
+     * @param ConfigInterface $config
+     */
+    public function __construct(UrlInterface $url, ConfigInterface $config)
+    {
+        $this->url = $url;
+        $this->config = $config;
+    }
+
+    /**
+     * Update open media gallery dialog URL for image-uploader component
+     *
+     * @param OpenDialogUrl $subject
+     * @param array $itemName
+     */
+    public function afterGetData($subject, array $itemName)
+    {
+        $newItem = [];
+        if ($this->config->isEnabled()) {
+            foreach ($itemName as $key => $item) {
+                $newItem[$key] = $this->url->getUrl('media_gallery/index/index');
+            }
+            return $newItem;
+        }
+    }
+}

--- a/MediaGalleryIntegration/etc/adminhtml/di.xml
+++ b/MediaGalleryIntegration/etc/adminhtml/di.xml
@@ -12,4 +12,7 @@
     <type name="Magento\Cms\Model\Wysiwyg\Gallery\DefaultConfigProvider">
         <plugin name="updateWysiwygOpenDialogUrl" type="Magento\MediaGalleryIntegration\Plugin\UpdateWysiwygOpenDialogUrl"/>
     </type>
+    <type name="Magento\PageBuilder\Model\Config\ContentType\AdditionalData\Provider\Uploader\OpenDialogUrl">
+        <plugin name="updateOpenDialogUrlPageBuilder" type="Magento\MediaGalleryIntegration\Plugin\UpdateOpenDialogUrlPageBuilder"/>
+    </type>
 </config>

--- a/MediaGalleryUi/etc/di.xml
+++ b/MediaGalleryUi/etc/di.xml
@@ -26,7 +26,7 @@
                 <item name="theme" xsi:type="string">/pub\/media\/theme/</item>
                 <item name="theme_customization" xsi:type="string">/pub\/media\/theme_customization/</item>
                 <item name="tmp" xsi:type="string">/pub\/media\/tmp/</item>
-		<item name="directories-with-dots" xsi:type="string">/\./</item>
+                <item name="directories-with-dots" xsi:type="string">/\./</item>
 	    </argument>
         </arguments>
      </type>

--- a/MediaGalleryUi/etc/di.xml
+++ b/MediaGalleryUi/etc/di.xml
@@ -26,6 +26,7 @@
                 <item name="theme" xsi:type="string">/pub\/media\/theme/</item>
                 <item name="theme_customization" xsi:type="string">/pub\/media\/theme_customization/</item>
                 <item name="tmp" xsi:type="string">/pub\/media\/tmp/</item>
+		<item name="directories-with-dots" xsi:type="string">/\./</item>
 	    </argument>
         </arguments>
      </type>

--- a/MediaGalleryUi/etc/di.xml
+++ b/MediaGalleryUi/etc/di.xml
@@ -26,7 +26,7 @@
                 <item name="theme" xsi:type="string">/pub\/media\/theme/</item>
                 <item name="theme_customization" xsi:type="string">/pub\/media\/theme_customization/</item>
                 <item name="tmp" xsi:type="string">/pub\/media\/tmp/</item>
-                <item name="directories-with-dots" xsi:type="string">/\./</item>
+                <item name="directories-with-dots" xsi:type="string">/^\./</item>
 	    </argument>
         </arguments>
      </type>


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/adobe-stock-integration#1084: Exclude directories starting with dot and their contents from media gallery
2. magento/adobe-stock-integration#1071: Page builder doesn't load images from Enhanced Media gallery, instead the "old" Media Gallery is used

### Manual testing scenarios (*)

1. Login to Admin Palnel
2.     Open Media Gallery i.e.:
3.         From Admin go to Content - Pages, click Add New Page)
4.         Expand Content,click Show / Hide Editor, click Insert Image...

Directories  starting with dots ignored from directory tree
Images from dot directories not displayed in media gallery grid

**Scenario 2**

1. Enabled Page builder
2. From Admin go to Content - Pages, click Add New Page
3. Expand Content, Expand Media
4. Drag and drop Image on the Row section
5. Click Select from Gallery

**The new Enhanced Media Gallery is opened**