### PR TITLE
Fix undefined error dorectories(), and Add Image action on view

### DIFF
--- a/MediaGalleryUi/view/adminhtml/templates/image_details.phtml
+++ b/MediaGalleryUi/view/adminhtml/templates/image_details.phtml
@@ -65,6 +65,7 @@ use Magento\Backend\Block\Template;
                     "mediaGalleryImageActions": {
                         "component": "Magento_MediaGalleryUi/js/image/image-actions",
                         "modalSelector": ".media-gallery-image-details-modal",
+                        "imageModelName" : "media_gallery_listing.media_gallery_listing.media_gallery_columns.thumbnail_url",
                         "mediaGalleryImageDetailsName": "mediaGalleryImageDetails",
                         "actionsList": [
                             {

--- a/MediaGalleryUi/view/adminhtml/templates/image_details.phtml
+++ b/MediaGalleryUi/view/adminhtml/templates/image_details.phtml
@@ -6,6 +6,7 @@
 
 use Magento\Backend\Block\Template;
 
+// phpcs:disable Magento2.Files.LineLength, Generic.Files.LineLength
 /** @var Template $block */
 ?>
 

--- a/MediaGalleryUi/view/adminhtml/web/js/image-uploader.js
+++ b/MediaGalleryUi/view/adminhtml/web/js/image-uploader.js
@@ -97,7 +97,8 @@ define([
          */
         getTargetFolder: function () {
 
-            if (_.isUndefined(this.directories().activeNode())) {
+            if (_.isUndefined(this.directories().activeNode()) ||
+                _.isNull(this.directories().activeNode())) {
                 return '/';
             }
 

--- a/MediaGalleryUi/view/adminhtml/web/js/image-uploader.js
+++ b/MediaGalleryUi/view/adminhtml/web/js/image-uploader.js
@@ -6,15 +6,16 @@
 define([
     'uiComponent',
     'jquery',
+    'underscore',
     'mage/translate',
     'jquery/file-uploader'
-], function (Component, $) {
+], function (Component, $, _) {
     'use strict';
 
     return Component.extend({
         defaults: {
             imageUploadInputSelector: '#image-uploader-form',
-            directoriesPath: 'media_gallery_listing.media_gallery_listing.media_gallery_directories_directories',
+            directoriesPath: 'media_gallery_listing.media_gallery_listing.media_gallery_directories',
             actionsPath: 'media_gallery_listing.media_gallery_listing.media_gallery_columns.thumbnail_url_actions',
             messagesPath: 'media_gallery_listing.media_gallery_listing.messages',
             imageUploadUrl: '',
@@ -95,13 +96,12 @@ define([
          * @returns {String}
          */
         getTargetFolder: function () {
-            var selectedFolder = this.directories().selectedFolder;
 
-            if (selectedFolder() === undefined) {
+            if (_.isUndefined(this.directories().selectedFolder)) {
                 return '/';
             }
 
-            return selectedFolder();
+            return this.directories().selectedFolder();
         },
 
         /**

--- a/MediaGalleryUi/view/adminhtml/web/js/image-uploader.js
+++ b/MediaGalleryUi/view/adminhtml/web/js/image-uploader.js
@@ -97,11 +97,11 @@ define([
          */
         getTargetFolder: function () {
 
-            if (_.isUndefined(this.directories().selectedFolder)) {
+            if (_.isUndefined(this.directories().activeNode())) {
                 return '/';
             }
 
-            return this.directories().selectedFolder();
+            return this.directories().activeNode();
         },
 
         /**


### PR DESCRIPTION
details page

<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/adobe-stock-integration#1115:Impossible to add image via "Add Image" button from View details [NOT Standalone Media Gallery] 
2. ...

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->

1. From Admin go to Content - Pages, click Add New Page
2. Expand Content,click Show / Hide Editor, click Insert Image...
3. Select an image added from Adobe Stock
4. Click on three dots near the image and select View Details
5. three_dots

**The image is added to the page**