### PR TITLE
#913 - save image for new gallery and select image after save

### DIFF
--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/actions.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/actions.js
@@ -175,7 +175,7 @@ define([
         /**
          * Get image data by image file name
          *
-         * @param imageFilename
+         * @param {String} imageFilename
          * @returns {null|Object}
          */
         getRecordFromMediaGalleryProvider: function (imageFilename) {

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/actions.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/actions.js
@@ -145,21 +145,13 @@ define([
                 imagePath = self.preview().displayedRecord().path,
                 imageFolders = imagePath.substring(0, imagePath.indexOf('/')),
                 imageFilename = imagePath.substring(imagePath.lastIndexOf('/') + 1),
-                locatedImage = $('div[data-row="file"]:has(img[alt=\"' + imageFilename + '\"])'),
-                recordIndex,
-                record = null,
+                record = this.getRecordFromMediaGalleryProvider(imageFilename),
                 subscription;
 
-            if (!locatedImage.length) {
-                subscription = this.imageItems.subscribe(function (items) {
+            if (!record) {
+                subscription = this.imageItems.subscribe(function () {
                     subscription.dispose();
-                    items.each(function (item) {
-                        if (item.name === imageFilename) {
-                            record = item;
-
-                            return false;
-                        }
-                    });
+                    record = self.getRecordFromMediaGalleryProvider(imageFilename);
 
                     if (!record) {
                         mediaGallery.notLocated();
@@ -175,11 +167,29 @@ define([
                 this.imageDirectory().selectStorageRoot();
             }
 
-            if (locatedImage.length) {
-                recordIndex = locatedImage.closest('.masonry-image-column').data('repeat-index');
-                record = this.imageItems()[recordIndex];
+            if (record) {
                 this.selectRecord(record);
             }
+        },
+
+        /**
+         * Get image data by image file name
+         *
+         * @param imageFilename
+         * @returns {null|Object}
+         */
+        getRecordFromMediaGalleryProvider: function (imageFilename) {
+            var report = null;
+
+            this.imageItems.each(function (item) {
+                if (item.name === imageFilename) {
+                    report = item;
+
+                    return false;
+                }
+            });
+
+            return report;
         },
 
         /**
@@ -236,11 +246,9 @@ define([
          * @param {bool} isLicensed
          */
         save: function (record, fileName, license, isLicensed) {
-            var mediaBrowser = $(this.preview().mediaGallerySelector).data('mageMediabrowser'),
-                requestUrl = isLicensed ? this.preview().saveLicensedAndDownloadUrl :
+            var requestUrl = isLicensed ? this.preview().saveLicensedAndDownloadUrl :
                     license ? this.preview().licenseAndDownloadUrl : this.preview().downloadImagePreviewUrl,
-                destinationPath = (mediaBrowser.activeNode.path || '') + '/' + fileName + '.' +
-                    this.getImageExtension(record);
+                destinationPath = this.getDestinationPath(fileName, record);
 
             $.ajax({
                 type: 'POST',
@@ -278,7 +286,7 @@ define([
                     $.ajaxSetup({
                         async: false
                     });
-                    mediaBrowser.reload();
+                    this.reloadGrid();
                     $.ajaxSetup({
                         async: true
                     });
@@ -316,14 +324,61 @@ define([
         },
 
         /**
+         * Get image destination path
+         *
+         * @param {String} fileName
+         * @param {Object} record
+         * @returns {String}
+         */
+        getDestinationPath: function (fileName, record) {
+            var activeNodePath;
+
+            if (this.isMediaBrowser()) {
+                activeNodePath = this.getMageMediaBrowserData().activeNode.path || '';
+            } else {
+                activeNodePath = this.imageDirectory().activeNode() || '';
+            }
+
+            return activeNodePath  + '/' + fileName + '.' + this.getImageExtension(record);
+        },
+
+        /**
+         * Reload grid
+         *
+         * @returns {*}
+         */
+        reloadGrid: function () {
+            var provider,
+                dataStorage;
+
+            if (this.isMediaBrowser()) {
+                return this.getMageMediaBrowserData().reload();
+            }
+
+            provider = uiRegistry.get('index = media_gallery_listing_data_source'),
+            dataStorage = provider.storage();
+
+            // this.subscriptionOnImageItems();
+            dataStorage.clearRequests();
+            provider.reload();
+        },
+
+        /**
+         * Get data for media browser
+         *
+         * @returns {Undefined|Object}
+         */
+        getMageMediaBrowserData: function () {
+            return $(this.preview().mediaGallerySelector).data('mageMediabrowser');
+        },
+
+        /**
          * Is the media browser used in the content of the grid
          *
          * @returns {Boolean}
          */
         isMediaBrowser: function () {
-            var mediaBrowser = $(this.preview().mediaGallerySelector).data('mageMediabrowser');
-
-            return typeof mediaBrowser !== 'undefined';
+            return typeof this.getMageMediaBrowserData() !== 'undefined';
         },
 
         /**

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/media-gallery.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/media-gallery.js
@@ -78,6 +78,10 @@ define([
                 return $.trim($(this).text()) === imageFolderName;
             });
 
+            if (!imageFolder.length) {
+                imageFolder = $('.jstree a:contains("' + this.jsTreeRootFolderName + '")');
+            }
+
             if (imageFolder.length) {
                 imageFolder[0].click();
             }


### PR DESCRIPTION
### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR fixes saving adobe stock images to the new media gallery.
Also, for the old gallery, I added selecting the `Storage Root` folder if an image's folder was not found.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/adobe-stock-integration#913: Saving adobe stock images to the new media gallery.
2. magento/adobe-stock-integration#1096:  Select the image after uploading to the media gallery 
### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Login to Admin panel
2. Open Media Gallery (i.e. Catalog -> Category -> expand Content -> Select from Gallery button)
3. Click "Search Adobe Stock"
4. Open preview for an image
5. Click Save Preview button (or License and save button) -> this image should be saved and selected in the media gallery