### PR TITLE
#issue-1085 Added resizing for media asset grid image thumbnail

### DIFF
--- a/MediaGalleryUi/Model/CreateGridThumbnail.php
+++ b/MediaGalleryUi/Model/CreateGridThumbnail.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\MediaGalleryUi\Model;
+
+use Magento\Framework\App\Filesystem\DirectoryList;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Filesystem;
+use Magento\Framework\Image\Adapter\AbstractAdapter;
+use Magento\Framework\Image\AdapterFactory as ImageAdapterFactory;
+
+/**
+ * Create grid thumbnail
+ */
+class CreateGridThumbnail
+{
+    /**
+     * Width
+     */
+    public const WIDTH = 200;
+
+    /**
+     * Height
+     */
+    public const HEIGHT = 200;
+
+    /**
+     * @var Filesystem
+     */
+    private $filesystem;
+
+    /**
+     * @var ImageAdapterFactory
+     */
+    private $imageAdapterFactory;
+
+    /**
+     * @var int
+     */
+    private $width;
+
+    /**
+     * @var int
+     */
+    private $height;
+
+    /**
+     * Constructor
+     *
+     * @param Filesystem $filesystem
+     * @param ImageAdapterFactory $imageAdapterFactory
+     * @param int $width
+     * @param int $height
+     */
+    public function __construct(
+        Filesystem $filesystem,
+        ImageAdapterFactory $imageAdapterFactory,
+        int $width = self::WIDTH,
+        int $height = self::HEIGHT
+    ) {
+        $this->filesystem = $filesystem;
+        $this->imageAdapterFactory = $imageAdapterFactory;
+        $this->width = $width;
+        $this->height = $height;
+    }
+
+    /**
+     * Create grid thumbnail
+     *
+     * @param string $imagePath
+     * @return string
+     * @throws \Exception
+     */
+    public function execute(string $imagePath): string
+    {
+        $mediaDirectory = $this->filesystem->getDirectoryRead(DirectoryList::MEDIA);
+
+        if (!$mediaDirectory->isExist($imagePath)) {
+            throw new LocalizedException(__('File "%1" does not exist in media directory.', $imagePath));
+        }
+
+        $thumbnailImagePath = $this->getThumbnailImagePath($imagePath);
+
+        if ($mediaDirectory->isExist($thumbnailImagePath)) {
+            return $thumbnailImagePath;
+        }
+
+        $absoluteOriginalImagePath = $mediaDirectory->getAbsolutePath($imagePath);
+        $absoluteThumbnailImagePath = $mediaDirectory->getAbsolutePath($thumbnailImagePath);
+        /** @var AbstractAdapter $thumbnailImage */
+        $thumbnailImage = $this->imageAdapterFactory->create();
+        $thumbnailImage->open($absoluteOriginalImagePath);
+        $thumbnailImage->constrainOnly(true);
+        $thumbnailImage->keepTransparency(true);
+        $thumbnailImage->keepFrame(false);
+        $thumbnailImage->keepAspectRatio(true);
+        $thumbnailImage->resize($this->width, $this->height);
+        $thumbnailImage->save($absoluteThumbnailImagePath);
+
+        return $thumbnailImagePath;
+    }
+
+    /**
+     * Get thumbnail image path
+     *
+     * @param string $originalImagePath
+     *
+     * @return string
+     */
+    private function getThumbnailImagePath(string $originalImagePath): string
+    {
+        return sprintf('thumbnail/%sx%s/%s', $this->width, $this->height, $originalImagePath);
+    }
+}

--- a/MediaGalleryUi/Model/CreateGridThumbnail.php
+++ b/MediaGalleryUi/Model/CreateGridThumbnail.php
@@ -14,7 +14,7 @@ use Magento\Framework\Image\Adapter\AbstractAdapter;
 use Magento\Framework\Image\AdapterFactory as ImageAdapterFactory;
 
 /**
- * Create grid thumbnail
+ * Class creates a thumbnail grid by resizing original image
  */
 class CreateGridThumbnail
 {

--- a/MediaGalleryUi/Model/UpdateAssetInGrid.php
+++ b/MediaGalleryUi/Model/UpdateAssetInGrid.php
@@ -41,23 +41,31 @@ class UpdateAssetInGrid
     private $assetKeywords;
 
     /**
+     * @var CreateGridThumbnail
+     */
+    private $createGridThumbnail;
+
+    /**
      * Constructor
      *
      * @param ResourceConnection $resource
      * @param DriverInterface $file
      * @param LoggerInterface $logger
      * @param GetAssetKeywords $assetKeywords
+     * @param CreateGridThumbnail $createGridThumbnail
      */
     public function __construct(
         ResourceConnection $resource,
         DriverInterface $file,
         LoggerInterface $logger,
-        GetAssetKeywords $assetKeywords
+        GetAssetKeywords $assetKeywords,
+        CreateGridThumbnail $createGridThumbnail
     ) {
         $this->resource = $resource;
         $this->file = $file;
         $this->logger = $logger;
         $this->assetKeywords = $assetKeywords;
+        $this->createGridThumbnail = $createGridThumbnail;
     }
 
     /**
@@ -76,13 +84,14 @@ class UpdateAssetInGrid
             $keywords = array_map(function (KeywordInterface $keyword) {
                 return $keyword->getKeyword();
             }, $this->assetKeywords->execute($asset->getId()));
+            $thumbnailPath = $this->createGridThumbnail->execute($asset->getPath());
 
             $this->resource->getConnection()->insertOnDuplicate(
                 $this->resource->getTableName('media_gallery_asset_grid'),
                 [
                     'id' => $asset->getId(),
                     'directory' => $this->file->getParentDirectory($asset->getPath()),
-                    'thumbnail_url' => $asset->getPath(),
+                    'thumbnail_url' => $thumbnailPath,
                     'preview_url' => $asset->getPath(),
                     //phpcs:ignore Magento2.Functions.DiscouragedFunction
                     'name' => basename($asset->getPath()),


### PR DESCRIPTION
# Description 
This PR adds resizing for media gallery grid thumbnails.
<img width="880" alt="Screenshot 2020-04-01 at 12 35 09" src="https://user-images.githubusercontent.com/31502344/78135238-40a19080-742a-11ea-8458-54b043f707d4.png">

# Fixed Issues (if relevant)

1. magento/adobe-stock-integration#1085: Use thumbnail versions of images for displaying in the media gallery grid

### Manual testing scenarios (*)

1. Login to Admin Panel
2. Open Media Gallery
3. Check the original size of media gallery thumbnails