### PR TITLE
Correct error messages on upload image action to magento standart

### DIFF
--- a/MediaGalleryUi/view/adminhtml/web/js/image-uploader.js
+++ b/MediaGalleryUi/view/adminhtml/web/js/image-uploader.js
@@ -7,17 +7,17 @@ define([
     'uiComponent',
     'jquery',
     'underscore',
+    'Magento_Ui/js/modal/alert',
     'mage/translate',
     'jquery/file-uploader'
-], function (Component, $, _) {
+], function (Component, $, _, uiAlert) {
     'use strict';
 
     return Component.extend({
         defaults: {
             imageUploadInputSelector: '#image-uploader-form',
             directoriesPath: 'media_gallery_listing.media_gallery_listing.media_gallery_directories',
-            actionsPath: 'media_gallery_listing.media_gallery_listing.media_gallery_columns.thumbnail_url_actions',
-            messagesPath: 'media_gallery_listing.media_gallery_listing.messages',
+            actionsPath: 'media_gallery_listing.media_gallery_listing.media_gallery_columns.thumbnail_url',
             imageUploadUrl: '',
             acceptFileTypes: '',
             allowedExtensions: '',
@@ -25,8 +25,7 @@ define([
             loader: false,
             modules: {
                 directories: '${ $.directoriesPath }',
-                actions: '${ $.actionsPath }',
-                mediaGridMessages: '${ $.messagesPath }'
+                actions: '${ $.actionsPath }'
             }
         },
 
@@ -82,8 +81,9 @@ define([
                     var response = data.jqXHR.responseJSON;
 
                     if (response !== undefined && response.message) {
-                        this.mediaGridMessages().add('error', $.mage.__(response.message));
-                        this.mediaGridMessages().scheduleCleanup();
+                        uiAlert({
+                            content: response.message
+                        });
                     }
                     this.hideLoader();
                 }.bind(this)


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/adobe-stock-integration#1123: "Technical problem with the server..." and "File validation failed." error messages appear if try to Upload an unsupported file type 
2. magento/adobe-stock-integration#1124 "Technical problem with the server..." and "An error occurred on attempt to uploaded the image." error messages appear if try to Upload an image with more then 5 MB size 

### Manual testing scenarios (*)

    From Admin go to Content - Pages, click Add New Page
    Expand Content,click Show / Hide Editor, click Insert Image...
    Select a folder from the folder tree
    Click Upload Image button
    Select an unsupported file from your local machine, txt for example and click Open

A propper message like on NOT Enhanced Media Gallery