### PR TITLE
Fix used in section counts, with same image on one page

### DIFF
--- a/MediaGalleryUi/Model/AssetDetailsProvider/UsedIn.php
+++ b/MediaGalleryUi/Model/AssetDetailsProvider/UsedIn.php
@@ -64,14 +64,20 @@ class UsedIn implements AssetDetailsProviderInterface
     private function getUsedIn(int $assetId): array
     {
         $usedIn = [];
+        $entityIds = [];
+        
         $contentIdentities = $this->getContent->execute([$assetId]);
+
         foreach ($contentIdentities as $contentIdentity) {
+            $entityId = $contentIdentity->getEntityId();
             $type = $this->contentTypes[$contentIdentity->getEntityType()] ?? $contentIdentity->getEntityType();
+
             if (!isset($usedIn[$type])) {
                 $usedIn[$type] = 1;
-            } else {
+            } elseif ($entityIds[$type]['entity_id'] !== $entityId) {
                 $usedIn[$type] += 1;
             }
+            $entityIds[$type]['entity_id'] = $entityId;
         }
         return $usedIn;
     }

--- a/MediaGalleryUi/Model/AssetDetailsProvider/UsedIn.php
+++ b/MediaGalleryUi/Model/AssetDetailsProvider/UsedIn.php
@@ -65,17 +65,23 @@ class UsedIn implements AssetDetailsProviderInterface
     {
         $usedIn = [];
         $entityIds = [];
-        
+
         $contentIdentities = $this->getContent->execute([$assetId]);
 
         foreach ($contentIdentities as $contentIdentity) {
             $entityId = $contentIdentity->getEntityId();
             $type = $this->contentTypes[$contentIdentity->getEntityType()] ?? $contentIdentity->getEntityType();
-
-            if (!isset($usedIn[$type])) {
-                $usedIn[$type] = 1;
+            $singleType = $this->contentTypes[$contentIdentity->getEntityType() . '_single'] ?? $type;
+            
+            if (!isset($entityIds[$type])) {
+                $usedIn[$singleType] = 1;
             } elseif ($entityIds[$type]['entity_id'] !== $entityId) {
-                $usedIn[$type] += 1;
+                if (isset($usedIn[$type])) {
+                    $usedIn[$type] +=1;
+                } else {
+                    $usedIn[$type] = $usedIn[$singleType]+1;
+                    unset($usedIn[$singleType]);
+                }
             }
             $entityIds[$type]['entity_id'] = $entityId;
         }

--- a/MediaGalleryUi/etc/di.xml
+++ b/MediaGalleryUi/etc/di.xml
@@ -36,7 +36,9 @@
         <arguments>
             <argument name="contentTypes" xsi:type="array">
                 <item name="catalog_category" xsi:type="string">Categories</item>
+                <item name="catalog_category_single" xsi:type="string">Category</item>
                 <item name="catalog_product" xsi:type="string">Products</item>
+                <item name="catalog_product_single" xsi:type="string">Product</item>
                 <item name="cms_block" xsi:type="string">Blocks</item>
                 <item name="cms_page" xsi:type="string">Pages</item>
             </argument>

--- a/MediaGalleryUi/etc/di.xml
+++ b/MediaGalleryUi/etc/di.xml
@@ -35,7 +35,7 @@
     <type name="Magento\MediaGalleryUi\Model\AssetDetailsProvider\UsedIn">
         <arguments>
             <argument name="contentTypes" xsi:type="array">
-                <item name="catalog_category" xsi:type="string">Categorys</item>
+                <item name="catalog_category" xsi:type="string">Categories</item>
                 <item name="catalog_product" xsi:type="string">Products</item>
                 <item name="cms_block" xsi:type="string">Blocks</item>
                 <item name="cms_page" xsi:type="string">Pages</item>

--- a/MediaGalleryUi/etc/di.xml
+++ b/MediaGalleryUi/etc/di.xml
@@ -35,10 +35,10 @@
     <type name="Magento\MediaGalleryUi\Model\AssetDetailsProvider\UsedIn">
         <arguments>
             <argument name="contentTypes" xsi:type="array">
-                <item name="catalog_category" xsi:type="string">Category</item>
-                <item name="catalog_product" xsi:type="string">Product</item>
-                <item name="cms_block" xsi:type="string">Block</item>
-                <item name="cms_page" xsi:type="string">Page</item>
+                <item name="catalog_category" xsi:type="string">Categorys</item>
+                <item name="catalog_product" xsi:type="string">Products</item>
+                <item name="cms_block" xsi:type="string">Blocks</item>
+                <item name="cms_page" xsi:type="string">Pages</item>
             </argument>
         </arguments>
     </type>

--- a/MediaGalleryUi/etc/di.xml
+++ b/MediaGalleryUi/etc/di.xml
@@ -40,7 +40,9 @@
                 <item name="catalog_product" xsi:type="string">Products</item>
                 <item name="catalog_product_single" xsi:type="string">Product</item>
                 <item name="cms_block" xsi:type="string">Blocks</item>
+                <item name="cms_block_single" xsi:type="string">Block</item>
                 <item name="cms_page" xsi:type="string">Pages</item>
+                <item name="cms_page_single" xsi:type="string">Page</item>
             </argument>
         </arguments>
     </type>


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/adobe-stock-integration#1277: The Used in counts the one products Description and Short description as two Products
2. ...

### Manual testing scenarios (*)
1. Create a Product and add the same image to it's **Content - Description** and the same image to **Content - Short Description**
2. Go to **Content - Media Gallery** and select the previously used image 
3. Click on "three dots" and select **View Details**
4.  Observe the _Used In_ section

**Used in **1** Product**