### PR TITLE
"Uploaded date" filter is missing from Media Gallery

### DIFF
--- a/MediaGalleryUi/view/adminhtml/ui_component/media_gallery_listing.xml
+++ b/MediaGalleryUi/view/adminhtml/ui_component/media_gallery_listing.xml
@@ -94,7 +94,7 @@
                     <label translate="true">Directory</label>
                 </settings>
             </filterInput>
-            <filterRange name="created_at"
+            <filterRange name="created_at_date"
                          class="Magento\Ui\Component\Filters\Type\Date"
                          provider="${ $.parentName }"
                          template="ui/grid/filters/elements/group" sortOrder="30">
@@ -216,7 +216,15 @@
             </settings>
         </column>
         <column name="created_at">
+            <argument name="data" xsi:type="array">
+                <item name="config" xsi:type="array">
+                    <item name="sort_by" xsi:type="array">
+                        <item name="excluded" xsi:type="boolean">true</item>
+                    </item>
+                </item>
+            </argument>
             <settings>
+                <label translate="true">Uploaded Date</label>
                 <filter>dateRange</filter>
                 <dataType>date</dataType>
                 <visible>false</visible>

--- a/MediaGalleryUi/view/adminhtml/ui_component/standalone_media_gallery_listing.xml
+++ b/MediaGalleryUi/view/adminhtml/ui_component/standalone_media_gallery_listing.xml
@@ -81,7 +81,7 @@
                     <label translate="true">Directory</label>
                 </settings>
             </filterInput>
-            <filterRange name="created_at"
+            <filterRange name="created_at_date"
                          class="Magento\Ui\Component\Filters\Type\Date"
                          provider="${ $.parentName }"
                          template="ui/grid/filters/elements/group" sortOrder="30">
@@ -203,7 +203,15 @@
             </settings>
         </column>
         <column name="created_at">
+            <argument name="data" xsi:type="array">
+                <item name="config" xsi:type="array">
+                    <item name="sort_by" xsi:type="array">
+                        <item name="excluded" xsi:type="boolean">true</item>
+                    </item>
+                </item>
+            </argument>
             <settings>
+                <label translate="true">Uploaded Date</label>
                 <filter>dateRange</filter>
                 <dataType>date</dataType>
                 <visible>false</visible>

--- a/MediaGalleryUi/view/adminhtml/web/js/grid/sortBy.js
+++ b/MediaGalleryUi/view/adminhtml/web/js/grid/sortBy.js
@@ -23,6 +23,11 @@ define([
                 columns.map(function (column) {
                     if (column.sortable === true) {
                         sortBy = column['sort_by'] || {};
+
+                        if (sortBy.excluded) {
+                            return;
+                        }
+
                         this.options.push({
                             value: column.index,
                             label: column.label,


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

Closes #1281

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/adobe-stock-integration#1281: "Uploaded date" filter is missing from Media Gallery
2. ...

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...