### PR TITLE
Apply bookmarks to save filters state and per page settings

### DIFF
--- a/MediaGalleryUi/view/adminhtml/ui_component/media_gallery_listing.xml
+++ b/MediaGalleryUi/view/adminhtml/ui_component/media_gallery_listing.xml
@@ -84,6 +84,7 @@
         </argument>
     </container>
     <listingToolbar name="listing_top" template="Magento_MediaGalleryUi/grid/toolbar">
+        <bookmark name="bookmarks"/>
         <filterSearch name="fulltext"/>
         <filters name="listing_filters">
             <filterInput name="path" provider="${ $.parentName }" sortOrder="100">

--- a/MediaGalleryUi/view/adminhtml/ui_component/standalone_media_gallery_listing.xml
+++ b/MediaGalleryUi/view/adminhtml/ui_component/standalone_media_gallery_listing.xml
@@ -71,6 +71,7 @@
         </argument>
     </container>
     <listingToolbar name="listing_top" template="Magento_MediaGalleryUi/grid/toolbar">
+        <bookmark name="bookmarks"/>
         <filterSearch name="fulltext"/>
         <filters name="listing_filters">
             <filterInput name="path" provider="${ $.parentName }" sortOrder="100">


### PR DESCRIPTION
<!---_
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/adobe-stock-integration#1199: Custom per page number disappears after web page refresh [Enhanced Media Gallery] 
2. ...

### Manual testing scenarios (*)
1. From Admin Go to **Content** - **Media Gallery**
2. Click on **per page** drop-down and select **Custom**
3. Type, for example, 35 and click on arrow **->** to save the bookmark
4. Verify that the previously created custom number is present in per page drop-down
5. Refresh the web page (F5)
6. Click on **per page** drop-down and verify if the previously saved 35 number exists

### Expected result (*)
The previously saved _per page_ number exists in the drop-down