### PR TITLE
Correct Page Builder plugin, with undefined key

### DIFF
--- a/MediaGalleryIntegration/Plugin/UpdateOpenDialogUrlPageBuilder.php
+++ b/MediaGalleryIntegration/Plugin/UpdateOpenDialogUrlPageBuilder.php
@@ -46,7 +46,6 @@ class UpdateOpenDialogUrlPageBuilder
      */
     public function afterGetData($subject, array $itemName)
     {
-        $newItem = [];
         if ($this->config->isEnabled()) {
             $itemName['openDialogUrl'] = $this->url->getUrl('media_gallery/index/index');
         }

--- a/MediaGalleryIntegration/Plugin/UpdateOpenDialogUrlPageBuilder.php
+++ b/MediaGalleryIntegration/Plugin/UpdateOpenDialogUrlPageBuilder.php
@@ -48,10 +48,7 @@ class UpdateOpenDialogUrlPageBuilder
     {
         $newItem = [];
         if ($this->config->isEnabled()) {
-            foreach ($itemName as $key) {
-                $newItem[$key] = $this->url->getUrl('media_gallery/index/index');
-            }
-            return $newItem;
+            $itemName['openDialogUrl'] = $this->url->getUrl('media_gallery/index/index');
         }
         return $itemName;
     }


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/adobe-stock-integration#<issue_number>: Issue title
2. ...

### Manual testing scenarios (*)


    From Admin go to Content - Pages, click Add New Page
    Expand Content, Expand Media
    Drag and drop Image on the Row section
    Click Select from Gallery
Not Enhanced Media Gallery is opened