### PR TITLE
Image is not Opened in Media gallery if it is on another page in Media Gallery

### DIFF
--- a/AdobeStockImageAdminUi/view/adminhtml/ui_component/adobe_stock_images_listing.xml
+++ b/AdobeStockImageAdminUi/view/adminhtml/ui_component/adobe_stock_images_listing.xml
@@ -211,6 +211,7 @@
                     <item name="mediaGalleryComponent" xsi:type="string">media_gallery_listing.media_gallery_listing.media_gallery_columns.thumbnail_url</item>
                     <item name="mediaGalleryProvider" xsi:type="string">media_gallery_listing.media_gallery_listing_data_source</item>
                     <item name="mediaGallerySortBy" xsi:type="string">media_gallery_listing.media_gallery_listing.listing_top.sorting</item>
+                    <item name="mediaGallerySearchInput" xsi:type="string">media_gallery_listing.media_gallery_listing.listing_top.fulltext</item>
                     <item name="listingPaging" xsi:type="string">media_gallery_listing.media_gallery_listing.listing_top.listing_paging</item>
 		</item>
             </argument>

--- a/AdobeStockImageAdminUi/view/adminhtml/ui_component/adobe_stock_images_listing.xml
+++ b/AdobeStockImageAdminUi/view/adminhtml/ui_component/adobe_stock_images_listing.xml
@@ -212,6 +212,7 @@
                     <item name="mediaGalleryProvider" xsi:type="string">media_gallery_listing.media_gallery_listing_data_source</item>
                     <item name="mediaGallerySortBy" xsi:type="string">media_gallery_listing.media_gallery_listing.listing_top.sorting</item>
                     <item name="mediaGallerySearchInput" xsi:type="string">media_gallery_listing.media_gallery_listing.listing_top.fulltext</item>
+                    <item name="mediaGalleryListingFilters" xsi:type="string">media_gallery_listing.media_gallery_listing.listing_top.listing_filters</item>
                     <item name="listingPaging" xsi:type="string">media_gallery_listing.media_gallery_listing.listing_top.listing_paging</item>
 		</item>
             </argument>

--- a/AdobeStockImageAdminUi/view/adminhtml/ui_component/standalone_adobe_stock_images_listing.xml
+++ b/AdobeStockImageAdminUi/view/adminhtml/ui_component/standalone_adobe_stock_images_listing.xml
@@ -212,6 +212,7 @@
                     <item name="mediaGalleryProvider" xsi:type="string">standalone_media_gallery_listing.media_gallery_listing_data_source</item>
                     <item name="mediaGallerySortBy" xsi:type="string">standalone_media_gallery_listing.standalone_media_gallery_listing.listing_top.sorting</item>
                     <item name="mediaGallerySearchInput" xsi:type="string">standalone_media_gallery_listing.standalone_media_gallery_listing.listing_top.fulltext</item>
+                    <item name="mediaGalleryListingFilters" xsi:type="string">standalone_media_gallery_listing.standalone_media_gallery_listing.listing_top.listing_filters</item>
                     <item name="listingPaging" xsi:type="string">standalone_media_gallery_listing.standalone_media_gallery_listing.listing_top.listing_paging</item>
 		</item>
             </argument>

--- a/AdobeStockImageAdminUi/view/adminhtml/ui_component/standalone_adobe_stock_images_listing.xml
+++ b/AdobeStockImageAdminUi/view/adminhtml/ui_component/standalone_adobe_stock_images_listing.xml
@@ -211,6 +211,7 @@
                     <item name="mediaGalleryComponent" xsi:type="string">standalone_media_gallery_listing.standalone_media_gallery_listing.media_gallery_columns.thumbnail_url</item>
                     <item name="mediaGalleryProvider" xsi:type="string">standalone_media_gallery_listing.media_gallery_listing_data_source</item>
                     <item name="mediaGallerySortBy" xsi:type="string">standalone_media_gallery_listing.standalone_media_gallery_listing.listing_top.sorting</item>
+                    <item name="mediaGallerySearchInput" xsi:type="string">standalone_media_gallery_listing.standalone_media_gallery_listing.listing_top.fulltext</item>
                     <item name="listingPaging" xsi:type="string">standalone_media_gallery_listing.standalone_media_gallery_listing.listing_top.listing_paging</item>
 		</item>
             </argument>

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/image-preview.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/image-preview.js
@@ -42,6 +42,7 @@ define([
                     mediaGalleryName: '${ $.mediaGalleryName }',
                     mediaGalleryProvider: '${ $.mediaGalleryProvider }',
                     mediaGallerySortBy: '${ $.mediaGallerySortBy }',
+                    mediaGallerySearchInput: '${ $.mediaGallerySearchInput }',
                     listingPaging: '${ $.listingPaging }'
                 }
             ]

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/image-preview.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/image-preview.js
@@ -43,6 +43,7 @@ define([
                     mediaGalleryProvider: '${ $.mediaGalleryProvider }',
                     mediaGallerySortBy: '${ $.mediaGallerySortBy }',
                     mediaGallerySearchInput: '${ $.mediaGallerySearchInput }',
+                    mediaGalleryListingFilters: '${ $.mediaGalleryListingFilters }',
                     listingPaging: '${ $.listingPaging }'
                 }
             ]

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/actions.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/actions.js
@@ -131,7 +131,7 @@ define([
             this.preview().getAdobeModal().trigger('closeModal');
 
             if (!this.isMediaBrowser()) {
-                this.selectImageInNewMediaGalleryBySearch(this.preview().displayedRecord().title)
+                this.selectImageInNewMediaGalleryBySearch(this.preview().displayedRecord().title);
             } else {
                 this.selectDisplayedImageForOldMediaGallery(this.preview().displayedRecord().path);
             }

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/actions.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/actions.js
@@ -50,6 +50,7 @@ define([
                 source: '${ $.provider }',
                 imageDirectory: '${ $.mediaGalleryName }',
                 mediaGallerySortBy: '${ $.mediaGallerySortBy }',
+                mediaGallerySearchInput: '${ $.mediaGallerySearchInput }',
                 listingPaging: '${ $.listingPaging }'
             },
             imports: {
@@ -127,7 +128,22 @@ define([
          */
         openInMediaGalleryClick: function () {
             this.preview().getAdobeModal().trigger('closeModal');
-            this.selectInMediaGallery(this.preview().displayedRecord().path);
+
+            if (!this.isMediaBrowser()) {
+                this.selectImageInNewMediaGalleryBySearch(this.preview().displayedRecord().title)
+            } else {
+                this.selectDisplayedImageForOldMediaGallery(this.preview().displayedRecord().path);
+            }
+        },
+
+        /**
+         * Select image in new media gallery via search input
+         *
+         * @param {String} title
+         */
+        selectImageInNewMediaGalleryBySearch: function (title) {
+            this.imageDirectory().selectStorageRoot();
+            this.mediaGallerySearchInput().apply(title);
         },
 
         /**

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/actions.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/actions.js
@@ -51,6 +51,7 @@ define([
                 imageDirectory: '${ $.mediaGalleryName }',
                 mediaGallerySortBy: '${ $.mediaGallerySortBy }',
                 mediaGallerySearchInput: '${ $.mediaGallerySearchInput }',
+                mediaGalleryListingFilters: '${ $.mediaGalleryListingFilters }',
                 listingPaging: '${ $.listingPaging }'
             },
             imports: {
@@ -142,7 +143,7 @@ define([
          * @param {String} title
          */
         selectImageInNewMediaGalleryBySearch: function (title) {
-            this.imageDirectory().selectStorageRoot();
+            this.mediaGalleryListingFilters().clear();
             this.mediaGallerySearchInput().apply(title);
         },
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

Closes #1297

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/adobe-stock-integration#1297: Image is not Opened in Media gallery if it is on another page in Media Gallery
2. ...

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...