### PR TITLE
Use thumbnail versions of images for displaying in the media gallery …

### DIFF
--- a/AdobeStockImage/Model/Storage/Save.php
+++ b/AdobeStockImage/Model/Storage/Save.php
@@ -16,6 +16,7 @@ use Magento\Framework\Filesystem;
 use Magento\Framework\Filesystem\Driver\Https;
 use Magento\Framework\Filesystem\DriverInterface;
 use Magento\MediaGalleryApi\Api\IsPathBlacklistedInterface;
+use Magento\Cms\Model\Wysiwyg\Images\Storage;
 
 /**
  * Save images to the file system
@@ -40,18 +41,26 @@ class Save
     private $isPathBlacklisted;
 
     /**
+     * @var Storage
+     */
+    private $storage;
+    
+    /**
      * @param Filesystem $filesystem
      * @param Https $driver
      * @param IsPathBlacklistedInterface $isPathBlacklisted
+     * @param Storage $storage
      */
     public function __construct(
         Filesystem $filesystem,
         Https $driver,
-        IsPathBlacklistedInterface $isPathBlacklisted
+        IsPathBlacklistedInterface $isPathBlacklisted,
+        Storage $storage
     ) {
         $this->filesystem = $filesystem;
         $this->driver = $driver;
         $this->isPathBlacklisted = $isPathBlacklisted;
+        $this->storage = $storage;
     }
 
     /**
@@ -81,6 +90,7 @@ class Save
 
         $fileContents = $this->driver->fileGetContents($this->getUrlWithoutProtocol($imageUrl));
         $mediaDirectory->writeFile($destinationPath, $fileContents);
+        $this->storage->resizeFile($mediaDirectory->getAbsolutePath($destinationPath));
     }
 
     /**

--- a/MediaGallerySynchronization/Model/SynchronizeFiles.php
+++ b/MediaGallerySynchronization/Model/SynchronizeFiles.php
@@ -11,7 +11,6 @@ use Magento\Framework\Exception\LocalizedException;
 use Magento\MediaGalleryApi\Api\SaveAssetsInterface;
 use Magento\MediaGallerySynchronizationApi\Api\SynchronizeFilesInterface;
 use Psr\Log\LoggerInterface;
-use Magento\Cms\Model\Wysiwyg\Images\Storage;
 
 /**
  * Synchronize files in media storage and media assets database records
@@ -34,26 +33,18 @@ class SynchronizeFiles implements SynchronizeFilesInterface
     private $log;
 
     /**
-     * @var Storage
-     */
-    private $storage;
-    
-    /**
      * @param CreateAssetFromFile $createAssetFromFile
      * @param SaveAssetsInterface $saveAsset
      * @param LoggerInterface $log
-     * @param Storage $storage
      */
     public function __construct(
         CreateAssetFromFile $createAssetFromFile,
         SaveAssetsInterface $saveAsset,
-        LoggerInterface $log,
-        Storage $storage
+        LoggerInterface $log
     ) {
         $this->createAssetFromFile = $createAssetFromFile;
         $this->saveAsset = $saveAsset;
         $this->log = $log;
-        $this->storage = $storage;
     }
 
     /**
@@ -65,7 +56,6 @@ class SynchronizeFiles implements SynchronizeFilesInterface
         foreach ($files as $file) {
             try {
                 $this->saveAsset->execute([$this->createAssetFromFile->execute($file)]);
-                $this->storage->resizeFile($file->getPathName());
             } catch (\Exception $exception) {
                 $this->log->critical($exception);
                 $failedFiles[] = $file->getFilename();

--- a/MediaGallerySynchronization/Model/SynchronizeFiles.php
+++ b/MediaGallerySynchronization/Model/SynchronizeFiles.php
@@ -11,6 +11,7 @@ use Magento\Framework\Exception\LocalizedException;
 use Magento\MediaGalleryApi\Api\SaveAssetsInterface;
 use Magento\MediaGallerySynchronizationApi\Api\SynchronizeFilesInterface;
 use Psr\Log\LoggerInterface;
+use Magento\Cms\Model\Wysiwyg\Images\Storage;
 
 /**
  * Synchronize files in media storage and media assets database records
@@ -33,18 +34,26 @@ class SynchronizeFiles implements SynchronizeFilesInterface
     private $log;
 
     /**
+     * @var Storage
+     */
+    private $storage;
+    
+    /**
      * @param CreateAssetFromFile $createAssetFromFile
      * @param SaveAssetsInterface $saveAsset
      * @param LoggerInterface $log
+     * @param Storage $storage
      */
     public function __construct(
         CreateAssetFromFile $createAssetFromFile,
         SaveAssetsInterface $saveAsset,
-        LoggerInterface $log
+        LoggerInterface $log,
+        Storage $storage
     ) {
         $this->createAssetFromFile = $createAssetFromFile;
         $this->saveAsset = $saveAsset;
         $this->log = $log;
+        $this->storage = $storage;
     }
 
     /**
@@ -56,6 +65,7 @@ class SynchronizeFiles implements SynchronizeFilesInterface
         foreach ($files as $file) {
             try {
                 $this->saveAsset->execute([$this->createAssetFromFile->execute($file)]);
+                $this->storage->resizeFile($file->getPathName());
             } catch (\Exception $exception) {
                 $this->log->critical($exception);
                 $failedFiles[] = $file->getFilename();

--- a/MediaGalleryUi/Plugin/ResizeSyncedFiles.php
+++ b/MediaGalleryUi/Plugin/ResizeSyncedFiles.php
@@ -33,10 +33,11 @@ class ResizeSyncedFiles
      * @param array $files
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function aroundExecute(SynchronizeFiles $subject, \Closure $closure, array $files): void
+    public function bExecute(SynchronizeFiles $subject, \Closure $closure, array $files): \Closure
     {
         foreach ($files as $file) {
             $this->storage->resizeFile($file->getPathName());
         }
+        return $closure($subject);
     }
 }

--- a/MediaGalleryUi/Plugin/ResizeSyncedFiles.php
+++ b/MediaGalleryUi/Plugin/ResizeSyncedFiles.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\MediaGalleryUi\Plugin;
+
+use Magento\MediaGallerySynchronization\Model\SynchronizeFiles;
+use Magento\Cms\Model\Wysiwyg\Images\Storage;
+
+class ResizeSyncedFiles
+{
+    /**
+     * @var Storage
+     */
+    private $storage;
+
+    /**
+     * @param Storage $storage
+     */
+    public function __construct(Storage $storage)
+    {
+        $this->storage = $storage;
+    }
+
+
+    /**
+     * Create thumbnails for synced files.
+     * @param SynchronizeFiles $subject
+     * @param \Closure $closure
+     * @param array $files
+     */
+    public function aroundExecute(SynchronizeFiles $subject, \Closure $closure, array $files): void
+    {
+        foreach ($files as $file) {
+            $this->storage->resizeFile($file->getPathName());
+        }
+    }
+}

--- a/MediaGalleryUi/Plugin/ResizeSyncedFiles.php
+++ b/MediaGalleryUi/Plugin/ResizeSyncedFiles.php
@@ -33,11 +33,11 @@ class ResizeSyncedFiles
      * @param array $files
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function bExecute(SynchronizeFiles $subject, \Closure $closure, array $files): \Closure
+    public function aroundExecute(SynchronizeFiles $subject, \Closure $closure, array $files)
     {
         foreach ($files as $file) {
             $this->storage->resizeFile($file->getPathName());
         }
-        return $closure($subject);
+        return $closure($files);
     }
 }

--- a/MediaGalleryUi/Plugin/ResizeSyncedFiles.php
+++ b/MediaGalleryUi/Plugin/ResizeSyncedFiles.php
@@ -25,12 +25,13 @@ class ResizeSyncedFiles
         $this->storage = $storage;
     }
 
-
     /**
      * Create thumbnails for synced files.
+     *
      * @param SynchronizeFiles $subject
      * @param \Closure $closure
      * @param array $files
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function aroundExecute(SynchronizeFiles $subject, \Closure $closure, array $files): void
     {

--- a/MediaGalleryUi/Ui/Component/Listing/Columns/Url.php
+++ b/MediaGalleryUi/Ui/Component/Listing/Columns/Url.php
@@ -15,6 +15,7 @@ use Magento\Store\Model\Store;
 use Magento\Store\Model\StoreManagerInterface;
 use Magento\Ui\Component\Listing\Columns\Column;
 use Magento\Cms\Helper\Wysiwyg\Images;
+use Magento\Cms\Model\Wysiwyg\Images\Storage;
 
 /**
  * Overlay column
@@ -37,11 +38,18 @@ class Url extends Column
     private $images;
 
     /**
+     * @var Storage
+     */
+    private $storage;
+    
+
+    /**
      * @param ContextInterface $context
      * @param UiComponentFactory $uiComponentFactory
      * @param StoreManagerInterface $storeManager
      * @param UrlInterface $urlInterface
      * @param Images $images
+     * @param Storage $storage
      * @param array $components
      * @param array $data
      */
@@ -51,6 +59,7 @@ class Url extends Column
         StoreManagerInterface $storeManager,
         UrlInterface $urlInterface,
         Images $images,
+        Storage $storage,
         array $components = [],
         array $data = []
     ) {
@@ -58,6 +67,7 @@ class Url extends Column
         $this->storeManager = $storeManager;
         $this->urlInterface = $urlInterface;
         $this->images = $images;
+        $this->storage = $storage;
     }
 
     /**
@@ -106,8 +116,6 @@ class Url extends Column
      */
     private function getUrl(string $path): string
     {
-        /** @var Store $store */
-        $store = $this->storeManager->getStore();
-        return $store->getBaseUrl(UrlInterface::URL_TYPE_MEDIA) . $path;
+        return $this->storage->getThumbnailUrl($this->images->getStorageRoot() . $path);
     }
 }

--- a/MediaGalleryUi/Ui/Component/Listing/Columns/Url.php
+++ b/MediaGalleryUi/Ui/Component/Listing/Columns/Url.php
@@ -41,7 +41,6 @@ class Url extends Column
      * @var Storage
      */
     private $storage;
-    
 
     /**
      * @param ContextInterface $context

--- a/MediaGalleryUi/composer.json
+++ b/MediaGalleryUi/composer.json
@@ -9,6 +9,7 @@
         "magento/module-store": "*",
         "magento/module-media-gallery-ui-api": "*",
         "magento/module-media-gallery-api": "*",
+        "magento/module-media-gallery-synchronization": "*",
         "magento/module-media-gallery-synchronization-api": "*",
         "magento/module-media-content-api": "*",
         "magento/module-cms": "*"

--- a/MediaGalleryUi/etc/di.xml
+++ b/MediaGalleryUi/etc/di.xml
@@ -20,6 +20,14 @@
             <argument name="resourceModel" xsi:type="string">Magento\MediaGalleryUi\Model\ResourceModel\Grid\Asset</argument>
         </arguments>
     </virtualType>
+    <type name="Magento\Cms\Model\Wysiwyg\Images\Storage">
+        <arguments>
+            <argument name="resizeParameters" xsi:type="array">
+                <item name="height" xsi:type="number">200</item>
+                <item name="width" xsi:type="number">200</item>
+            </argument>
+        </arguments>
+    </type>
     <type name="Magento\MediaGalleryUi\Model\Directories\FolderTree">
         <arguments>
             <argument name="path" xsi:type="string">media</argument>

--- a/MediaGalleryUi/etc/di.xml
+++ b/MediaGalleryUi/etc/di.xml
@@ -40,6 +40,10 @@
             </argument>
         </arguments>
     </type>
+    <type name="Magento\MediaGallerySynchronization\Model\SynchronizeFiles">
+        <plugin name="create_thumbnails_for_synced_fiels" type="Magento\MediaGalleryUi\Plugin\ResizeSyncedFiles"/>
+    </type>
+
     <type name="Magento\MediaGalleryUi\Model\AssetDetailsProvider\UsedIn">
         <arguments>
             <argument name="contentTypes" xsi:type="array">

--- a/MediaGalleryUi/etc/module.xml
+++ b/MediaGalleryUi/etc/module.xml
@@ -6,5 +6,9 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Magento_MediaGalleryUi" />
+    <module name="Magento_MediaGalleryUi">
+        <sequence>
+            <module name="Magento_Cms" />
+        </sequence>
+    </module>
 </config>

--- a/MediaGalleryUi/view/adminhtml/web/js/grid/columns/image/insertImageAction.js
+++ b/MediaGalleryUi/view/adminhtml/web/js/grid/columns/image/insertImageAction.js
@@ -33,29 +33,29 @@ define([
                 throw 'Target element not found for content update';
             }
 
-            if (targetElement.is('textarea')) {
-                $.ajax({
-                    url: config.onInsertUrl,
-                    data: {
-                        filename: record['encoded_id'],
-                        'store_id': config.storeId,
-                        'as_is': 1,
-                        'force_static_path': targetElement.data('force_static_path') ? 1 : 0,
-                        'form_key': FORM_KEY
-                    },
-                    context: this,
-                    showLoader: true
-                }).done($.proxy(function (data) {
+            $.ajax({
+                url: config.onInsertUrl,
+                data: {
+                    filename: record['encoded_id'],
+                    'store_id': config.storeId,
+                    'as_is': targetElement.is('textarea') ? 1 : 0,
+                    'force_static_path': targetElement.data('force_static_path') ? 1 : 0,
+                    'form_key': FORM_KEY
+                },
+                context: this,
+                showLoader: true
+            }).done($.proxy(function (data) {
+                if (targetElement.is('textarea')) {
                     this.insertAtCursor(targetElement.get(0), data);
                     targetElement.focus();
                     $(targetElement).change();
-                }, this));
-            } else {
-                targetElement.val(record['thumbnail_url'])
-                    .data('size', record.size)
-                    .data('mime-type', record['content_type'])
-                    .trigger('change');
-            }
+                } else {
+                    targetElement.val(data)
+                        .data('size', record.size)
+                        .data('mime-type', record['content_type'])
+                        .trigger('change');
+                }
+            }, this));
             window.MediabrowserUtility.closeDialog();
             targetElement.focus();
         },


### PR DESCRIPTION
…grid

<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/adobe-stock-integration#1085: Use thumbnail versions of images for displaying in the media gallery grid
2. ...

### Manual testing scenarios (*)
1. Login to Admin Palel
2. Open Media Gallery i.e.:
   - From Admin go to **Content** - **Pages**, click **Add New Page**)

**Thumbnails used in the grid, full-size images  used for image details slide panel**