### PR TITLE
License an image from the Media Gallery

### DIFF
--- a/AdobeStockImageAdminUi/view/adminhtml/ui_component/media_gallery_listing.xml
+++ b/AdobeStockImageAdminUi/view/adminhtml/ui_component/media_gallery_listing.xml
@@ -37,5 +37,12 @@
                 <sortable>false</sortable>
             </settings>
         </column>
+	<column name="thumbnail_url" component="Magento_AdobeStockImageAdminUi/js/mediaGallery/grid/columns/licenseImage">
+            <argument name="data" xsi:type="array">
+                <item name="config" xsi:type="array">
+                    <item name="imageDetailsurl" xsi:type="url" path="media_gallery/image/details"/>
+		</item>
+	    </argument>
+	</column>
     </columns>
 </listing>

--- a/AdobeStockImageAdminUi/view/adminhtml/ui_component/media_gallery_listing.xml
+++ b/AdobeStockImageAdminUi/view/adminhtml/ui_component/media_gallery_listing.xml
@@ -41,7 +41,8 @@
             <argument name="data" xsi:type="array">
                 <item name="config" xsi:type="array">
                     <item name="imageDetailsurl" xsi:type="url" path="media_gallery/image/details"/>
-		</item>
+                    <item name="imageComponent" xsi:type="string">adobe_stock_images_listing.adobe_stock_images_listing.adobe_stock_images_columns.preview</item>
+                </item>
 	    </argument>
 	</column>
     </columns>

--- a/AdobeStockImageAdminUi/view/adminhtml/ui_component/standalone_media_gallery_listing.xml
+++ b/AdobeStockImageAdminUi/view/adminhtml/ui_component/standalone_media_gallery_listing.xml
@@ -37,5 +37,13 @@
                 <sortable>false</sortable>
             </settings>
         </column>
+        <column name="thumbnail_url" component="Magento_AdobeStockImageAdminUi/js/mediaGallery/grid/columns/licenseImage">
+            <argument name="data" xsi:type="array">
+                <item name="config" xsi:type="array">
+                    <item name="imageDetailsurl" xsi:type="url" path="media_gallery/image/details"/>
+                    <item name="imageComponent" xsi:type="string">adobe_stock_images_listing.adobe_stock_images_listing.adobe_stock_images_columns.preview</item>
+                </item>
+	    </argument>
+	</column>
     </columns>
 </listing>

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/mediaGallery/grid/columns/image/licenseActions.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/mediaGallery/grid/columns/image/licenseActions.js
@@ -1,0 +1,112 @@
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+define([
+    'jquery',
+    'Magento_MediaGalleryUi/js/grid/columns/image/actions'
+], function ($, Action) {
+    'use strict';
+
+    return Action.extend({
+        defaults: {
+            adobeStockModalSelector: '.adobe-search-images-modal',
+            imageComponent: 'adobe_stock_images_listing.adobe_stock_images_listing.adobe_stock_images_columns.preview',
+            template: 'Magento_AdobeStockImageAdminUi/mediaGallery/grid/columns/image/licenseActions',
+            licenseAction: {
+                name: 'license',
+                title: 'License',
+                handler: 'licenseImageAction'
+            },
+            modules: {
+                image: '${ $.imageComponent }'
+            }
+        },
+
+        /**
+         * Initialize the component
+         *
+         * @returns {Object}
+         */
+        initialize: function () {
+            this._super().observe(['visible', 'licenseImage']);
+            this.actionsList.push(this.licenseAction);
+
+            return this;
+        },
+
+        /**
+         * License image
+         */
+        licenseImageAction: function (record) {
+            console.log(record.id);
+            this.getImageRecord(record.id);
+        },
+
+        /**
+         * Check if image licensed
+         */
+        isVisible: function (record, name) {
+
+            if (name === this.licenseAction.name) {
+                return record.licensed  ? true  : false;
+            }
+
+            return true;
+        },
+
+        /**
+         * Return image record fo license action
+         */
+        getImageRecord: function (imageId) {
+            $.ajax({
+                type: 'GET',
+                url: this.imageDetailsUrl,
+                dataType: 'json',
+                showLoader: true,
+                data: {
+                    'id': imageId
+                },
+                context: this,
+
+                /**
+                 * Success handler for deleting image
+                 *
+                 * @param {Object} response
+                 */
+                success: function (response) {
+                    $.ajaxSetup({
+                        async: false
+                    });
+
+                    response.imageDetails.id =  response.imageDetails['adobe_stock'][0].value;
+                    response.imageDetails.category =  response.imageDetails['adobe_stock'][3].value;
+                    this.image().actions().showLicenseConfirmation(response.imageDetails);
+
+                    $.ajaxSetup({
+                        async: true
+                    });
+                    this.imageModel().reloadGrid();
+                }.bind(this),
+
+                /**
+                 * Error handler for deleting image
+                 *
+                 * @param {Object} response
+                 */
+                error: function (response) {
+                    var message;
+
+                    if (typeof response.responseJSON === 'undefined' ||
+                        typeof response.responseJSON.message === 'undefined'
+                    ) {
+                        message = 'There was an error on attempt to get the image details.';
+                    } else {
+                        message = response.responseJSON.message;
+                    }
+                    console.log(response);
+                }.bind(this)
+            });
+        }
+    });
+});

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/mediaGallery/grid/columns/image/licenseActions.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/mediaGallery/grid/columns/image/licenseActions.js
@@ -11,7 +11,6 @@ define([
     return Action.extend({
         defaults: {
             adobeStockModalSelector: '.adobe-search-images-modal',
-            imageComponent: 'adobe_stock_images_listing.adobe_stock_images_listing.adobe_stock_images_columns.preview',
             template: 'Magento_AdobeStockImageAdminUi/mediaGallery/grid/columns/image/licenseActions',
             licenseAction: {
                 name: 'license',

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/mediaGallery/grid/columns/image/licenseActions.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/mediaGallery/grid/columns/image/licenseActions.js
@@ -4,13 +4,13 @@
  */
 define([
     'jquery',
-    'Magento_MediaGalleryUi/js/grid/columns/image/actions'
-], function ($, Action) {
+    'Magento_MediaGalleryUi/js/grid/columns/image/actions',
+    'Magento_Ui/js/modal/alert'
+], function ($, Action, uiAlert) {
     'use strict';
 
     return Action.extend({
         defaults: {
-            adobeStockModalSelector: '.adobe-search-images-modal',
             template: 'Magento_AdobeStockImageAdminUi/mediaGallery/grid/columns/image/licenseActions',
             licenseAction: {
                 name: 'license',
@@ -28,7 +28,7 @@ define([
          * @returns {Object}
          */
         initialize: function () {
-            this._super().observe(['visible', 'licenseImage']);
+            this._super().observe(['visible']);
             this.actionsList.push(this.licenseAction);
 
             return this;
@@ -36,26 +36,32 @@ define([
 
         /**
          * License image
+         *
+         * @param {Object} record
          */
         licenseImageAction: function (record) {
-            console.log(record.id);
             this.getImageRecord(record.id);
         },
 
         /**
          * Check if image licensed
+         *
+         * @param {Object} record
+         * @param {Object} name
          */
         isVisible: function (record, name) {
 
             if (name === this.licenseAction.name) {
-                return record.licensed  ? true  : false;
+                return (record.licensed == 0)  ? true  : false;
             }
 
             return true;
         },
 
         /**
-         * Return image record fo license action
+         * Get image record and start license process
+         *
+         * @param {Number} imageId
          */
         getImageRecord: function (imageId) {
             $.ajax({
@@ -103,7 +109,10 @@ define([
                     } else {
                         message = response.responseJSON.message;
                     }
-                    console.log(response);
+                    uiAlert({
+                        content: message
+                    });
+
                 }.bind(this)
             });
         }

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/mediaGallery/grid/columns/image/licenseActions.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/mediaGallery/grid/columns/image/licenseActions.js
@@ -52,7 +52,7 @@ define([
         isVisible: function (record, name) {
 
             if (name === this.licenseAction.name) {
-                return (record.licensed == 0)  ? true  : false;
+                return record.licensed === 0  ? true  : false;
             }
 
             return true;
@@ -114,7 +114,7 @@ define([
                         content: message
                     });
 
-                }.bind(this)
+                }
             });
         }
     });

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/mediaGallery/grid/columns/image/licenseActions.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/mediaGallery/grid/columns/image/licenseActions.js
@@ -86,7 +86,8 @@ define([
 
                     response.imageDetails.id =  response.imageDetails['adobe_stock'][0].value;
                     response.imageDetails.category =  response.imageDetails['adobe_stock'][3].value;
-                    this.image().actions().showLicenseConfirmation(response.imageDetails);
+                    this.image().displayedRecord(response.imageDetails);
+                    this.image().actions().licenseProcess();
 
                     $.ajaxSetup({
                         async: true

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/mediaGallery/grid/columns/image/licenseActions.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/mediaGallery/grid/columns/image/licenseActions.js
@@ -52,7 +52,7 @@ define([
         isVisible: function (record, name) {
 
             if (name === this.licenseAction.name) {
-                return record.licensed === 0  ? true  : false;
+                return parseInt(record.licensed) === 0  ? true  : false;
             }
 
             return true;

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/mediaGallery/grid/columns/image/licenseActions.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/mediaGallery/grid/columns/image/licenseActions.js
@@ -5,8 +5,9 @@
 define([
     'jquery',
     'Magento_MediaGalleryUi/js/grid/columns/image/actions',
-    'Magento_Ui/js/modal/alert'
-], function ($, Action, uiAlert) {
+    'Magento_Ui/js/modal/alert',
+    'underscore'
+], function ($, Action, uiAlert, _) {
     'use strict';
 
     return Action.extend({
@@ -28,8 +29,22 @@ define([
          * @returns {Object}
          */
         initialize: function () {
-            this._super().observe(['visible']);
+            this._super();
             this.actionsList.push(this.licenseAction);
+
+            return this;
+        },
+
+        /**
+         * Init observable variables
+         *
+         * @return {Object}
+         */
+        initObservable: function () {
+            this._super()
+                .observe([
+                    'visible'
+                ]);
 
             return this;
         },
@@ -51,6 +66,10 @@ define([
          */
         isVisible: function (record, name) {
             if (name === this.licenseAction.name) {
+                if (_.isNull(record.licensed)) {
+                    return false;
+                }
+
                 return !parseInt(record.licensed, 16);
             }
 

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/mediaGallery/grid/columns/image/licenseActions.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/mediaGallery/grid/columns/image/licenseActions.js
@@ -14,7 +14,7 @@ define([
             template: 'Magento_AdobeStockImageAdminUi/mediaGallery/grid/columns/image/licenseActions',
             licenseAction: {
                 name: 'license',
-                title: 'License',
+                title: $.mage.__('License'),
                 handler: 'licenseImageAction'
             },
             modules: {
@@ -50,9 +50,8 @@ define([
          * @param {Object} name
          */
         isVisible: function (record, name) {
-
             if (name === this.licenseAction.name) {
-                return parseInt(record.licensed, 16) === 0  ? true  : false;
+                return !parseInt(record.licensed, 16);
             }
 
             return true;
@@ -80,19 +79,12 @@ define([
                  * @param {Object} response
                  */
                 success: function (response) {
-                    $.ajaxSetup({
-                        async: false
-                    });
-
                     response.imageDetails.id =  response.imageDetails['adobe_stock'][0].value;
                     response.imageDetails.category =  response.imageDetails['adobe_stock'][3].value;
                     this.image().displayedRecord(response.imageDetails);
                     this.image().actions().licenseProcess();
-
-                    $.ajaxSetup({
-                        async: true
-                    });
                     this.imageModel().reloadGrid();
+
                 }.bind(this),
 
                 /**
@@ -106,7 +98,7 @@ define([
                     if (typeof response.responseJSON === 'undefined' ||
                         typeof response.responseJSON.message === 'undefined'
                     ) {
-                        message = 'There was an error on attempt to get the image details.';
+                        message = $.mage.__('There was an error on attempt to get the image details.');
                     } else {
                         message = response.responseJSON.message;
                     }

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/mediaGallery/grid/columns/image/licenseActions.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/mediaGallery/grid/columns/image/licenseActions.js
@@ -52,7 +52,7 @@ define([
         isVisible: function (record, name) {
 
             if (name === this.licenseAction.name) {
-                return parseInt(record.licensed) === 0  ? true  : false;
+                return parseInt(record.licensed, 16) === 0  ? true  : false;
             }
 
             return true;

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/mediaGallery/grid/columns/licenseImage.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/mediaGallery/grid/columns/licenseImage.js
@@ -14,7 +14,8 @@ define([
                     component: 'Magento_AdobeStockImageAdminUi/js/mediaGallery/grid/columns/image/licenseActions',
                     name: '${ $.name }_actions',
                     imageModelName: '${ $.name }',
-                    imageDetailsUrl: '${ $.imageDetailsurl }'
+                    imageDetailsUrl: '${ $.imageDetailsurl }',
+                    imageComponent: '${ $.imageComponent }'
                 }
             ]
         }

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/mediaGallery/grid/columns/licenseImage.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/mediaGallery/grid/columns/licenseImage.js
@@ -1,0 +1,22 @@
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+define([
+    'Magento_MediaGalleryUi/js/grid/columns/image'
+], function (Image) {
+    'use strict';
+
+    return Image.extend({
+        defaults: {
+            viewConfig: [
+                {
+                    component: 'Magento_AdobeStockImageAdminUi/js/mediaGallery/grid/columns/image/licenseActions',
+                    name: '${ $.name }_actions',
+                    imageModelName: '${ $.name }',
+                    imageDetailsUrl: '${ $.imageDetailsurl }'
+                }
+            ]
+        }
+    });
+});

--- a/AdobeStockImageAdminUi/view/adminhtml/web/template/mediaGallery/grid/columns/image/licenseActions.html
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/template/mediaGallery/grid/columns/image/licenseActions.html
@@ -1,0 +1,13 @@
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+
+<!-- ko  foreach: { data: actionsList, as: 'action' } -->
+    <li>
+        <a class="action-menu-item" href=""
+           data-bind="visible: $parent.isVisible($row(), action.name), text: action.title, click: $parent[action.handler].bind($parent, $row()), 'data-action': 'item-' + action.name" />
+    </li>
+<!-- /ko -->

--- a/MediaGalleryUi/Model/GetImageDetailsByAssetId.php
+++ b/MediaGalleryUi/Model/GetImageDetailsByAssetId.php
@@ -116,6 +116,7 @@ class GetImageDetailsByAssetId
         return [
             'image_url' => $this->getUrl($asset->getPath()),
             'title' => $asset->getTitle(),
+            'path' => $asset->getPath(),
             'id' => $assetId,
             'details' => [
                 [

--- a/MediaGalleryUi/view/adminhtml/web/js/grid/columns/image/actions.js
+++ b/MediaGalleryUi/view/adminhtml/web/js/grid/columns/image/actions.js
@@ -18,12 +18,12 @@ define([
             actionsList: [
                 {
                     name: 'image-details',
-                    title: 'View Details',
+                    title: $.mage.__('View Details'),
                     handler: 'viewImageDetails'
                 },
                 {
                     name: 'delete',
-                    title: 'Delete',
+                    title: $.mage.__('Delete'),
                     handler: 'deleteImageAction'
                 }
             ],


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Standalone functionality will work after merge -> https://github.com/magento/adobe-stock-integration/pull/1149/files
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/adobe-stock-integration#910: License an image from the Media Gallery
2. ...

 Manual testing scenarios (*)
1. Install Magento and Adobe Stock Integration [See documentation](https://github.com/magento/adobe-stock-integration/wiki/Installation-Guide)
2. Have a preview image saved from Adobe Stock
3. Have Adobe Stock account with credits - contact @sivaschenko 

Steps to reproduce (*)
1. Login to Admin panel
2. Open Media Gallery (i.e. Catalog -> Category -> expand Content -> Select from Gallery button)
3. Open the menu for the preview image saved from Adobe Stock

"License" option is present in the image menu. Selecting the option initiates the images licensing process