### PR TITLE
Several fixes for Internet explorer & edge

### DIFF
--- a/AdobeStockImageAdminUi/view/adminhtml/web/css/source/_module.less
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/css/source/_module.less
@@ -75,6 +75,7 @@
         }
 
         .masonry-image-column {
+            position: static;
             &:first-child .masonry-image-preview .preview-buttons .action-previous,
             &:last-child .masonry-image-preview .preview-buttons .action-next {
                 opacity: .5;
@@ -111,6 +112,9 @@
         }
 
         .masonry-image-preview {
+
+            position: absolute;
+
             .title {
                 font-weight: bold;
             }
@@ -203,10 +207,10 @@
 
             .related-loader {
                 height: 100px;
+                position: absolute;
                 left: 50%;
                 margin-left: -50px;
                 margin-top: 50px;
-                top: 50%;
                 width: 100px;
             }
 
@@ -224,7 +228,6 @@
                     .thumbnail {
                         display: inline-flex;
                         height: 100px;
-                        justify-content: center;
                         margin-right: 10px;
                         max-width: 150px;
                         overflow: hidden;

--- a/AdobeStockImageAdminUi/view/adminhtml/web/css/source/_module.less
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/css/source/_module.less
@@ -207,10 +207,10 @@
 
             .related-loader {
                 height: 100px;
-                position: absolute;
                 left: 50%;
                 margin-left: -50px;
                 margin-top: 50px;
+                position: absolute;
                 width: 100px;
             }
 

--- a/MediaGalleryUi/view/adminhtml/ui_component/media_gallery_listing.xml
+++ b/MediaGalleryUi/view/adminhtml/ui_component/media_gallery_listing.xml
@@ -234,7 +234,7 @@
         <column name="path">
             <settings>
                 <visible>false</visible>
-                <sortable>true</sortable>
+                <sortable>false</sortable>
             </settings>
         </column>
         <column name="directory_desc">
@@ -269,7 +269,7 @@
         <column name="title">
             <settings>
                 <visible>false</visible>
-                <sortable>true</sortable>
+                <sortable>false</sortable>
             </settings>
         </column>
         <column name="name_az">

--- a/MediaGalleryUi/view/adminhtml/ui_component/standalone_media_gallery_listing.xml
+++ b/MediaGalleryUi/view/adminhtml/ui_component/standalone_media_gallery_listing.xml
@@ -221,7 +221,7 @@
         <column name="path">
             <settings>
                 <visible>false</visible>
-                <sortable>true</sortable>
+                <sortable>false</sortable>
             </settings>
         </column>
         <column name="directory_desc">
@@ -256,7 +256,7 @@
         <column name="title">
             <settings>
                 <visible>false</visible>
-                <sortable>true</sortable>
+                <sortable>false</sortable>
             </settings>
         </column>
         <column name="name_az">

--- a/MediaGalleryUi/view/adminhtml/web/css/source/_module.less
+++ b/MediaGalleryUi/view/adminhtml/web/css/source/_module.less
@@ -40,7 +40,7 @@
         color: @color-media-gallery-buttons-text;
     }
 
-    .masonry-image-grid .no-data-message-container, .masonry-image-grid .error-message-container {
+    .masonry-image-grid .error-message-container {
         left: 50%;
         margin-right: -50%;
         position: sticky;
@@ -252,12 +252,11 @@
         }
 
         .masonry-image-grid {
-            position: relative;
             display: grid;align-items: first baseline;
-            grid-template-columns: repeat(7, 1fr);
-            justify-content: end;
+            grid-template-columns: repeat(auto-fill, minmax(204px, 1fr));
+            justify-items: end;
             margin: 10px 0;
-        }
+            position: relative;
     }
 
     .media-gallery-image-details-modal {

--- a/MediaGalleryUi/view/adminhtml/web/css/source/_module.less
+++ b/MediaGalleryUi/view/adminhtml/web/css/source/_module.less
@@ -127,7 +127,7 @@
         .masonry-image-overlay {
             background-color: @color-masonry-overlay;
             font-size: 11px;
-            margin-left: 110px;
+            margin-left: 120px;
             margin-top: 170px;
             padding: .3rem;
             pointer-events: none;
@@ -253,7 +253,8 @@
         }
 
         .masonry-image-grid {
-            display: grid;align-items: first baseline;
+            align-items: first baseline;
+            display: grid;
             grid-template-columns: repeat(auto-fill, 210px);
             justify-content: end;
             margin: 10px 0;

--- a/MediaGalleryUi/view/adminhtml/web/css/source/_module.less
+++ b/MediaGalleryUi/view/adminhtml/web/css/source/_module.less
@@ -257,6 +257,7 @@
             justify-items: end;
             margin: 10px 0;
             position: relative;
+        }
     }
 
     .media-gallery-image-details-modal {

--- a/MediaGalleryUi/view/adminhtml/web/css/source/_module.less
+++ b/MediaGalleryUi/view/adminhtml/web/css/source/_module.less
@@ -40,6 +40,7 @@
         color: @color-media-gallery-buttons-text;
     }
 
+    .masonry-image-grid .no-data-message-container,
     .masonry-image-grid .error-message-container {
         left: 50%;
         margin-right: -50%;

--- a/MediaGalleryUi/view/adminhtml/web/css/source/_module.less
+++ b/MediaGalleryUi/view/adminhtml/web/css/source/_module.less
@@ -127,7 +127,7 @@
         .masonry-image-overlay {
             background-color: @color-masonry-overlay;
             font-size: 11px;
-            margin-left: 120px;
+            margin-left: 110px;
             margin-top: 170px;
             padding: .3rem;
             pointer-events: none;
@@ -254,8 +254,8 @@
 
         .masonry-image-grid {
             display: grid;align-items: first baseline;
-            grid-template-columns: repeat(auto-fill, minmax(204px, 1fr));
-            justify-items: end;
+            grid-template-columns: repeat(auto-fill, 210px);
+            justify-content: end;
             margin: 10px 0;
             position: relative;
         }

--- a/MediaGalleryUi/view/adminhtml/web/css/source/_module.less
+++ b/MediaGalleryUi/view/adminhtml/web/css/source/_module.less
@@ -40,8 +40,15 @@
         color: @color-media-gallery-buttons-text;
     }
 
+    .masonry-image-grid .no-data-message-container, .masonry-image-grid .error-message-container {
+        left: 50%;
+        margin-right: -50%;
+        position: sticky;
+        top: 50%;
+    }
+    
     .media-gallery-container {
-
+        
         .admin__action-dropdown-wrap._active .admin__action-dropdown-text::after {
             margin-right: 6px;
         }
@@ -245,6 +252,10 @@
         }
 
         .masonry-image-grid {
+            position: relative;
+            display: grid;align-items: first baseline;
+            grid-template-columns: repeat(7, 1fr);
+            justify-content: end;
             margin: 10px 0;
         }
     }


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/adobe-stock-integration#1081: Image Preview is broken on Internet Explorer & Edge
2. magento/adobe-stock-integration#1308: Empty spots in "Sort by" drop-down list (Internet Explorer & Edge)
3. magento/adobe-stock-integration#1303: 
Extra white space on Media Gallery grid (Not Standalone Media Gallery)


### Manual testing scenarios (*)
1. Go to **Catalog - Products** and click **Add Product**
2. Expand **Content**, click **Show / Hide Editor** **Insert Image**
3. Observe the right side of Media Gallery Grid

No white space, like on Standalone Media Gallery
No Empty spots in the drop-down list sortBy
The preview is properly displayed