### PR TITLE
Two identical error messages appear if try to License and Save an image without Client Secret key

### DIFF
--- a/AdobeStockImageAdminUi/view/adminhtml/ui_component/adobe_stock_images_listing.xml
+++ b/AdobeStockImageAdminUi/view/adminhtml/ui_component/adobe_stock_images_listing.xml
@@ -202,7 +202,6 @@
         <column name="preview" class="Magento\AdobeStockImageAdminUi\Ui\Component\Listing\Columns\ImagePreview" component="Magento_AdobeStockImageAdminUi/js/components/grid/column/image-preview">
             <argument name="data" xsi:type="array">
                 <item name="config" xsi:type="array">
-                    <item name="messagesName" xsi:type="string">adobe_stock_images_listing.adobe_stock_images_listing.messages</item>
                     <item name="mediaGalleryName" xsi:type="string">media_gallery_listing.media_gallery_listing.media_gallery_directories</item>
                     <item name="mediaGalleryComponent" xsi:type="string">media_gallery_listing.media_gallery_listing.media_gallery_columns.thumbnail_url</item>
                     <item name="mediaGalleryProvider" xsi:type="string">media_gallery_listing.media_gallery_listing_data_source</item>

--- a/AdobeStockImageAdminUi/view/adminhtml/ui_component/standalone_adobe_stock_images_listing.xml
+++ b/AdobeStockImageAdminUi/view/adminhtml/ui_component/standalone_adobe_stock_images_listing.xml
@@ -202,7 +202,6 @@
         <column name="preview" class="Magento\AdobeStockImageAdminUi\Ui\Component\Listing\Columns\ImagePreview" component="Magento_AdobeStockImageAdminUi/js/components/grid/column/image-preview">
             <argument name="data" xsi:type="array">
                 <item name="config" xsi:type="array">
-                    <item name="messagesName" xsi:type="string">standalone_adobe_stock_images_listing.standalone_adobe_stock_images_listing.messages</item>
                     <item name="mediaGalleryName" xsi:type="string">standalone_media_gallery_listing.standalone_media_gallery_listing.media_gallery_directories</item>
                     <item name="mediaGalleryComponent" xsi:type="string">standalone_media_gallery_listing.standalone_media_gallery_listing.media_gallery_columns.thumbnail_url</item>
                     <item name="mediaGalleryProvider" xsi:type="string">standalone_media_gallery_listing.media_gallery_listing_data_source</item>

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/image-preview.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/image-preview.js
@@ -40,7 +40,6 @@ define([
                     provider: '${ $.provider }',
                     mediaGallery: '${ $.mediaGalleryComponent }',
                     mediaGalleryName: '${ $.mediaGalleryName }',
-                    messagesName: '${ $.messagesName }',
                     mediaGalleryProvider: '${ $.mediaGalleryProvider }'
                 }
             ]

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/actions.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/actions.js
@@ -27,6 +27,7 @@ define([
             buyCreditsUrl: 'https://stock.adobe.com/',
             messageDelay: 5,
             imageItems: [],
+            messages: [],
             listens: {
                 '${ $.provider }:data.items': 'updateActions'
             },
@@ -35,7 +36,6 @@ define([
                 preview: '${ $.parentName }.preview',
                 overlay: '${ $.parentName }.overlay',
                 source: '${ $.provider }',
-                messages: '${ $.messagesName }',
                 imageDirectory: '${ $.mediaGalleryName }'
             },
             imports: {
@@ -51,7 +51,8 @@ define([
         initObservable: function () {
             this._super()
                 .observe([
-                    'imageItems'
+                    'imageItems',
+                    'messages'
                 ]);
 
             return this;
@@ -314,8 +315,11 @@ define([
                             });
                         }
                     }
-                    this.messages().add('error', message);
-                    this.messages().scheduleCleanup(this.messageDelay);
+                    this.messages.push({
+                        code: 'error',
+                        message: message
+                    });
+                    this.messagesCleanup();
                 }
             });
         },
@@ -414,7 +418,7 @@ define([
          * @return {Array}
          */
         getMessages: function () {
-            return this.messages().get();
+            return this.messages();
         },
 
         /**
@@ -535,8 +539,11 @@ define([
                             errorMessage = $.mage.__('Your admin role does not have permissions to license an image');
                         }
 
-                        this.messages().add('error', errorMessage);
-                        this.messages().scheduleCleanup(this.messageDelay);
+                        this.messages.push({
+                            code: 'error',
+                            message: errorMessage
+                        });
+                        this.messagesCleanup();
                     }
                 }
             );
@@ -594,10 +601,13 @@ define([
                     });
                 }.bind(this))
                 .catch(function (error) {
-                    this.messages().add('error', error);
+                    this.messages.push({
+                        code: 'error',
+                        message: error
+                    });
                 }.bind(this))
                 .finally(function () {
-                    this.messages().scheduleCleanup(this.messageDelay);
+                    this.messagesCleanup();
                 }.bind(this));
         },
 
@@ -675,6 +685,19 @@ define([
                 imageIndex = filePathArray.length - 1;
 
             return filePathArray[imageIndex].substring(0, filePathArray[imageIndex].lastIndexOf('.'));
+        },
+
+        /**
+         * Messages cleanup
+         */
+        messagesCleanup: function () {
+            // eslint-disable-next-line no-unused-vars
+            var timerId;
+
+            timerId = setTimeout(function () {
+                clearTimeout(timerId);
+                this.messages.removeAll();
+            }.bind(this), Number(this.messageDelay) * 1000);
         }
     });
 });


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->


<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

Closes #1242

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/adobe-stock-integration#1242: Two identical error messages appear if try to License and Save an image without Client Secret key
2. ...

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...