### PR TITLE
Trigger media gallery reindex when Enhanced Media Gallery is enabled in configuration

### DIFF
--- a/MediaGalleryUi/Plugin/MediaGalleryIndexerTrigger.php
+++ b/MediaGalleryUi/Plugin/MediaGalleryIndexerTrigger.php
@@ -36,7 +36,8 @@ class MediaGalleryIndexerTrigger
      * Update media gallery grid table when configuration is saved and media gallery enabled
      *
      * @param Value $config
-     * @return void
+     * @param Value $result
+     * @return Value
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function afterSave(Value $config, Value $result): Value

--- a/MediaGalleryUi/Plugin/MediaGalleryIndexerTrigger.php
+++ b/MediaGalleryUi/Plugin/MediaGalleryIndexerTrigger.php
@@ -37,11 +37,12 @@ class MediaGalleryIndexerTrigger
      *
      * @param Value $config
      * @return void
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function afterSave(Value $config, Value $result): void
     {
-        $isEnabled = $result->getPath() == self::MEDIA_GALLERY_CONFIG_VALUE;
-        if ($isEnabled && $result->isValueChanged() && $result->getValue() == self::MEDIA_GALLERY_ENABLED_VALUE) {
+        $isMediaGallery = $result->getPath() == self::MEDIA_GALLERY_CONFIG_VALUE;
+        if ($isMediaGallery && $result->isValueChanged() && $result->getValue() == self::MEDIA_GALLERY_ENABLED_VALUE) {
             $this->imagesIndexer->execute();
         }
     }

--- a/MediaGalleryUi/Plugin/MediaGalleryIndexerTrigger.php
+++ b/MediaGalleryUi/Plugin/MediaGalleryIndexerTrigger.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\MediaGalleryUi\Plugin;
+
+use Magento\MediaGalleryUi\Model\ImagesIndexer;
+use Magento\Framework\App\Config\Value;
+
+/**
+ * Plugin to update media gallery grid table when media gallery enabled in configuration
+ */
+class MediaGalleryIndexerTrigger
+{
+    private const MEDIA_GALLERY_CONFIG_VALUE = 'system/media_gallery/enabled';
+    private const MEDIA_GALLERY_ENABLED_VALUE = 1;
+    
+    /**
+     * @var ImagesIndexer
+     */
+    private $imagesIndexer;
+       
+    /**
+     * @param ImagesIndexer $imagesIndexer
+     */
+    public function __construct(
+        ImagesIndexer $imagesIndexer
+    ) {
+        $this->imagesIndexer = $imagesIndexer;
+    }
+
+    /**
+     * Update media gallery grid table when configuration is saved and media gallery enabled
+     *
+     * @param Value $config
+     * @return void
+     */
+    public function afterSave(Value $config, Value $result): void
+    {
+        $isEnabled = $result->getPath() == self::MEDIA_GALLERY_CONFIG_VALUE;
+        if ($isEnabled && $result->isValueChanged() && $result->getValue() == self::MEDIA_GALLERY_ENABLED_VALUE) {
+            $this->imagesIndexer->execute();
+        }
+    }
+}

--- a/MediaGalleryUi/Plugin/MediaGalleryIndexerTrigger.php
+++ b/MediaGalleryUi/Plugin/MediaGalleryIndexerTrigger.php
@@ -39,11 +39,13 @@ class MediaGalleryIndexerTrigger
      * @return void
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function afterSave(Value $config, Value $result): void
+    public function afterSave(Value $config, Value $result): Value
     {
         $isMediaGallery = $result->getPath() == self::MEDIA_GALLERY_CONFIG_VALUE;
         if ($isMediaGallery && $result->isValueChanged() && $result->getValue() == self::MEDIA_GALLERY_ENABLED_VALUE) {
             $this->imagesIndexer->execute();
         }
+
+        return $result;
     }
 }

--- a/MediaGalleryUi/etc/adminhtml/di.xml
+++ b/MediaGalleryUi/etc/adminhtml/di.xml
@@ -11,4 +11,7 @@
             <argument name="path" xsi:type="string">media</argument>
         </arguments>
     </type>
+    <type name="Magento\Framework\App\Config\Value">
+        <plugin name="admin_system_config_adobe_stock_save_plugin" type="Magento\MediaGalleryUi\Plugin\MediaGalleryIndexerTrigger" sortOrder="1"/>
+    </type>
 </config>


### PR DESCRIPTION

<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/adobe-stock-integration#1097: Trigger media gallery reindex when Enhanced Media Gallery is enabled in configuration
2. ...

### Manual testing scenarios (*)
Set Stores -> Configuration -> Advanced -> System -> Enhanced Media Gallery to Yes
Media gallery reindex is triggered

Save second time with same value
Media gallery reindex is not triggered

Save again with no
Media gallery reindex is not triggered

Save again with yes
Media gallery reindex is  triggered