### PR TITLE
FIX: use relative path during image directory ignore list validation

### DIFF
--- a/MediaGallerySynchronization/Model/Synchronize.php
+++ b/MediaGallerySynchronization/Model/Synchronize.php
@@ -122,8 +122,9 @@ class Synchronize implements SynchronizeInterface
     private function isApplicable(string $path): bool
     {
         try {
-            return $this->getMediaDirectory()->getRelativePath($path)
-                && !$this->isPathBlacklisted->execute($path)
+            $relativePath = $this->getMediaDirectory()->getRelativePath($path);
+            return $relativePath
+                && !$this->isPathBlacklisted->execute($relativePath)
                 && preg_match(self::IMAGE_FILE_NAME_PATTERN, $path);
         } catch (\Exception $exception) {
             $this->log->critical($exception);


### PR DESCRIPTION
### Description (*)
Use the relative path of the image for blacklist validation.

### Fixed Issues (if relevant)
https://github.com/magento/adobe-stock-integration/issues/1243

### Manual testing scenarios (*)
N/A