### PR TITLE
User is redirected to Media Gallery instead of staying on Image Details page (Delete confirmation message)

### DIFF
--- a/MediaGalleryUi/view/adminhtml/templates/image_details.phtml
+++ b/MediaGalleryUi/view/adminhtml/templates/image_details.phtml
@@ -69,6 +69,7 @@ use Magento\Framework\Escaper;
                     "mediaGalleryImageActions": {
                         "component": "Magento_MediaGalleryUi/js/image/image-actions",
                         "modalSelector": ".media-gallery-image-details-modal",
+                        "modalWindowSelector": ".media-gallery-image-details",
                         "imageModelName" : "media_gallery_listing.media_gallery_listing.media_gallery_columns.thumbnail_url",
                         "mediaGalleryImageDetailsName": "mediaGalleryImageDetails",
                         "actionsList": [

--- a/MediaGalleryUi/view/adminhtml/templates/image_details_standalone.phtml
+++ b/MediaGalleryUi/view/adminhtml/templates/image_details_standalone.phtml
@@ -67,6 +67,7 @@ use Magento\Backend\Block\Template;
                     "mediaGalleryImageActions": {
                         "component": "Magento_MediaGalleryUi/js/image/image-actions",
                         "modalSelector": ".media-gallery-image-details-modal",
+                        "modalWindowSelector": ".media-gallery-image-details",
                         "mediaGalleryImageDetailsName": "mediaGalleryImageDetails",
                         "skipButton": "<?= $escaper->escapeJs($block->getData('skipButton')); ?>",
                         "imageModelName" : "standalone_media_gallery_listing.standalone_media_gallery_listing.media_gallery_columns.thumbnail_url",

--- a/MediaGalleryUi/view/adminhtml/web/js/image/image-actions.js
+++ b/MediaGalleryUi/view/adminhtml/web/js/image/image-actions.js
@@ -15,6 +15,7 @@ define([
     return Element.extend({
         defaults: {
             modalSelector: '',
+            modalWindowSelector: '',
             template: 'Magento_MediaGalleryUi/image/actions',
             modules: {
                 imageModel: '${ $.imageModelName }'
@@ -28,6 +29,7 @@ define([
          */
         initialize: function () {
             this._super();
+            $(window).on('fileDeleted.enhancedMediaGallery', this.closeViewDetailsModal.bind(this));
 
             return this;
         },
@@ -36,9 +38,10 @@ define([
          * Close the images details modal
          */
         closeModal: function () {
-            var modalElement = $(this.modalSelector);
+            var modalElement = $(this.modalSelector),
+                modalWindow = $(this.modalWindowSelector);
 
-            if (!modalElement.length || _.isUndefined(modalElement.modal)) {
+            if (!modalWindow.hasClass('_show') || !modalElement.length || _.isUndefined(modalElement.modal)) {
                 return;
             }
 
@@ -49,7 +52,6 @@ define([
          * Delete image action
          */
         deleteImageAction: function () {
-            this.closeModal();
             deleteImage.deleteImageAction(this.imageModel().getSelected(), this.imageModel().deleteImageUrl);
         },
 
@@ -64,6 +66,13 @@ define([
                     storeId: this.imageModel().storeId
                 }
             );
+            this.closeModal();
+        },
+
+        /**
+         * Close view details modal after confirm deleting image
+         */
+        closeViewDetailsModal: function () {
             this.closeModal();
         }
     });


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

Closes #1271

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/adobe-stock-integration#1271: User is redirected to Media Gallery instead of staying on Image Details page (Delete confirmation message)
2. ...

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...