### PR TITLE
Move component names to xml configutation, fix save preview on standalone page && adobe stock info on gallery page

### DIFF
--- a/AdobeStockImageAdminUi/view/adminhtml/layout/cms_wysiwyg_images_index.xml
+++ b/AdobeStockImageAdminUi/view/adminhtml/layout/cms_wysiwyg_images_index.xml
@@ -8,6 +8,10 @@
 <layout xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/layout_generic.xsd">
     <referenceContainer name="root">
         <block class="Magento\Backend\Block\Template" name="stock.panel" template="Magento_AdobeStockImageAdminUi::panel.phtml" aclResource="Magento_AdobeStockImageAdminUi::save_preview_images">
+            <arguments>
+                <argument name="masonry_component_path" xsi:type="string">adobe_stock_images_listing.adobe_stock_images_listing.adobe_stock_images_columns</argument>
+                <argument name="data_source_path" xsi:type="string">adobe_stock_images_listing.adobe_stock_images_listing_data_source</argument>
+            </arguments>
             <block class="Magento\AdobeIms\Block\Adminhtml\SignIn" name="adobe.signIn" template="Magento_AdobeIms::signIn.phtml" aclResource="Magento_AdobeIms::adobe_ims">
                 <arguments>
                     <argument name="configProviders" xsi:type="array">

--- a/AdobeStockImageAdminUi/view/adminhtml/layout/media_gallery_index_index.xml
+++ b/AdobeStockImageAdminUi/view/adminhtml/layout/media_gallery_index_index.xml
@@ -9,6 +9,10 @@
         xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/layout_generic.xsd">
     <referenceContainer name="root">
         <block class="Magento\Backend\Block\Template" name="stock.panel" template="Magento_AdobeStockImageAdminUi::panel.phtml" aclResource="Magento_AdobeStockImageAdminUi::save_preview_images">
+            <arguments>
+                <argument name="masonry_component_path" xsi:type="string">adobe_stock_images_listing.adobe_stock_images_listing.adobe_stock_images_columns</argument>
+                <argument name="data_source_path" xsi:type="string">adobe_stock_images_listing.adobe_stock_images_listing_data_source</argument>
+            </arguments>
             <block class="Magento\AdobeIms\Block\Adminhtml\SignIn" name="adobe.signIn" template="Magento_AdobeIms::signIn.phtml" aclResource="Magento_AdobeIms::adobe_ims">
                 <arguments>
                     <argument name="configProviders" xsi:type="array">

--- a/AdobeStockImageAdminUi/view/adminhtml/layout/media_gallery_media_index.xml
+++ b/AdobeStockImageAdminUi/view/adminhtml/layout/media_gallery_media_index.xml
@@ -10,6 +10,10 @@
     <body>
         <referenceContainer name="content">
             <block class="Magento\Backend\Block\Template" name="stock.panel" template="Magento_AdobeStockImageAdminUi::panel.phtml" aclResource="Magento_AdobeStockImageAdminUi::save_preview_images">
+		<arguments>
+		    <argument name="masonry_component_path" xsi:type="string">standalone_adobe_stock_images_listing.standalone_adobe_stock_images_listing.adobe_stock_images_columns</argument>
+		    <argument name="data_source_path" xsi:type="string">standalone_adobe_stock_images_listing.standalone_adobe_stock_images_listing_data_source</argument>
+                </arguments>
                 <block class="Magento\AdobeIms\Block\Adminhtml\SignIn" name="adobe.signIn" template="Magento_AdobeIms::signIn.phtml" aclResource="Magento_AdobeStockImageAdminUi::save_preview_images">
                     <arguments>
                         <argument name="configProviders" xsi:type="array">
@@ -17,7 +21,7 @@
                         </argument>
                     </arguments>
                 </block>
-                <uiComponent name="adobe_stock_images_listing"/>
+                <uiComponent name="standalone_adobe_stock_images_listing"/>
             </block>
             <referenceBlock name="media.gallery.container">
                 <block class="Magento\Backend\Block\Template" name="adobe.stock.image.details" template="Magento_AdobeStockImageAdminUi::image_details/adobe_stock.phtml" after="image.details" aclResource="Magento_AdobeStockImageAdminUi::save_preview_images"/>

--- a/AdobeStockImageAdminUi/view/adminhtml/layout/media_gallery_media_index.xml
+++ b/AdobeStockImageAdminUi/view/adminhtml/layout/media_gallery_media_index.xml
@@ -23,9 +23,9 @@
                 </block>
                 <uiComponent name="standalone_adobe_stock_images_listing"/>
             </block>
-            <referenceBlock name="media.gallery.container">
+            <referenceContainer name="content">
                 <block class="Magento\Backend\Block\Template" name="adobe.stock.image.details" template="Magento_AdobeStockImageAdminUi::image_details/adobe_stock.phtml" after="image.details" aclResource="Magento_AdobeStockImageAdminUi::save_preview_images"/>
-            </referenceBlock>
+            </referenceContainer>
         </referenceContainer>
     </body>
 </page>

--- a/AdobeStockImageAdminUi/view/adminhtml/templates/panel.phtml
+++ b/AdobeStockImageAdminUi/view/adminhtml/templates/panel.phtml
@@ -22,7 +22,8 @@
                     "stock_panel": {
                         "component": "Magento_AdobeStockImageAdminUi/js/panel",
                         "containerId": ".adobe-search-images-modal",
-                        "masonryComponentPath": "adobe_stock_images_listing.adobe_stock_images_listing.adobe_stock_images_columns"
+                        "masonryComponentPath":"<?= $block->escapeJs($block->getData('masonry_component_path')); ?>",
+                        "dataSourcePath": "<?= $block->escapeJs($block->getData('data_source_path')); ?>"
                     }
                 }
             },

--- a/AdobeStockImageAdminUi/view/adminhtml/ui_component/standalone_adobe_stock_images_listing.xml
+++ b/AdobeStockImageAdminUi/view/adminhtml/ui_component/standalone_adobe_stock_images_listing.xml
@@ -8,14 +8,14 @@
 <listing xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Ui:etc/ui_configuration.xsd">
     <argument name="data" xsi:type="array">
         <item name="js_config" xsi:type="array">
-            <item name="provider" xsi:type="string">adobe_stock_images_listing.adobe_stock_images_listing_data_source
+            <item name="provider" xsi:type="string">standalone_adobe_stock_images_listing.adobe_stock_images_listing_data_source
             </item>
         </item>
     </argument>
     <settings>
         <spinner>adobe_stock_images_columns</spinner>
         <deps>
-            <dep>adobe_stock_images_listing.adobe_stock_images_listing_data_source</dep>
+            <dep>standalone_adobe_stock_images_listing.adobe_stock_images_listing_data_source</dep>
         </deps>
     </settings>
     <dataSource name="adobe_stock_images_listing_data_source" component="Magento_Ui/js/grid/provider">
@@ -54,7 +54,7 @@
         </paging>
 	<container
 		name="sorting"
-		provider="adobe_stock_images_listing.adobe_stock_images_listing_data_source"
+		provider="standalone_adobe_stock_images_listing.adobe_stock_images_listing_data_source"
 		displayArea="sorting"
 		sortOrder="20"
 		component="Magento_Ui/js/grid/sortBy">
@@ -62,7 +62,7 @@
                 <item name="config" xsi:type="array">
                     <item name="deps" xsi:type="array">
                         <item name="0" xsi:type="string">
-                            adobe_stock_images_listing.adobe_stock_images_listing.adobe_stock_images_columns
+                            standalone_adobe_stock_images_listing.standalone_adobe_stock_images_listing.adobe_stock_images_columns
                         </item>
                     </item>
                 </item>
@@ -202,9 +202,9 @@
         <column name="preview" class="Magento\AdobeStockImageAdminUi\Ui\Component\Listing\Columns\ImagePreview" component="Magento_AdobeStockImageAdminUi/js/components/grid/column/image-preview">
             <argument name="data" xsi:type="array">
                 <item name="config" xsi:type="array">
-                    <item name="messagesName" xsi:type="string">adobe_stock_images_listing.adobe_stock_images_listing.messages</item>
-                    <item name="mediaGalleryName" xsi:type="string">media_gallery_listing.media_gallery_listing.media_gallery_directories</item>
-                    <item name="mediaGalleryProvider" xsi:type="string">media_gallery_listing.media_gallery_listing_data_source</item>
+                    <item name="messagesName" xsi:type="string">standalone_adobe_stock_images_listing.standalone_adobe_stock_images_listing.messages</item>
+                    <item name="mediaGalleryName" xsi:type="string">standalone_media_gallery_listing.standalone_media_gallery_listing.media_gallery_directories</item>		    
+                    <item name="mediaGalleryProvider" xsi:type="string">standalone_media_gallery_listing.media_gallery_listing_data_source</item>
 		</item>
             </argument>
             <settings>

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/image-preview.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/image-preview.js
@@ -20,7 +20,6 @@ define([
             mediaGallerySelector: '.media-gallery-modal:has(#search_adobe_stock)',
             adobeStockModalSelector: '.adobe-search-images-modal',
             activeMediaGallerySelector: 'aside.modal-slide.adobe-stock-modal._show',
-            messagesName: 'adobe_stock_images_listing.adobe_stock_images_listing.messages',
             modules: {
                 keywords: '${ $.name }_keywords',
                 related: '${ $.name }_related',
@@ -39,7 +38,9 @@ define([
                     component: 'Magento_AdobeStockImageAdminUi/js/components/grid/column/preview/actions',
                     name: '${ $.name }_actions',
                     provider: '${ $.provider }',
-                    messagesName: '${ $.messagesName }'
+                    mediaGalleryName: '${ $.mediaGalleryName }',
+                    messagesName: '${ $.messagesName }',
+                    mediaGalleryProvider: '${ $.mediaGalleryProvider }'
                 }
             ]
         },

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/actions.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/actions.js
@@ -27,8 +27,6 @@ define([
             buyCreditsUrl: 'https://stock.adobe.com/',
             messageDelay: 5,
             imageItems: [],
-            mediaGalleryProvider: 'media_gallery_listing.media_gallery_listing_data_source',
-            mediaGalleryDirectoryComponent: 'media_gallery_listing.media_gallery_listing.media_gallery_directories',
             listens: {
                 '${ $.provider }:data.items': 'updateActions'
             },
@@ -38,7 +36,7 @@ define([
                 overlay: '${ $.parentName }.overlay',
                 source: '${ $.provider }',
                 messages: '${ $.messagesName }',
-                imageDirectory: '${ $.mediaGalleryDirectoryComponent }'
+                imageDirectory: '${ $.mediaGalleryName }'
             },
             imports: {
                 imageItems: '${ $.mediaGalleryProvider }:data.items'

--- a/MediaGalleryUi/view/adminhtml/templates/image_details.phtml
+++ b/MediaGalleryUi/view/adminhtml/templates/image_details.phtml
@@ -11,7 +11,6 @@ use Magento\Framework\Escaper;
 /** @var Template $block */
 /** @var $escaper Escaper */
 
-// phpcs:disable Magento2.Files.LineLength, Generic.Files.LineLength
 ?>
 
 <div class="media-gallery-image-details-modal"

--- a/MediaGalleryUi/view/adminhtml/templates/image_details_standalone.phtml
+++ b/MediaGalleryUi/view/adminhtml/templates/image_details_standalone.phtml
@@ -68,7 +68,15 @@ use Magento\Backend\Block\Template;
                         "mediaGalleryImageDetailsName": "mediaGalleryImageDetails",
                         "targetElementId": "<?= $block->escapeJs($block->getData('targetElementId')); ?>",
                         "skipButton": "<?= $block->escapeJs($block->getData('skipButton')); ?>",
+                        "imageModelName" : "standalone_media_gallery_listing.standalone_media_gallery_listing.media_gallery_columns.thumbnail_url",
                         "actionsList": [
+                           {
+                                "title": "<?= $escaper->escapeJs(__('Delete Image')); ?>",
+                                "handler": "deleteImageAction",
+                                "name": "delete",
+                                "classes": "action-default scalable delete action-quaternary"
+                            },
+
                             {
                                 "title": "<?= $block->escapeJs(__('Cancel')); ?>",
                                 "handler": "closeModal",

--- a/MediaGalleryUi/view/adminhtml/templates/image_details_standalone.phtml
+++ b/MediaGalleryUi/view/adminhtml/templates/image_details_standalone.phtml
@@ -6,6 +6,7 @@
 
 use Magento\Backend\Block\Template;
 
+// phpcs:disable Magento2.Files.LineLength, Generic.Files.LineLength
 /** @var Template $block */
 ?>
 

--- a/MediaGalleryUi/view/adminhtml/web/css/source/_module.less
+++ b/MediaGalleryUi/view/adminhtml/web/css/source/_module.less
@@ -140,10 +140,6 @@
             right: 0;
             width: 10%;
 
-            .action-select-wrap {
-                cursor: pointer;
-            }
-
             .three-dots {
                 &:before {
                     content: url("@{baseDir}Magento_MediaGalleryUi/images/3-dots.png");
@@ -255,7 +251,6 @@
 
                 .image-details-section {
                     margin-bottom: 40px;
-                    min-width: 350px;
                     word-wrap: anywhere;
                     .lib-clearfix();
                 }


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
Fixed save action on standalone media gallery page.

### Manual testing scenarios (*)

    From Admin go to Content - Media Media Gallery
    Select an image added from Adobe Stock
    Click on three dots, select View Details
    Verify Adobe Stock details

 From Admin go to Content - Media Media Gallery
Click on Adobe Stock Search Button
 try to save image, or license image