### PR TITLE
Add filtering by "Source" to Standalone Media Gallery

### DIFF
--- a/AdobeStockImageAdminUi/Ui/Component/Listing/Columns/Source/Options.php
+++ b/AdobeStockImageAdminUi/Ui/Component/Listing/Columns/Source/Options.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\AdobeStockImageAdminUi\Ui\Component\Listing\Columns\Source;
+
+use Magento\Framework\Data\OptionSourceInterface;
+
+/**
+ * Image source filter options
+ */
+class Options implements OptionSourceInterface
+{
+    /**
+     * @inheritdoc
+     */
+    public function toOptionArray(): array
+    {
+        return [
+            [
+                'value' => 'Adobe Stock',
+                'label' =>  __('Adobe Stock'),
+            ],
+            [
+                'value' => 'Local',
+                'label' =>  __('Uploaded Locally'),
+            ],
+        ];
+    }
+}

--- a/AdobeStockImageAdminUi/view/adminhtml/ui_component/media_gallery_listing.xml
+++ b/AdobeStockImageAdminUi/view/adminhtml/ui_component/media_gallery_listing.xml
@@ -27,6 +27,14 @@
                     <dataScope>licensed</dataScope>
                 </settings>
             </filterSelect>
+            <filterSelect name="source" provider="${ $.parentName }" sortOrder="60">
+                <settings>
+                    <caption translate="true">All</caption>
+                    <options class="Magento\AdobeStockImageAdminUi\Ui\Component\Listing\Columns\Source\Options"/>
+                    <label translate="true">Source</label>
+                    <dataScope>source</dataScope>
+                </settings>
+            </filterSelect>
         </filters>
     </listingToolbar>
     <columns name="media_gallery_columns">

--- a/AdobeStockImageAdminUi/view/adminhtml/ui_component/standalone_media_gallery_listing.xml
+++ b/AdobeStockImageAdminUi/view/adminhtml/ui_component/standalone_media_gallery_listing.xml
@@ -27,6 +27,14 @@
                     <dataScope>licensed</dataScope>
                 </settings>
             </filterSelect>
+            <filterSelect name="source" provider="${ $.parentName }" sortOrder="60">
+                <settings>
+                    <caption translate="true">All</caption>
+                    <options class="Magento\AdobeStockImageAdminUi\Ui\Component\Listing\Columns\Source\Options"/>
+                    <label translate="true">Source</label>
+                    <dataScope>source</dataScope>
+                </settings>
+            </filterSelect>
         </filters>
     </listingToolbar>
     <columns name="media_gallery_columns">

--- a/MediaGalleryUi/Model/UpdateAssetInGrid.php
+++ b/MediaGalleryUi/Model/UpdateAssetInGrid.php
@@ -20,6 +20,8 @@ use Psr\Log\LoggerInterface;
  */
 class UpdateAssetInGrid
 {
+    private const SOURCE_LOCAL = 'Local';
+
     /**
      * @var ResourceConnection
      */
@@ -87,7 +89,7 @@ class UpdateAssetInGrid
                     //phpcs:ignore Magento2.Functions.DiscouragedFunction
                     'name' => basename($asset->getPath()),
                     'content_type' => strtoupper(str_replace('image/', '', $asset->getContentType())),
-                    'source' => $asset->getSource(),
+                    'source' => $asset->getSource() ?: self::SOURCE_LOCAL,
                     'width' => $asset->getWidth(),
                     'height' => $asset->getHeight(),
                     'size' => $asset->getSize(),


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Add filtering by "Source" to Standalone Media Gallery and New Media Gallery
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/adobe-stock-integration#1139: Add filtering by "Source" to Standalone Media Gallery
2. ...

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
See https://github.com/magento/adobe-stock-integration/issues/1139