### PR TITLE
The wrong folder selected after saving the image to a subfolder with name is the same as the parent

### DIFF
--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/actions.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/actions.js
@@ -166,7 +166,7 @@ define([
          * Selects displayed image in media gallery for new gallery
          */
         selectDisplayedImageForNewMediaGallery: function (path) {
-            var imageFolders = path.substring(0, path.indexOf('/')),
+            var imageFolders = path.substring(0, path.lastIndexOf('/')),
                 record = this.getRecordFromMediaGalleryProvider(path),
                 subscription; // eslint-disable-line no-unused-vars
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

Closes #1296

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/adobe-stock-integration#1296: The wrong folder selected after saving the image to a subfolder with name is the same as the parent
2. ...

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...