### PR TITLE
Enable MediaGallery to tinyMCE3

### DIFF
--- a/MediaGalleryIntegration/Plugin/UpdateWysiwygDialogUrlTinyMce.php
+++ b/MediaGalleryIntegration/Plugin/UpdateWysiwygDialogUrlTinyMce.php
@@ -12,9 +12,9 @@ use Magento\Framework\DataObject;
 use Magento\MediaGalleryUiApi\Api\ConfigInterface;
 
 /**
- * Plugin to update open media gallery dialog URL for image-uploader component
+ * Plugin to update open media gallery dialog URL for tinyMCE3
  */
-class UpdateWysiwygOpenDialogUrlTinyMce
+class UpdateWysiwygDialogUrlTinyMce
 {
     /**
      * @var UrlInterface
@@ -39,15 +39,18 @@ class UpdateWysiwygOpenDialogUrlTinyMce
     }
 
     /**
-     * Update open media gallery dialog URL for image-uploader component
+     * Update open media gallery dialog URL for wysiwyg instance
      *
-     * @param Image $component
+     * @param DataObject $config
      */
-    public function afterPrepare(DataObject $config): void
+    public function afterGetConfig($subject, DataObject $config): DataObject
     {
         if (!$this->config->isEnabled()) {
-            return;
+            return $config;
         }
+        
         $config->setData('files_browser_window_url', $this->url->getUrl('media_gallery/index/index'));
+
+        return $config;
     }
 }

--- a/MediaGalleryIntegration/Plugin/UpdateWysiwygDialogUrlTinyMce.php
+++ b/MediaGalleryIntegration/Plugin/UpdateWysiwygDialogUrlTinyMce.php
@@ -10,6 +10,7 @@ namespace Magento\MediaGalleryIntegration\Plugin;
 use Magento\Framework\UrlInterface;
 use Magento\Framework\DataObject;
 use Magento\MediaGalleryUiApi\Api\ConfigInterface;
+use Magento\Tinymce3\Model\Config\Gallery\Config;
 
 /**
  * Plugin to update open media gallery dialog URL for tinyMCE3
@@ -41,9 +42,11 @@ class UpdateWysiwygDialogUrlTinyMce
     /**
      * Update open media gallery dialog URL for wysiwyg instance
      *
+     * @param Config $subject
      * @param DataObject $config
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function afterGetConfig($subject, DataObject $config): DataObject
+    public function afterGetConfig(Config $subject, DataObject $config): DataObject
     {
         if (!$this->config->isEnabled()) {
             return $config;

--- a/MediaGalleryIntegration/Plugin/UpdateWysiwygDialogUrlTinyMce.php
+++ b/MediaGalleryIntegration/Plugin/UpdateWysiwygDialogUrlTinyMce.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\MediaGalleryIntegration\Plugin;
+
+use Magento\Framework\UrlInterface;
+use Magento\Framework\DataObject;
+use Magento\MediaGalleryUiApi\Api\ConfigInterface;
+
+/**
+ * Plugin to update open media gallery dialog URL for image-uploader component
+ */
+class UpdateWysiwygOpenDialogUrlTinyMce
+{
+    /**
+     * @var UrlInterface
+     */
+    private $url;
+
+    /**
+     * @var ConfigInterface
+     */
+    private $config;
+    
+    /**
+     * @param UrlInterface $url
+     * @param ConfigInterface $config
+     */
+    public function __construct(
+        UrlInterface $url,
+        ConfigInterface $config
+    ) {
+        $this->url = $url;
+        $this->config = $config;
+    }
+
+    /**
+     * Update open media gallery dialog URL for image-uploader component
+     *
+     * @param Image $component
+     */
+    public function afterPrepare(DataObject $config): void
+    {
+        if (!$this->config->isEnabled()) {
+            return;
+        }
+        $config->setData('files_browser_window_url', $this->url->getUrl('media_gallery/index/index'));
+    }
+}

--- a/MediaGalleryIntegration/composer.json
+++ b/MediaGalleryIntegration/composer.json
@@ -7,7 +7,8 @@
         "magento/module-ui": "*",
         "magento/module-media-gallery-ui-api": "*",
         "magento/module-media-gallery-ui": "*",
-        "magento/module-cms": "*"
+        "magento/module-cms": "*",
+        "magento/module-tinymce-3": "*"
     },
     "type": "magento2-module",
     "license": [

--- a/MediaGalleryIntegration/etc/adminhtml/di.xml
+++ b/MediaGalleryIntegration/etc/adminhtml/di.xml
@@ -15,4 +15,7 @@
     <type name="Magento\PageBuilder\Model\Config\ContentType\AdditionalData\Provider\Uploader\OpenDialogUrl">
         <plugin name="updateOpenDialogUrlPageBuilder" type="Magento\MediaGalleryIntegration\Plugin\UpdateOpenDialogUrlPageBuilder"/>
     </type>
+        <type name="Magento\Tinymce3\Model\Config\Gallery\Config">
+        <plugin name="updateWysiwygOpendialogurlTinyMce3" type="Magento\MediaGalleryIntegration\Plugin\UpdateWysiwygDialogUrlTinyMce"/>
+    </type>
 </config>


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/adobe-stock-integration#1178: 
Not Enhanced Media Gallery is called form WYSIWYG Editor TinyMCE 3
2. ...

### Manual testing scenarios (*)
1.  Go to **Stores** - **Confoguration** - **General** - **Content Management**
2. Select **WYSIWYG Editor** _TinyMCE 3 (deprecated)_ and **Save Config** 
![TinyMCE 3_config1](https://user-images.githubusercontent.com/45624059/78898925-4aa43e80-7a7d-11ea-8921-6b15e26cf096.png)
3. Go to **Catalog** - **Products** and click Add Product
4. Expand **Content** and clik **Insert/Edit Embeded media** 
5. In the appeared _Insert/Edit Embeded media_ widow, click **Browse**

Enhanced Media Gallery is opened