### PR TITLE
1245: fix image still exists after delete

### DIFF
--- a/MediaGalleryUi/Model/DeleteImage.php
+++ b/MediaGalleryUi/Model/DeleteImage.php
@@ -9,6 +9,8 @@ namespace Magento\MediaGalleryUi\Model;
 
 use Magento\Cms\Model\Wysiwyg\Images\Storage;
 use Magento\Framework\App\Filesystem\DirectoryList;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\MediaGalleryApi\Api\IsPathBlacklistedInterface;
 use Magento\Framework\Filesystem;
 use Magento\MediaGalleryApi\Api\Data\AssetInterface;
 
@@ -23,6 +25,11 @@ class DeleteImage
     private $imagesStorage;
 
     /**
+     * @var IsPathBlacklistedInterface
+     */
+    private $isPathBlacklisted;
+
+    /**
      * @var Filesystem
      */
     private $filesystem;
@@ -32,22 +39,32 @@ class DeleteImage
      *
      * @param Storage $imagesStorage
      * @param Filesystem $filesystem
+     * @param IsPathBlacklistedInterface $isPathBlacklisted
      */
     public function __construct(
         Storage $imagesStorage,
-        Filesystem $filesystem
+        Filesystem $filesystem,
+        IsPathBlacklistedInterface $isPathBlacklisted
     ) {
         $this->imagesStorage = $imagesStorage;
         $this->filesystem = $filesystem;
+        $this->isPathBlacklisted = $isPathBlacklisted;
     }
 
     /**
-     * Delete asset from a storage
+     * Delete asset image physically from file storage and from data storage via MediaGallery plugin.
+     * @see \Magento\MediaGallery\Plugin\Wysiwyg\Images\Storage
      *
      * @param AssetInterface $asset
+     *
+     * @throws LocalizedException
      */
     public function execute(AssetInterface $asset): void
     {
+        if ($this->isPathBlacklisted->execute($asset->getPath())) {
+            throw new LocalizedException(__('Could not delete image: destination directory is restricted.'));
+        }
+
         $mediaDirectory = $this->filesystem->getDirectoryRead(DirectoryList::MEDIA);
         $absolutePath = $mediaDirectory->getAbsolutePath($asset->getPath());
         $this->imagesStorage->deleteFile($absolutePath);

--- a/MediaGalleryUi/Model/DeleteImage.php
+++ b/MediaGalleryUi/Model/DeleteImage.php
@@ -53,10 +53,10 @@ class DeleteImage
 
     /**
      * Delete asset image physically from file storage and from data storage via MediaGallery plugin.
+     *
      * @see \Magento\MediaGallery\Plugin\Wysiwyg\Images\Storage
      *
      * @param AssetInterface $asset
-     *
      * @throws LocalizedException
      */
     public function execute(AssetInterface $asset): void

--- a/MediaGalleryUi/Model/DeleteImage.php
+++ b/MediaGalleryUi/Model/DeleteImage.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\MediaGalleryUi\Model;
+
+use Magento\Cms\Model\Wysiwyg\Images\Storage;
+use Magento\Framework\App\Filesystem\DirectoryList;
+use Magento\Framework\Filesystem;
+use Magento\MediaGalleryApi\Api\Data\AssetInterface;
+
+/**
+ * Delete image from a storage
+ */
+class DeleteImage
+{
+    /**
+     * @var Storage
+     */
+    private $imagesStorage;
+
+    /**
+     * @var Filesystem
+     */
+    private $filesystem;
+
+    /**
+     * DeleteImage constructor.
+     *
+     * @param Storage $imagesStorage
+     * @param Filesystem $filesystem
+     */
+    public function __construct(
+        Storage $imagesStorage,
+        Filesystem $filesystem
+    ) {
+        $this->imagesStorage = $imagesStorage;
+        $this->filesystem = $filesystem;
+    }
+
+    /**
+     * Delete asset from a storage
+     *
+     * @param AssetInterface $asset
+     */
+    public function execute(AssetInterface $asset): void
+    {
+        $mediaDirectory = $this->filesystem->getDirectoryRead(DirectoryList::MEDIA);
+        $absolutePath = $mediaDirectory->getAbsolutePath($asset->getPath());
+        $this->imagesStorage->deleteFile($absolutePath);
+    }
+}


### PR DESCRIPTION
### Description (*)
To fix the reported issue I provide this PR: use `Magento\Cms\Model\Wysiwyg\Images\Storage::deleteFile` for image delete process. This method removes the image physically and has a plugin which will remove data from a data storage - `\Magento\MediaGallery\Plugin\Wysiwyg\Images\Storage::afterDeleteFile` I also choose this method because of `Magento_MediaGalleryUi` has a dependency and use the `Magento_CMS module`.

### Fixed Issues (if relevant)
#1245 

Depends on: https://github.com/magento/magento2/pull/27994