### PR TITLE
The "See more" button doesn't work when More images are loaded and the same image is previewed again

### DIFF
--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/related.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/related.js
@@ -14,7 +14,7 @@ define([
         defaults: {
             template: 'Magento_AdobeStockImageAdminUi/grid/column/preview/related',
             filterChipsProvider: 'componentType = filters, ns = ${ $.ns }',
-            filterInputSelector: 'input#words',
+            filterInputSelector: '#words',
             tabImagesLimit: 4,
             serieFilterValue: '',
             modelFilterValue: '',

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/related.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/related.js
@@ -14,7 +14,7 @@ define([
         defaults: {
             template: 'Magento_AdobeStockImageAdminUi/grid/column/preview/related',
             filterChipsProvider: 'componentType = filters, ns = ${ $.ns }',
-            filterInputSelector: '#words',
+            filterBookmarksSelector: '.admin__data-grid-action-bookmarks',
             tabImagesLimit: 4,
             serieFilterValue: '',
             modelFilterValue: '',
@@ -251,7 +251,7 @@ define([
          * Scrolls user window to the filter input
          */
         scrollToFilter: function () {
-            $(this.filterInputSelector).get(0).scrollIntoView({
+            $(this.filterBookmarksSelector).get(0).scrollIntoView({
                 behavior: 'smooth',
                 block: 'center',
                 inline: 'nearest'

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/related.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/related.js
@@ -248,7 +248,7 @@ define([
         },
 
         /**
-         * Scrolls user window to the filter input
+         * Scrolls user window to the filter bookmarks
          */
         scrollToFilter: function () {
             $(this.filterBookmarksSelector).get(0).scrollIntoView({

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/related.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/related.js
@@ -14,7 +14,7 @@ define([
         defaults: {
             template: 'Magento_AdobeStockImageAdminUi/grid/column/preview/related',
             filterChipsProvider: 'componentType = filters, ns = ${ $.ns }',
-            filterTitleSelector: '.admin__current-filters-title-wrap',
+            filterInputSelector: 'input#words',
             tabImagesLimit: 4,
             serieFilterValue: '',
             modelFilterValue: '',
@@ -248,10 +248,10 @@ define([
         },
 
         /**
-         * Scrolls user window to the filter title
+         * Scrolls user window to the filter input
          */
         scrollToFilter: function () {
-            $(this.filterTitleSelector).get(0).scrollIntoView({
+            $(this.filterInputSelector).get(0).scrollIntoView({
                 behavior: 'smooth',
                 block: 'center',
                 inline: 'nearest'


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/adobe-stock-integration#850: The "See more" button doesn't work when More images are loaded and the same image is previewed again
2. ...

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...