### PR TITLE
Provide own insertAtcursor method to avoid mediaBrowser widget iniialization

### DIFF
--- a/MediaGalleryUi/view/adminhtml/web/js/grid/columns/image/insertImageAction.js
+++ b/MediaGalleryUi/view/adminhtml/web/js/grid/columns/image/insertImageAction.js
@@ -46,7 +46,7 @@ define([
                     context: this,
                     showLoader: true
                 }).done($.proxy(function (data) {
-                    $.mage.mediabrowser().insertAtCursor(targetElement.get(0), data);
+                    this.insertAtCursor(targetElement.get(0), data);
                     targetElement.focus();
                     $(targetElement).change();
                 }, this));
@@ -58,6 +58,38 @@ define([
             }
             window.MediabrowserUtility.closeDialog();
             targetElement.focus();
+        },
+
+        /**
+         * Insert image to target instance.
+         *
+         * @param {Object} element
+         * @param {*} value
+         */
+        insertAtCursor: function (element, value) {
+            var sel, startPos, endPos, scrollTop;
+
+            if ('selection' in document) {
+                //For browsers like Internet Explorer
+                element.focus();
+                sel = document.selection.createRange();
+                sel.text = value;
+                element.focus();
+            } else if (element.selectionStart || element.selectionStart == '0') { //eslint-disable-line eqeqeq
+                //For browsers like Firefox and Webkit based
+                startPos = element.selectionStart;
+                endPos = element.selectionEnd;
+                scrollTop = element.scrollTop;
+                element.value = element.value.substring(0, startPos) + value +
+                    element.value.substring(startPos, endPos) + element.value.substring(endPos, element.value.length);
+                element.focus();
+                element.selectionStart = startPos + value.length;
+                element.selectionEnd = startPos + value.length + element.value.substring(startPos, endPos).length;
+                element.scrollTop = scrollTop;
+            } else {
+                element.value += value;
+                element.focus();
+            }
         },
 
         /**


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/adobe-stock-integration#1272: "Uncaught TypeError: Cannot read property 'id' of null" error appears if add a Page content image and open Media Gallery again
2. ...

### Manual testing scenarios (*)
1. From Admin go to **Content** - **Pages**, click **Add New Page**
2. Expand **Content**,click **Show / Hide Editor**, select **Insert Image...**
3. Select an image from Media Gallery and click **Add Selected**
4. Click **Insert Image** again

**No error in Browsers dev console** 