### PR TITLE
Fix save image inserted to wysiwyg as directive with media url

### DIFF
--- a/MediaGalleryUi/Ui/Component/Listing/Columns/Url.php
+++ b/MediaGalleryUi/Ui/Component/Listing/Columns/Url.php
@@ -71,7 +71,7 @@ class Url extends Column
     {
         if (isset($dataSource['data']['items'])) {
             foreach ($dataSource['data']['items'] as & $item) {
-                $item['encoded_id'] = $this->images->idEncode($item[$this->getData('name')]);
+                $item['encoded_id'] = $this->images->idEncode($item['name']);
                 $item[$this->getData('name')] = $this->getUrl($item[$this->getData('name')]);
             }
         }

--- a/MediaGalleryUi/view/adminhtml/web/js/grid/columns/image/insertImageAction.js
+++ b/MediaGalleryUi/view/adminhtml/web/js/grid/columns/image/insertImageAction.js
@@ -33,6 +33,8 @@ define([
                 throw 'Target element not found for content update';
             }
 
+            console.log(record['encoded_id']);
+
             if (targetElement.is('textarea')) {
                 $.ajax({
                     url: config.onInsertUrl,
@@ -47,6 +49,8 @@ define([
                     showLoader: true
                 }).done($.proxy(function (data) {
                     $.mage.mediabrowser().insertAtCursor(targetElement.get(0), data);
+                    targetElement.focus();
+                    $(targetElement).change();
                 }, this));
             } else {
                 targetElement.val(record['thumbnail_url'])

--- a/MediaGalleryUi/view/adminhtml/web/js/grid/columns/image/insertImageAction.js
+++ b/MediaGalleryUi/view/adminhtml/web/js/grid/columns/image/insertImageAction.js
@@ -33,8 +33,6 @@ define([
                 throw 'Target element not found for content update';
             }
 
-            console.log(record['encoded_id']);
-
             if (targetElement.is('textarea')) {
                 $.ajax({
                     url: config.onInsertUrl,


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/adobe-stock-integration#1153: An image added from Enhanced Media Gallery to Page Content is not saved 
2. ...

### Manual testing scenarios (*)

    From Admin go to Content - Pages, click Add New Page
    Expand Content,click Show / Hide Editor, click Insert Image...
    Select an image for Enhanced Media Gallery and click Add Selected
    Type a Page Title and click Save
    After the page has been saved, expand Content and verify if the image has been saved

**The image is saved in Content editor**
