### PR TITLE
Grey overlay over the Image Details after deleting another image from Standalone Media Galley

### DIFF
--- a/MediaGalleryUi/view/adminhtml/web/js/image/image-actions.js
+++ b/MediaGalleryUi/view/adminhtml/web/js/image/image-actions.js
@@ -28,7 +28,6 @@ define([
          */
         initialize: function () {
             this._super();
-            $(window).on('fileDeleted.enhancedMediaGallery', this.closeModal.bind(this));
 
             return this;
         },
@@ -51,6 +50,7 @@ define([
          */
         deleteImageAction: function () {
             deleteImage.deleteImageAction(this.imageModel().getSelected(), this.imageModel().deleteImageUrl);
+            this.closeModal();
         },
 
         /**


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/adobe-stock-integration#1197: Grey overlay over the Image Details after deleting another image from Standalone Media Galley
2. ...

### Manual testing scenarios (*)
1. From Admin Go to **Content** - **Media Gallery**
2. Select an image from Media Gallery and **Delete** it
3. Select another image from Media Gallery, click on **three dots** - **View Details**

#
Image Details are displayed correctly without a grey overlay 