### PR TITLE
Add color preview rectangle to Active filter state to color filter.

### DIFF
--- a/AdobeStockImageAdminUi/view/adminhtml/ui_component/adobe_stock_images_listing.xml
+++ b/AdobeStockImageAdminUi/view/adminhtml/ui_component/adobe_stock_images_listing.xml
@@ -69,6 +69,11 @@
             </argument>
         </container>
         <filters name="listing_filters" sortOrder="10">
+            <settings>
+                <chipsConfig>
+                    <param name="template" xsi:type="string">Magento_AdobeStockImageAdminUi/grid/filter/chips</param>
+                </chipsConfig>
+            </settings>
             <filterSelect name="content_type_filter" provider="${ $.parentName }" sortOrder="10">
                 <settings>
                     <caption translate="true">All</caption>

--- a/AdobeStockImageAdminUi/view/adminhtml/ui_component/standalone_adobe_stock_images_listing.xml
+++ b/AdobeStockImageAdminUi/view/adminhtml/ui_component/standalone_adobe_stock_images_listing.xml
@@ -69,13 +69,18 @@
             </argument>
         </container>
         <filters name="listing_filters" sortOrder="10">
+            <settings>
+                <chipsConfig>
+                    <param name="template" xsi:type="string">Magento_AdobeStockImageAdminUi/grid/filter/chips</param>
+                </chipsConfig>
+            </settings>
             <filterSelect name="content_type_filter" provider="${ $.parentName }" sortOrder="10">
                 <settings>
                     <caption translate="true">All</caption>
                     <options class="Magento\AdobeStockImageAdminUi\Ui\Component\Listing\Columns\ContentType\Options"/>
                     <label translate="true">Subcategory</label>
                     <dataScope>content_type_filter</dataScope>
-                </settings>
+               </settings>
             </filterSelect>
             <filterSelect name="orientation_filter" provider="${ $.parentName }" sortOrder="20">
                 <settings>

--- a/AdobeStockImageAdminUi/view/adminhtml/ui_component/standalone_adobe_stock_images_listing.xml
+++ b/AdobeStockImageAdminUi/view/adminhtml/ui_component/standalone_adobe_stock_images_listing.xml
@@ -80,7 +80,7 @@
                     <options class="Magento\AdobeStockImageAdminUi\Ui\Component\Listing\Columns\ContentType\Options"/>
                     <label translate="true">Subcategory</label>
                     <dataScope>content_type_filter</dataScope>
-               </settings>
+                </settings>
             </filterSelect>
             <filterSelect name="orientation_filter" provider="${ $.parentName }" sortOrder="20">
                 <settings>

--- a/AdobeStockImageAdminUi/view/adminhtml/web/css/source/_module.less
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/css/source/_module.less
@@ -14,13 +14,13 @@
 & when (@media-common = true) {
     .adobe-stock-images-search-modal-content {
         .color-rectangle {
+            border-color: @color-dots-background-color;
+            border: solid 1px;
             display: inline-block;
+            height: 12px;
             position: inherit;
             top: 2px;
-            border: solid 1px;
-            border-color: @color-dots-background-color;
             width: 12px;
-            height: 12px;
         }
         
         .masonry-image {

--- a/AdobeStockImageAdminUi/view/adminhtml/web/css/source/_module.less
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/css/source/_module.less
@@ -14,8 +14,8 @@
 & when (@media-common = true) {
     .adobe-stock-images-search-modal-content {
         .color-rectangle {
-            border-color: @color-dots-background-color;
             border: solid 1px;
+            border-color: @color-dots-background-color;
             display: inline-block;
             height: 12px;
             position: inherit;

--- a/AdobeStockImageAdminUi/view/adminhtml/web/css/source/_module.less
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/css/source/_module.less
@@ -13,6 +13,16 @@
 
 & when (@media-common = true) {
     .adobe-stock-images-search-modal-content {
+        .color-rectangle {
+            top: 2px;
+            position: inherit;
+            border-color: @color-dots-background-color;
+            width: 12px;
+            height: 12px;
+            display: inline-block;
+            border: solid 1px;
+        }
+        
         .masonry-image {
             &-grid {
                 display: inline-block;

--- a/AdobeStockImageAdminUi/view/adminhtml/web/css/source/_module.less
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/css/source/_module.less
@@ -14,13 +14,13 @@
 & when (@media-common = true) {
     .adobe-stock-images-search-modal-content {
         .color-rectangle {
-            top: 2px;
+            display: inline-block;
             position: inherit;
+            top: 2px;
+            border: solid 1px;
             border-color: @color-dots-background-color;
             width: 12px;
             height: 12px;
-            display: inline-block;
-            border: solid 1px;
         }
         
         .masonry-image {

--- a/AdobeStockImageAdminUi/view/adminhtml/web/template/grid/filter/chips.html
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/template/grid/filter/chips.html
@@ -1,0 +1,34 @@
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<div class="admin__data-grid-filters-current" css="_show: hasPreviews()">
+    <div class="admin__current-filters-title-wrap">
+        <span class="admin__current-filters-title" translate="'Active filters\\:'"/>
+    </div>
+    <div class="admin__current-filters-list-wrap">
+        <ul class="admin__current-filters-list" data-role="filter-list">
+            <each args="elems">
+                <li outereach="previews">
+                    <span text="label + '\\:'"/>
+                    <span if="typeof preview ==='string' && label === 'Color'" class="color-rectangle" data-bind="style:{ 'background-color' :  preview }"/>
+                    <span if="typeof preview === 'string'" text="preview"/>
+                    <span if="typeof preview === 'object'">
+                        <text args="preview[0] || '...'"/> - <text args="preview[1] || '...'"/>
+                    </span>
+                    <button class="action-remove" type="button"
+                        data-action="grid-filter-remove-chip"
+                        click="$parent.clear.bind($parent, elem)">
+                        <span translate="'Remove'"/>
+                    </button>
+                </li>
+            </each>
+        </ul>
+    </div>
+    <div class="admin__current-filters-actions-wrap">
+        <button class="action-tertiary action-clear" type="button" click="clear" translate="'Clear all'"
+            attr="'data-action': hasPreviews() ? 'grid-filter-reset' : ''"/>
+    </div>
+</div>


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/adobe-stock-integration#1276: IThe color filter doesn't match the UI Prototype 
2. ...

### Manual testing scenarios (*)
1. Go to **Content - Media Gallery**
2. Click **Search Adobe Stock**
3. Click **Filters** and **Apply** any _Color_ filter
4. Verify if there is a colored rectangle near the color number  

The color rectangle is present and equals to UI protopype
![DeepinScreenshot_select-area_20200427134304](https://user-images.githubusercontent.com/2481206/80363529-04c4e400-888d-11ea-839c-2e509066bec2.png)
