### PR TITLE
Added ability to locate node in jstree after create folder, and in bookmarks state

### DIFF
--- a/MediaGalleryUi/Model/Directories/FolderTree.php
+++ b/MediaGalleryUi/Model/Directories/FolderTree.php
@@ -86,7 +86,7 @@ class FolderTree
             $pathArray = explode('/', $path);
             $directories[] = [
                 'data' => count($pathArray) > 0 ? end($pathArray) : $path,
-                'attr' => ['id' => $index],
+                'attr' => ['id' => $path],
                 'metadata' => [
                     'path' => $path
                 ],

--- a/MediaGalleryUi/Model/Directories/FolderTree.php
+++ b/MediaGalleryUi/Model/Directories/FolderTree.php
@@ -78,7 +78,7 @@ class FolderTree
             return $directories;
         }
 
-        foreach ($directory->readRecursively() as $index => $path) {
+        foreach ($directory->readRecursively() as $path) {
             if (!$directory->isDirectory($path) || $this->isBlacklisted->execute($path)) {
                 continue;
             }

--- a/MediaGalleryUi/view/adminhtml/web/js/directory/directories.js
+++ b/MediaGalleryUi/view/adminhtml/web/js/directory/directories.js
@@ -133,6 +133,9 @@ define([
                 errorMessage = 'There was an error on attempt to create folder!',
                 callback = function () {
                     this.directoryTree().reloadJsTree();
+                    $(this.directoryTree().directoryTreeSelector).on('loaded.jstree', function () {
+                        this.directoryTree().locateNode(folder + '/' + path);
+                    }.bind(this));
                 }.bind(this);
 
             this.sendPostRequest(this.directoryTree().createDirectoryUrl, data, errorMessage, callback);

--- a/MediaGalleryUi/view/adminhtml/web/js/directory/directoryTree.js
+++ b/MediaGalleryUi/view/adminhtml/web/js/directory/directoryTree.js
@@ -42,7 +42,6 @@ define([
                 this.getJsonTree();
                 this.initEvents();
                 this.checkChipFiltersState();
-
             }.bind(this));
 
             return this;
@@ -120,7 +119,6 @@ define([
          * Listener to clear filters event
          */
         clearFiltersHandle: function () {
-
             if (_.isUndefined(this.filterChips().filters.path)) {
                 $(this.directoryTreeSelector).jstree('deselect_all');
                 this.activeNode(null);
@@ -222,7 +220,6 @@ define([
                  */
                 success: function (data) {
                     this.createTree(data);
-
                 }.bind(this),
 
                 /**

--- a/MediaGalleryUi/view/adminhtml/web/js/directory/directoryTree.js
+++ b/MediaGalleryUi/view/adminhtml/web/js/directory/directoryTree.js
@@ -41,6 +41,8 @@ define([
             this.waitForContainer(function () {
                 this.getJsonTree();
                 this.initEvents();
+                this.checkChipCiltersState();
+
             }.bind(this));
 
             return this;
@@ -92,9 +94,33 @@ define([
         },
 
         /**
+         * Verify directory filter on init event, select folder per directory filter state
+         */
+        checkChipCiltersState: function () {
+            if (!_.isUndefined(this.filterChips().filters.path) && this.filterChips().filters.path !== '') {
+                $(this.directoryTreeSelector).on('loaded.jstree', function () {
+                    this.locateNode(this.filterChips().filters.path);
+                }.bind(this));
+            }
+        },
+
+        /**
+         * Locate and higlight node in jstree by path id.
+         *
+         * @param {String} path
+         */
+        locateNode: function (path) {
+            path = path.replace(/\//g, '\\/');
+            $(this.directoryTreeSelector).jstree('open_node', '#' + path);
+            $(this.directoryTreeSelector).jstree('select_node', '#' + path, true);
+
+        },
+
+        /**
          * Listener to clear filters event
          */
         clearFiltersHandle: function () {
+
             if (_.isUndefined(this.filterChips().filters.path)) {
                 $(this.directoryTreeSelector).jstree('deselect_all');
                 this.activeNode(null);
@@ -196,6 +222,7 @@ define([
                  */
                 success: function (data) {
                     this.createTree(data);
+
                 }.bind(this),
 
                 /**

--- a/MediaGalleryUi/view/adminhtml/web/js/directory/directoryTree.js
+++ b/MediaGalleryUi/view/adminhtml/web/js/directory/directoryTree.js
@@ -41,7 +41,7 @@ define([
             this.waitForContainer(function () {
                 this.getJsonTree();
                 this.initEvents();
-                this.checkChipCiltersState();
+                this.checkChipFiltersState();
 
             }.bind(this));
 
@@ -96,7 +96,7 @@ define([
         /**
          * Verify directory filter on init event, select folder per directory filter state
          */
-        checkChipCiltersState: function () {
+        checkChipFiltersState: function () {
             if (!_.isUndefined(this.filterChips().filters.path) && this.filterChips().filters.path !== '') {
                 $(this.directoryTreeSelector).on('loaded.jstree', function () {
                     this.locateNode(this.filterChips().filters.path);


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/adobe-stock-integration#1294: The Active filter is Applied but the Directory is not selected after web page refresh
2. ...

### Manual testing scenarios (*)
2. Select a folder, verify that the folder directory is selected and Active filter is applied 
3. Refresh the web page (F5)


The Active filter is applied and the Directory is selected