### PR TITLE
Frontend validation on uploading not supported file formats

### DIFF
--- a/MediaGalleryUi/Controller/Adminhtml/Image/Upload.php
+++ b/MediaGalleryUi/Controller/Adminhtml/Image/Upload.php
@@ -23,8 +23,6 @@ use Psr\Log\LoggerInterface;
 class Upload extends Action implements HttpPostActionInterface
 {
     private const HTTP_OK = 200;
-    private const HTTP_INTERNAL_ERROR = 500;
-    private const HTTP_BAD_REQUEST = 400;
 
     /**
      * @see _isAllowed()
@@ -85,14 +83,14 @@ class Upload extends Action implements HttpPostActionInterface
                 'message' => __('The image was uploaded successfully.'),
             ];
         } catch (LocalizedException $exception) {
-            $responseCode = self::HTTP_BAD_REQUEST;
+            $responseCode = self::HTTP_OK;
             $responseContent = [
                 'success' => false,
                 'message' => $exception->getMessage(),
             ];
         } catch (Exception $exception) {
             $this->logger->critical($exception);
-            $responseCode = self::HTTP_INTERNAL_ERROR;
+            $responseCode = self::HTTP_OK;
             $responseContent = [
                 'success' => false,
                 'message' => __('Could not upload image.'),

--- a/MediaGalleryUi/Controller/Adminhtml/Image/Upload.php
+++ b/MediaGalleryUi/Controller/Adminhtml/Image/Upload.php
@@ -23,6 +23,7 @@ use Psr\Log\LoggerInterface;
 class Upload extends Action implements HttpPostActionInterface
 {
     private const HTTP_OK = 200;
+    private const HTTP_BAD_REQUEST = 400;
 
     /**
      * @see _isAllowed()

--- a/MediaGalleryUi/Ui/Component/Listing/Columns/Url.php
+++ b/MediaGalleryUi/Ui/Component/Listing/Columns/Url.php
@@ -90,7 +90,6 @@ class Url extends Column
             array_replace_recursive(
                 (array)$this->getData('config'),
                 [
-                    'targetElementId' => $this->context->getRequestParam('target_element_id'),
                     'onInsertUrl' => $this->urlInterface->getUrl('cms/wysiwyg_images/oninsert'),
                     'storeId' => $this->storeManager->getStore()->getId()
                 ]

--- a/MediaGalleryUi/view/adminhtml/templates/image_details_standalone.phtml
+++ b/MediaGalleryUi/view/adminhtml/templates/image_details_standalone.phtml
@@ -68,7 +68,6 @@ use Magento\Backend\Block\Template;
                         "component": "Magento_MediaGalleryUi/js/image/image-actions",
                         "modalSelector": ".media-gallery-image-details-modal",
                         "mediaGalleryImageDetailsName": "mediaGalleryImageDetails",
-                        "targetElementId": "<?= $escaper->escapeJs($block->getData('targetElementId')); ?>",
                         "skipButton": "<?= $escaper->escapeJs($block->getData('skipButton')); ?>",
                         "imageModelName" : "standalone_media_gallery_listing.standalone_media_gallery_listing.media_gallery_columns.thumbnail_url",
                         "actionsList": [

--- a/MediaGalleryUi/view/adminhtml/web/js/image-uploader.js
+++ b/MediaGalleryUi/view/adminhtml/web/js/image-uploader.js
@@ -7,9 +7,10 @@ define([
     'uiComponent',
     'jquery',
     'underscore',
+    'Magento_Ui/js/lib/validation/validator',
     'mage/translate',
     'jquery/file-uploader'
-], function (Component, $, _) {
+], function (Component, $, _, validator) {
     'use strict';
 
     return Component.extend({
@@ -80,6 +81,15 @@ define([
                 }.bind(this),
 
                 add: function (e, data) {
+                    if (!this.isSizeExceeded(data.files[0])) {
+                        this.mediaGridMessages().add(
+                            'error',
+                            $.mage.__('Cannot upload <b>' + data.files[0].name + '</b>. file exceeds maximum file size limit.')
+                        );
+
+                        return;
+                    }
+
                     this.showLoader();
                     this.count(1);
                     data.submit();
@@ -106,6 +116,17 @@ define([
                     this.actions().reloadGrid();
                 }.bind(this)
             });
+        },
+
+        /**
+         * Checks if size of provided file exceeds
+         * defined in configuration size limits.
+         *
+         * @param {Object} file - File to be checked.
+         * @returns {Boolean}
+         */
+        isSizeExceeded: function (file) {
+            return validator('validate-max-size', file.size, this.maxFileSize);
         },
 
         /**

--- a/MediaGalleryUi/view/adminhtml/web/js/image-uploader.js
+++ b/MediaGalleryUi/view/adminhtml/web/js/image-uploader.js
@@ -115,7 +115,10 @@ define([
          */
         showErrorMessage: function (data) {
             data.files.each(function (file) {
-                this.mediaGridMessages().add('error', $.mage.__('Cannot upload <b>' + file.name + '</b>. This file is not supported'));
+                this.mediaGridMessages().add(
+                    'error',
+                    $.mage.__('Cannot upload <b>' + file.name + '</b>. This file is not supported')
+                );
             }.bind(this));
 
             this.hideLoader();
@@ -123,10 +126,8 @@ define([
 
         /**
          * Show success message, and files counts
-         *
-         * @param {Object} data
          */
-        showSuccessMessage: function (data) {
+        showSuccessMessage: function () {
             var prefix = this.count() === 1 ? 'an image' : this.count() + ' images';
 
             this.mediaGridMessages().messages.remove(function (item) {

--- a/MediaGalleryUi/view/adminhtml/web/js/image-uploader.js
+++ b/MediaGalleryUi/view/adminhtml/web/js/image-uploader.js
@@ -36,7 +36,12 @@ define([
          * @return {exports}
          */
         initialize: function () {
-            this._super().observe(['loader']);
+            this._super().observe(
+                [
+                    'loader',
+                    'count'
+                ]
+            );
 
             return this;
         },
@@ -47,7 +52,9 @@ define([
         initializeFileUpload: function () {
             $(this.imageUploadInputSelector).fileupload({
                 url: this.imageUploadUrl,
-                dataType: 'json',
+                acceptFileTypes: this.acceptFileTypes,
+                allowedExtensions: this.allowedExtensions,
+                maxFileSize: this.maxFileSize,
 
                 /**
                  * Extending the form data
@@ -71,27 +78,63 @@ define([
                         }]
                     );
                 }.bind(this),
-                acceptFileTypes: this.acceptFileTypes,
-                allowedExtensions: this.allowedExtensions,
-                maxFileSize: this.maxFileSize,
+
                 add: function (e, data) {
                     this.showLoader();
+                    this.count(1);
                     data.submit();
                 }.bind(this),
-                done: function () {
-                    this.hideLoader();
-                    this.actions().reloadGrid();
+
+                stop: function () {
+                    this.mediaGridMessages().scheduleCleanup();
                 }.bind(this),
-                fail: function (e, data) {
+
+                start: function () {
+                    this.mediaGridMessages().clear();
+                }.bind(this),
+
+                done: function (e, data) {
                     var response = data.jqXHR.responseJSON;
 
-                    if (response !== undefined && response.message) {
-                        this.mediaGridMessages().add('error', $.mage.__(response.message));
-                        this.mediaGridMessages().scheduleCleanup();
+                    if (!response.success) {
+                        this.showErrorMessage(data);
+
+                        return;
                     }
+                    this.showSuccessMessage(data);
                     this.hideLoader();
+                    this.actions().reloadGrid();
                 }.bind(this)
             });
+        },
+
+        /**
+         * Show error meassages with file name.
+         *
+         * @param {Object} data
+         */
+        showErrorMessage: function (data) {
+            data.files.each(function (file) {
+                this.mediaGridMessages().add('error', $.mage.__('Cannot upload <b>' + file.name + '</b>. This file is not supported'));
+            }.bind(this));
+
+            this.hideLoader();
+        },
+
+        /**
+         * Show success message, and files counts
+         *
+         * @param {Object} data
+         */
+        showSuccessMessage: function (data) {
+            var prefix = this.count() === 1 ? 'an image' : this.count() + ' images';
+
+            this.mediaGridMessages().messages.remove(function (item) {
+                return item.code === 'success';
+            });
+            this.mediaGridMessages().add('success', $.mage.__('Successfully uploaded ' + prefix));
+            this.count(this.count() + 1);
+
         },
 
         /**

--- a/MediaGalleryUi/view/adminhtml/web/js/image-uploader.js
+++ b/MediaGalleryUi/view/adminhtml/web/js/image-uploader.js
@@ -84,7 +84,8 @@ define([
                     if (!this.isSizeExceeded(data.files[0]).passed) {
                         this.mediaGridMessages().add(
                             'error',
-                            $.mage.__('Cannot upload <b>' + data.files[0].name + '</b>. file exceeds maximum file size limit.')
+                            $.mage.__('Cannot upload <b>' + data.files[0].name +
+                                      '</b>. file exceeds maximum file size limit.')
                         );
 
                         return;

--- a/MediaGalleryUi/view/adminhtml/web/js/image-uploader.js
+++ b/MediaGalleryUi/view/adminhtml/web/js/image-uploader.js
@@ -81,7 +81,7 @@ define([
                 }.bind(this),
 
                 add: function (e, data) {
-                    if (!this.isSizeExceeded(data.files[0])) {
+                    if (!this.isSizeExceeded(data.files[0]).passed) {
                         this.mediaGridMessages().add(
                             'error',
                             $.mage.__('Cannot upload <b>' + data.files[0].name + '</b>. file exceeds maximum file size limit.')

--- a/MediaGalleryUi/view/adminhtml/web/js/image-uploader.js
+++ b/MediaGalleryUi/view/adminhtml/web/js/image-uploader.js
@@ -117,7 +117,7 @@ define([
             data.files.each(function (file) {
                 this.mediaGridMessages().add(
                     'error',
-                    $.mage.__('Cannot upload <b>' + file.name + '</b>. This file is not supported')
+                    $.mage.__('Cannot upload <b>' + file.name + '</b>. This file format is not supported')
                 );
             }.bind(this));
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/adobe-stock-integration#1193: No frontend validation on uploading not supported file formats
2. ...

### Manual testing scenarios (*)
- Consider option to disable not supported file formats from selection. 
- If user dragged the not supported files to upload, perform frontend validation
- If possible upload files with supported format and show success message  and block uploading not supported formats and  show error message with file types that are not supported. If above not possible , than block uploading all files and  show error message

## Design

![Image-uploaded-messages](https://user-images.githubusercontent.com/752610/79155983-a6c9d400-7d97-11ea-98b1-4fe9f6ae8227.png)

Basically, bulk the success messages into one message, but call out each failed file:

`Cannot upload “filename-of-the-image.mov”. This file format is not supported.`