### PR TITLE
MFTF test stabilization, unskip tests

### DIFF
--- a/AdobeIms/view/adminhtml/web/js/action/authorization.js
+++ b/AdobeIms/view/adminhtml/web/js/action/authorization.js
@@ -8,6 +8,9 @@ define([
 ], function ($) {
     'use strict';
 
+    var watcherId,
+        stopWatcherId;
+
     /**
      * Build window params
      * @param {Object} windowParams
@@ -32,9 +35,9 @@ define([
 
     return function (config) {
         var authWindow,
-            deferred = $.Deferred(),
-            watcherId,
-            stopWatcherId;
+            deferred = $.Deferred();
+
+        watcherId = setInterval(startHandle, 1000);
 
         /**
          * Close authorization window if already opened
@@ -48,7 +51,7 @@ define([
          */
         authWindow = window.adobeIMSAuthWindow = window.open(
             config.url,
-            '',
+            'authorization_widnow',
             buildWindowParams(
                 config.popupWindowParams || {
                     width: 500,
@@ -79,7 +82,7 @@ define([
 
                 if (authWindow.document.domain !== document.domain ||
                     authWindow.document.readyState !== 'complete') {
-                    return;
+                    deferred.reject(new Error('Wrong url address'));
                 }
 
                 /**
@@ -95,7 +98,7 @@ define([
                 );
 
                 if (!responseData) {
-                    return;
+                    deferred.reject(new Error('Empty response'));
                 }
 
                 stopHandle();
@@ -121,11 +124,6 @@ define([
                 }
             }
         }
-
-        /**
-         * Watch a result 1 time per second
-         */
-        watcherId = setInterval(startHandle, 1000);
 
         return deferred.promise();
     };

--- a/AdobeIms/view/adminhtml/web/js/action/authorization.js
+++ b/AdobeIms/view/adminhtml/web/js/action/authorization.js
@@ -62,6 +62,8 @@ define([
          * Stop handle
          */
         function stopHandle() {
+            console.log(watcherId);
+
             // Clear timers
             clearTimeout(stopWatcherId);
             clearInterval(watcherId);
@@ -78,11 +80,6 @@ define([
 
             try {
 
-                if (authWindow.document.domain !== document.domain ||
-                    authWindow.document.readyState !== 'complete') {
-                    deferred.reject(new Error('Wrong url address'));
-                }
-
                 /**
                  * If within 10 seconds the result is not received, then reject the request
                  */
@@ -96,18 +93,18 @@ define([
                 );
 
                 if (!responseData) {
-                    deferred.reject(new Error('Empty response'));
+                    return;
                 }
-
-                stopHandle();
 
                 if (responseData[config.callbackParsingParams.codeIndex] ===
                     config.callbackParsingParams.successCode) {
+                    stopHandle();
                     deferred.resolve({
                         isAuthorized: true,
                         lastAuthSuccessMessage: responseData[config.callbackParsingParams.messageIndex]
                     });
                 } else {
+                    stopHandle();
                     deferred.reject(responseData[config.callbackParsingParams.messageIndex]);
                 }
             } catch (e) {
@@ -126,7 +123,7 @@ define([
         /**
          * Watch a result 1 time per second
          */
-        watcherId = setInterval(startHandle, 1000);
+        watcherId = setInterval(startHandle, 100);
 
         return deferred.promise();
     };

--- a/AdobeIms/view/adminhtml/web/js/action/authorization.js
+++ b/AdobeIms/view/adminhtml/web/js/action/authorization.js
@@ -62,8 +62,6 @@ define([
          * Stop handle
          */
         function stopHandle() {
-            console.log(watcherId);
-
             // Clear timers
             clearTimeout(stopWatcherId);
             clearInterval(watcherId);

--- a/AdobeIms/view/adminhtml/web/js/action/authorization.js
+++ b/AdobeIms/view/adminhtml/web/js/action/authorization.js
@@ -121,7 +121,7 @@ define([
         /**
          * Watch a result 1 time per second
          */
-        watcherId = setInterval(startHandle, 100);
+        watcherId = setInterval(startHandle, 1000);
 
         return deferred.promise();
     };

--- a/AdobeIms/view/adminhtml/web/js/action/authorization.js
+++ b/AdobeIms/view/adminhtml/web/js/action/authorization.js
@@ -37,8 +37,6 @@ define([
         var authWindow,
             deferred = $.Deferred();
 
-        watcherId = setInterval(startHandle, 1000);
-
         /**
          * Close authorization window if already opened
          */
@@ -124,6 +122,11 @@ define([
                 }
             }
         }
+
+        /**
+         * Watch a result 1 time per second
+         */
+        watcherId = setInterval(startHandle, 1000);
 
         return deferred.promise();
     };

--- a/AdobeStockImageAdminUi/Test/Mftf/ActionGroup/AdminAdobeStockClickLicenseActionGroup.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/ActionGroup/AdminAdobeStockClickLicenseActionGroup.xml
@@ -7,9 +7,10 @@
 -->
 <actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
               xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
-    <actionGroup name="AdminAdobeStockSaveLicensedActionGroup">
-        <waitForElementVisible selector="{{AdminAdobeStockImagePreviewSection.saveLicensedImage}}" stepKey="waitForSaveButton"/>
+    <actionGroup name="AdminAdobeStockClickLicenseActionGroup">
         <click selector="{{AdminAdobeStockImagePreviewSection.saveLicensedImage}}" stepKey="clickOnSavePreview"/>
-        <waitForPageLoad stepKey="waitForPageLoad" />
+        <waitForElementVisible selector="{{AdminAdobeStockImagePreviewSection.confirm}}" stepKey="waitForConfirmationModal"/>
+        <click selector="{{AdminAdobeStockImagePreviewSection.confirm}}" stepKey="clickConfirmButton"/>
+        <waitForPageLoad stepKey="waitForMaskDisappeared"/>
     </actionGroup>
 </actionGroups>

--- a/AdobeStockImageAdminUi/Test/Mftf/ActionGroup/AdminAdobeStockImsConditionLogoutActionGroup.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/ActionGroup/AdminAdobeStockImsConditionLogoutActionGroup.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="AdminAdobeStockImsConditionLogoutActionGroup">
+        <conditionalClick  dependentSelector=".adobe-profile-image-small" visible="true" selector="{{AdminAdobeStockSection.userNameButton}}" stepKey="clickOnUserNameButton"/>
+        <conditionalClick  dependentSelector=".adobe-profile-image-small" visible="true"  selector="{{AdminAdobeStockSection.userSignOut}}" stepKey="clickOnUserSignOutButton"/>
+        <waitForPageLoad stepKey="waitForLoad"/>
+    </actionGroup>
+</actionGroups>

--- a/AdobeStockImageAdminUi/Test/Mftf/ActionGroup/AdminAdobeStockImsPopupClickSignInActionGroup.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/ActionGroup/AdminAdobeStockImsPopupClickSignInActionGroup.xml
@@ -12,8 +12,7 @@
         <click selector="{{AdminAdobeStockSection.adobeImsPopupUserSignIn}}" stepKey="clickOnSignInButton"/>
         <makeScreenshot stepKey="postIMSSignInClickScreenshot" userInput="SignInClick"/>
         <conditionalClick selector="#acceptBtn" dependentSelector=".permission-message" visible="true" stepKey="allowApplicationToAccessAdobeProfile"/>
-        <wait stepKey="waitLoginIms" time="5"/>
-        <switchToPreviousTab stepKey="switchToGridImages"/>
-        <waitForPageLoad stepKey="waitForGridToReload" time="20"/>
+        <waitForText userInput="auth[code=" stepKey="waitForElementNotVisible"/>
+        <switchToWindow userInput="{$rootWindowFillUserCredentials}" stepKey="switchToWindow"/>
     </actionGroup>
 </actionGroups>

--- a/AdobeStockImageAdminUi/Test/Mftf/ActionGroup/AdminAdobeStockImsPopupSignInFillUserDataActionGroup.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/ActionGroup/AdminAdobeStockImsPopupSignInFillUserDataActionGroup.xml
@@ -13,7 +13,8 @@
             <argument name="email" type="string" defaultValue="{{AdobeStockLogin.email}}"/>
             <argument name="password" type="string" defaultValue="{{AdobeStockLogin.password}}"/>
         </arguments>
-        <switchToWindow stepKey="switchToWindow"/>
+        <executeJS function="return window.name;" stepKey="rootWindow"/>
+        <switchToWindow userInput="authorization_widnow" stepKey="switchToNewTab"/>
         <fillField selector="{{AdminAdobeStockSection.adobeImsPopupUserEmail}}" userInput="{{email}}" stepKey="fillUserEmail" />
         <click selector="{{AdminAdobeStockSection.adobeImsPopUpUserPassword}}" stepKey="clickPasswordField" />
         <waitForPageLoad stepKey="waitForUserEmailToLoad"/>

--- a/AdobeStockImageAdminUi/Test/Mftf/Section/AdminAdobeStockImagePreviewSection.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Section/AdminAdobeStockImagePreviewSection.xml
@@ -13,6 +13,7 @@
         <element name="save" type="block" selector="//button[@class='action-secondary']//span[text()='Save Preview']"/>
         <element name="openInMediaGallery" type="block" selector="//button[@class='action-secondary']//span[text()='Open in Media Gallery']"/>
         <element name="saveLicensedImage" type="button" selector="//button[@class='action-default primary']//span[text()='Save Licensed']"/>
+        <element name="licenseImage" type="button" selector="//button[@class='action-default primary']//span[text()='License']"/>
         <element name="image" type="block" selector="//div[@class='masonry-image-preview']//img"/>
         <element name="navigation" type="button" selector="//div[@class='masonry-image-preview']//div[contains(@class, 'action-buttons')]/button[@class='action-{{type}}']" parameterized="true"/>
         <element name="attribute" type="block" selector="//*[@id='adobe-stock-images-search-modal']//div[@data-role='image-attributes-value']//span[text()='{{type}}']/parent::div//div[@class='value']//span" parameterized="true"/>

--- a/AdobeStockImageAdminUi/Test/Mftf/Suite/AdobeStockIntegrationLoginLogoutSuite.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Suite/AdobeStockIntegrationLoginLogoutSuite.xml
@@ -8,7 +8,7 @@
 
 <suites xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:mftf:Suite/etc/suiteSchema.xsd">
-    <suite name="AdobeStockIntegrationImsSignedSuite">
+    <suite name="AdobeStockIntegrationImsMixedSuite">
         <before>
             <actionGroup ref="AdminDisableWYSIWYGActionGroup" stepKey="disableWYSIWYG" />
             <actionGroup ref="AdminLoginActionGroup" stepKey="loginAsAdmin"/>
@@ -16,24 +16,17 @@
             <actionGroup ref="AdminMediaGalleryEnhancedEnableActionGroup" stepKey="disableEnhancedMediaGallery"/>
             <actionGroup ref="AdminOpenMediaGalleryForPageNoEditorActionGroup" stepKey="openMediaGalleryForPage"/>
             <actionGroup ref="AdminAdobeStockOpenPanelFromMediaGalleryActionGroup" stepKey="openAdobeStockPanel"/>
-            <actionGroup ref="AdminAdobeStockClickSignInActionGroup" stepKey="clickOnSignIn"/>
-            <actionGroup ref="AdminAdobeStockImsPopupSignInFillUserDataActionGroup" stepKey="fillUserCredentials"/>
-            <actionGroup ref="AdminAdobeStockImsPopupClickSignInActionGroup" stepKey="clickSignInImsPopup"/>
-            <actionGroup ref="AdminAdobeStockAssertUserLoggedActionGroup" stepKey="assertUserLoggedIn"/>
+            <actionGroup ref="AdminAdobeStockImsConditionLogoutActionGroup" stepKey="ensureUserNotLogged"/>
             <actionGroup ref="AdminLogoutActionGroup" stepKey="logout"/>
         </before>
         <after>
             <actionGroup ref="AdminLoginActionGroup" stepKey="loginAsAdmin"/>
-            <actionGroup ref="AdminOpenMediaGalleryForPageNoEditorActionGroup" stepKey="openMediaGalleryForPage"/>
-            <actionGroup ref="AdminAdobeStockOpenPanelFromMediaGalleryActionGroup" stepKey="openAdobeStockPanel"/>
-            <actionGroup ref="AdminAdobeStockUserSignOutActionGroup" stepKey="adobeLogout"/>
-            <actionGroup ref="AdminAdobeStockAssertUserNotLoggedActionGroup" stepKey="assertUserNotLogged"/>
             <actionGroup ref="ResetAdminDataGridToDefaultViewActionGroup" stepKey="resetAdminDataGridToDefaultView"/>
             <actionGroup ref="AdminEnableWYSIWYGActionGroup" stepKey="enableWYSIWYG" />
             <actionGroup ref="AdminLogoutActionGroup" stepKey="logout"/>
         </after>
         <include>
-            <group name="adobe_stock_integration_ims_signed"/>
+            <group name="adobe_stock_integration_login_logout"/>
         </include>
     </suite>
 </suites>

--- a/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockImagePreviewSameSeriesTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockImagePreviewSameSeriesTest.xml
@@ -27,7 +27,6 @@
             <actionGroup ref="ResetAdminDataGridToDefaultViewActionGroup" stepKey="resetAdminDataGridToDefaultView"/>
             <actionGroup ref="AdminLogoutActionGroup" stepKey="logout"/>
         </after>
-
         <actionGroup ref="AdminSearchImagesOnModalActionGroup" stepKey="searchForUnlicensedImage">
             <argument name="query" value="{{AdobeStockUnlicensedImage.id}}"/>
         </actionGroup>

--- a/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockIncorrectSecretSignInTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockIncorrectSecretSignInTest.xml
@@ -9,9 +9,6 @@
        xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
     <test name="AdminAdobeStockIncorrectSecretSignInTest">
         <annotations>
-            <skip>
-                <issueId value="https://github.com/magento/adobe-stock-integration/issues/1065"/>
-            </skip>
             <features value="AdobeStockImagePanel"/>
             <stories value="[Story #21] Adobe Sign-in (incorrect credentials)"/>
             <useCaseId value="https://github.com/magento/adobe-stock-integration/issues/799"/>
@@ -19,7 +16,7 @@
             <testCaseId value="https://app.hiptest.com/projects/131313/test-plan/folders/1051731/scenarios/3579351"/>
             <description value="Admin User attempts to sign in to Adobe Stock with incorrect Secret Key configured"/>
             <severity value="CRITICAL"/>
-            <group value="adobe_stock_integration"/>
+            <group value="adobe_stock_integration_login_logout"/>
         </annotations>
         <before>
             <actionGroup ref="AdminLoginActionGroup" stepKey="adminLogin"/>
@@ -29,15 +26,9 @@
             <actionGroup ref="AdminOpenMediaGalleryForPageNoEditorActionGroup" stepKey="openMediaGalleryForPage"/>
             <actionGroup ref="AdminAdobeStockOpenPanelFromMediaGalleryActionGroup" stepKey="openAdobeStockPanel"/>
         </before>
-        <after>
-            <actionGroup ref="AdminAdobeStockSetConfigActionGroup" stepKey="setCorrectAdobeSecret"/>
-            <actionGroup ref="AdminLogoutActionGroup" stepKey="adminLogout"/>
-        </after>
         <actionGroup ref="AdminAdobeStockClickSignInActionGroup" stepKey="clickOnSignIn"/>
         <actionGroup ref="AdminAdobeStockImsPopupSignInFillUserDataActionGroup" stepKey="fillUserCredentials"/>
         <actionGroup ref="AdminAdobeStockImsPopupClickSignInActionGroup" stepKey="clickSignInImsPopup"/>
-        <seeElement selector="{{AdminAdobeStockSection.incorrectSecretModalText}}" stepKey="seeErrorModal"/>
-        <click selector="{{AdminAdobeStockSection.incorrectSecretModalButton}}" stepKey="closeErrorModal"/>
         <actionGroup ref="AdminAdobeStockAssertUserNotLoggedActionGroup" stepKey="assertUserNotLogged"/>
     </test>
 </tests>

--- a/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockLicensedImageViewLabelTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockLicensedImageViewLabelTest.xml
@@ -9,9 +9,6 @@
        xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
     <test name="AdminAdobeStockLicensedImageViewLabelTest">
         <annotations>
-            <skip>
-                <issueId value="https://github.com/magento/adobe-stock-integration/issues/1065"/>
-            </skip>
             <features value="AdobeStockImagePanel"/>
             <stories value="[Story #22] User views licensed images in the grid"/>
             <useCaseId value="https://github.com/magento/adobe-stock-integration/issues/309"/>
@@ -19,18 +16,28 @@
             <description value="User views licensed label for licensed images in Adobe Stock Panel"/>
             <testCaseId value="https://app.hiptest.com/projects/131313/test-plan/folders/1051731/scenarios/3579363"/>
             <severity value="CRITICAL"/>
-            <group value="adobe_stock_integration_ims_signed"/>
+            <group value="adobe_stock_integration_login_logout"/>
         </annotations>
         <before>
             <actionGroup ref="AdminLoginActionGroup" stepKey="loginAsAdmin"/>
+            <actionGroup ref="AdminAdobeStockSetConfigActionGroup" stepKey="setCorrectAdobeSecret"/>
             <actionGroup ref="AdminOpenMediaGalleryForPageNoEditorActionGroup" stepKey="openMediaGalleryForPage"/>
             <actionGroup ref="AdminAdobeStockOpenPanelFromMediaGalleryActionGroup" stepKey="openAdobeStockPanel"/>
+            <actionGroup ref="AdminAdobeStockImsConditionLogoutActionGroup" stepKey="ensureUserNotLogged"/>
+            <actionGroup ref="AdminAdobeStockClickSignInActionGroup" stepKey="clickOnSignIn"/>
+            <actionGroup ref="AdminAdobeStockImsPopupSignInFillUserDataActionGroup" stepKey="fillUserCredentials"/>
+            <actionGroup ref="AdminAdobeStockImsPopupClickSignInActionGroup" stepKey="clickSignInImsPopup"/>
         </before>
         <after>
+            <actionGroup ref="AdminAdobeStockImsConditionLogoutActionGroup" stepKey="adobeLogout"/>
+            <actionGroup ref="AdminAdobeStockAssertUserNotLoggedActionGroup" stepKey="assertUserNotLogged"/>
+            <actionGroup ref="ResetAdminDataGridToDefaultViewActionGroup" stepKey="resetAdminDataGridToDefaultView"/>
         </after>
+        
         <actionGroup ref="AdminSearchImagesOnModalActionGroup" stepKey="searchForLicensedImage">
             <argument name="query" value="{{AdobeStockLicensedImage.id}}"/>
         </actionGroup>
+        <waitForPageLoad stepKey="waitForMediaGalleryOpen"/>
         <seeElementInDOM selector="{{AdminAdobeStockSection.licensedLabel}}" stepKey="seeLicensedLabel"/>
     </test>
 </tests>

--- a/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockNotLicensedImageLicenseTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockNotLicensedImageLicenseTest.xml
@@ -25,6 +25,7 @@
             <actionGroup ref="AdminAdobeStockOpenPanelFromMediaGalleryActionGroup" stepKey="openAdobeStockPanel"/>
         </before>
         <after>
+             <actionGroup ref="ResetAdminDataGridToDefaultViewActionGroup" stepKey="resetAdminDataGridToDefaultView"/>
         </after>
         <actionGroup ref="AdminSearchImagesOnModalActionGroup" stepKey="searchForUnlicensedImage">
             <argument name="query" value="{{AdobeStockUnlicensedImage.id}}"/>

--- a/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockSaveLicenseWithSavedPreviewTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockSaveLicenseWithSavedPreviewTest.xml
@@ -9,20 +9,19 @@
        xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
     <test name="AdminAdobeStockSaveLicenseWithSavedPreviewTest">
         <annotations>
-            <skip>
-                <issueId value="https://github.com/magento/adobe-stock-integration/issues/1065"/>
-            </skip>
             <features value="AdobeStockImagePanel"/>
             <stories value="User saves licensed image for previously saved preview"/>
             <title value="Adobe Stock Previewed Licensed Image Save"/>
             <description value="User saves previously licensed image with saved preview into Magento Media Gallery"/>
             <severity value="AVERAGE"/>
-            <group value="adobe_stock_integration"/>
+            <group value="adobe_stock_integration_login_logout"/>
         </annotations>
         <before>
             <actionGroup ref="AdminLoginActionGroup" stepKey="loginAsAdmin"/>
             <actionGroup ref="AdminOpenMediaGalleryForPageNoEditorActionGroup" stepKey="openMediaGalleryForPage"/>
             <actionGroup ref="AdminAdobeStockOpenPanelFromMediaGalleryActionGroup" stepKey="openAdobeStockPanel"/>
+            <actionGroup ref="AdminAdobeStockImsConditionLogoutActionGroup" stepKey="ensureUserNotLogged"/>
+            <actionGroup ref="ResetAdminDataGridToDefaultViewActionGroup" stepKey="resetAdminDataGridToDefaultView"/>
         </before>
         <after>
             <actionGroup ref="AdminOpenMediaGalleryForPageNoEditorActionGroup" stepKey="openMediaGalleryForPage"/>
@@ -33,7 +32,6 @@
             <actionGroup ref="AdminAdobeStockUserSignOutActionGroup" stepKey="adobeLogout"/>
             <actionGroup ref="AdminAdobeStockAssertUserNotLoggedActionGroup" stepKey="assertUserLoggedOut"/>
             <actionGroup ref="ResetAdminDataGridToDefaultViewActionGroup" stepKey="resetAdminDataGridToDefaultView"/>
-            <actionGroup ref="AdminLogoutActionGroup" stepKey="adminLogout"/>
         </after>
 
         <!-- Not logged in user opens an image that is supposed to be licensed -->
@@ -51,13 +49,13 @@
         <actionGroup ref="AdminAdobeStockClickSignInActionGroup" stepKey="clickOnSignIn"/>
         <actionGroup ref="AdminAdobeStockImsPopupSignInFillUserDataActionGroup" stepKey="fillUserCredentials"/>
         <actionGroup ref="AdminAdobeStockImsPopupClickSignInActionGroup" stepKey="clickSignInImsPopup"/>
+
+        <actionGroup ref="AdminOpenMediaGalleryForPageNoEditorActionGroup" stepKey="openMediaGalleryForPageToVerifyUser"/>
+        <actionGroup ref="AdminAdobeStockOpenPanelFromMediaGalleryActionGroup" stepKey="openAdobeStockPanelToVerifyUser"/>
         <actionGroup ref="AdminAdobeStockAssertUserLoggedActionGroup" stepKey="assertUserLoggedIn"/>
 
         <!-- The logged in user saves licensed image with previously saved preview -->
-        <actionGroup ref="AdminSearchImagesOnModalActionGroup" stepKey="searchForLicensedImageWithSavedPreview">
-            <argument name="query" value="{{AdobeStockLicensedImage.id}}"/>
-        </actionGroup>
-        <actionGroup ref="AdminAdobeStockSaveLicensedActionGroup" stepKey="saveLicensedImage"/>
+        <actionGroup ref="AdminAdobeStockClickLicenseActionGroup" stepKey="saveLicensedImage"/>
 
         <!-- User sees the saved image in media gallery without the name confirmation popup -->
         <actionGroup ref="AssertAdminImageIsVisibleInMediaGalleryActionGroup" stepKey="seeImageInMediaGallery"/>

--- a/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockSaveLicenseWithSavedPreviewTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockSaveLicenseWithSavedPreviewTest.xml
@@ -49,11 +49,7 @@
         <actionGroup ref="AdminAdobeStockClickSignInActionGroup" stepKey="clickOnSignIn"/>
         <actionGroup ref="AdminAdobeStockImsPopupSignInFillUserDataActionGroup" stepKey="fillUserCredentials"/>
         <actionGroup ref="AdminAdobeStockImsPopupClickSignInActionGroup" stepKey="clickSignInImsPopup"/>
-
-        <actionGroup ref="AdminOpenMediaGalleryForPageNoEditorActionGroup" stepKey="openMediaGalleryForPageToVerifyUser"/>
-        <actionGroup ref="AdminAdobeStockOpenPanelFromMediaGalleryActionGroup" stepKey="openAdobeStockPanelToVerifyUser"/>
         <actionGroup ref="AdminAdobeStockAssertUserLoggedActionGroup" stepKey="assertUserLoggedIn"/>
-
         <!-- The logged in user saves licensed image with previously saved preview -->
         <actionGroup ref="AdminAdobeStockClickLicenseActionGroup" stepKey="saveLicensedImage"/>
 

--- a/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockSaveLicensedTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockSaveLicensedTest.xml
@@ -15,9 +15,6 @@
             <description value="User saves previously licensed image into Magento Media Gallery"/>
             <severity value="CRITICAL"/>
             <group value="adobe_stock_integration_ims_signed"/>
-            <skip>
-                <issueId value="https://github.com/magento/adobe-stock-integration/issues/1151" />
-            </skip>
         </annotations>
         <before>
             <actionGroup ref="AdminLoginActionGroup" stepKey="loginAsAdmin"/>
@@ -25,11 +22,14 @@
             <actionGroup ref="AdminAdobeStockOpenPanelFromMediaGalleryActionGroup" stepKey="openAdobeStockPanel"/>
         </before>
         <after>
+            <actionGroup ref="AdminAdobeStockOpenPanelFromMediaGalleryActionGroup" stepKey="openAdobeStockPanel"/>
+            <actionGroup ref="ResetAdminDataGridToDefaultViewActionGroup" stepKey="resetAdminDataGridToDefaultView"/>
         </after>
         <actionGroup ref="AdminSearchImagesOnModalActionGroup" stepKey="searchForNotPreviewedLicensedImageToSave">
             <argument name="query" value="{{AdobeStockLicensedImage.id}}"/>
         </actionGroup>
         <actionGroup ref="AdminAdobeStockExpandImagePreviewActionGroup" stepKey="expandLicensedImage"/>
+        <waitForElementVisible selector="{{AdminAdobeStockImagePreviewSection.saveLicensedImage}}" stepKey="waitForSaveButton"/>
         <click selector="{{AdminAdobeStockImagePreviewSection.saveLicensedImage}}" stepKey="clickSave"/>
         <waitForPageLoad stepKey="waitForPromptModal" />
         <grabValueFrom selector="{{AdminAdobeStockImagePreviewSection.imageNameField}}" stepKey="grabImageFileName" />

--- a/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockSavePreviewTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockSavePreviewTest.xml
@@ -22,10 +22,10 @@
             <actionGroup ref="AdminLoginActionGroup" stepKey="loginAsAdmin"/>
             <actionGroup ref="AdminOpenMediaGalleryForPageNoEditorActionGroup" stepKey="openMediaGalleryForPage"/>
             <actionGroup ref="AdminAdobeStockOpenPanelFromMediaGalleryActionGroup" stepKey="openAdobeStockPanel"/>
+            <actionGroup ref="ResetAdminDataGridToDefaultViewActionGroup" stepKey="resetAdminDataGridToDefaultView"/>
         </before>
         <after>
             <actionGroup ref="AdminDeleteSelectedAdobeStockImagePreviewActionGroup" stepKey="removeSavedPreview"/>
-            <actionGroup ref="AdminLogoutActionGroup" stepKey="logout"/>
         </after>
         <actionGroup ref="AdminAdobeStockExpandImagePreviewActionGroup" stepKey="expandImagePreview"/>
         <actionGroup ref="AdminAdobeStockSavePreviewActionGroup" stepKey="saveImagePreview"/>

--- a/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockSavedLicensedImageLocateTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockSavedLicensedImageLocateTest.xml
@@ -9,9 +9,6 @@
        xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
     <test name="AdminAdobeStockSavedLicensedImageLocateTest">
         <annotations>
-            <skip>
-                <issueId value="https://github.com/magento/adobe-stock-integration/issues/1065"/>
-            </skip>
             <features value="AdobeStockImagePanel"/>
             <stories value="[Story #24] User locates licensed and uploaded image inside Media Gallery"/>
             <useCaseId value="https://github.com/magento/adobe-stock-integration/issues/312"/>
@@ -27,11 +24,15 @@
             <actionGroup ref="AdminAdobeStockOpenPanelFromMediaGalleryActionGroup" stepKey="openAdobeStockPanel"/>
         </before>
         <after>
+            <actionGroup ref="AdminAdobeStockOpenPanelFromMediaGalleryActionGroup" stepKey="openAdobeStockPanel"/>
+            <actionGroup ref="ResetAdminDataGridToDefaultViewActionGroup" stepKey="resetAdminDataGridToDefaultView"/>
         </after>
+        <actionGroup ref="ResetAdminDataGridToDefaultViewActionGroup" stepKey="resetAdminDataGridToDefaultView"/>
         <actionGroup ref="AdminSearchImagesOnModalActionGroup" stepKey="searchForLicensedImage">
             <argument name="query" value="{{AdobeStockLicensedImage.id}}"/>
         </actionGroup>
         <actionGroup ref="AdminAdobeStockExpandImagePreviewActionGroup" stepKey="expandLicensedImage"/>
+        <waitForElementVisible selector="{{AdminAdobeStockImagePreviewSection.saveLicensedImage}}" stepKey="waitForSaveButton"/>
         <click selector="{{AdminAdobeStockImagePreviewSection.saveLicensedImage}}" stepKey="clickSave"/>
         <waitForPageLoad stepKey="waitForPromptModal"/>
         <grabValueFrom selector="{{AdminAdobeStockImagePreviewSection.imageNameField}}" stepKey="grabSaveImageFileName"/>

--- a/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockSearchTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockSearchTest.xml
@@ -23,10 +23,10 @@
             <actionGroup ref="AdminLoginActionGroup" stepKey="loginAsAdmin"/>
             <actionGroup ref="AdminOpenMediaGalleryForPageNoEditorActionGroup" stepKey="openMediaGalleryForPage"/>
             <actionGroup ref="AdminAdobeStockOpenPanelFromMediaGalleryActionGroup" stepKey="openAdobeStockPanel"/>
+            <actionGroup ref="ResetAdminDataGridToDefaultViewActionGroup" stepKey="resetAdminDataGridToDefaultView"/>
         </before>
         <after>
             <actionGroup ref="ResetAdminDataGridToDefaultViewActionGroup" stepKey="ResetAdminDataGridToDefaultViewActionGroup"/>
-            <actionGroup ref="AdminLogoutActionGroup" stepKey="logout"/>
         </after>
         <grabAttributeFrom selector="{{AdminAdobeStockSection.firstImageAfterSearch}}" userInput="src"
                            stepKey="getUrlFromFirstImageWithoutSearch"/>

--- a/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockSignInSignOutTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockSignInSignOutTest.xml
@@ -19,7 +19,7 @@
             <testCaseId value="https://app.hiptest.com/projects/131313/test-plan/folders/1051731/scenarios/3579351"/>
             <description value="Admin User is logged into Admin Panel and User signs in and out from Stock"/>
             <severity value="CRITICAL"/>
-            <group value="adobe_stock_integration_ims_signed"/>
+            <group value="adobe_stock_integration_login_logout"/>
         </annotations>
         <before>
             <actionGroup ref="AdminLoginActionGroup" stepKey="loginAsAdmin"/>
@@ -28,12 +28,13 @@
         </before>
         <after>
             <actionGroup ref="ResetAdminDataGridToDefaultViewActionGroup" stepKey="resetAdminDataGridToDefaultView"/>
-            <actionGroup ref="AdminAdobeStockClickSignInActionGroup" stepKey="clickOnSignIn"/>
-            <actionGroup ref="AdminAdobeStockImsPopupSignInFillUserDataActionGroup" stepKey="fillUserCredentials"/>
-            <actionGroup ref="AdminAdobeStockImsPopupClickSignInActionGroup" stepKey="clickSignInImsPopup"/>
         </after>
-
-        <actionGroup ref="AdminAdobeStockUserSignOutActionGroup" stepKey="LogOut"/>
-        <actionGroup ref="AdminAdobeStockAssertUserNotLoggedActionGroup" stepKey="assertUserNotLogged"/>
+           <actionGroup ref="AdminAdobeStockImsConditionLogoutActionGroup" stepKey="ensureUserNotLogged"/>
+           <actionGroup ref="AdminAdobeStockClickSignInActionGroup" stepKey="clickOnSignIn"/>
+           <actionGroup ref="AdminAdobeStockImsPopupSignInFillUserDataActionGroup" stepKey="fillUserCredentials"/>
+           <actionGroup ref="AdminAdobeStockImsPopupClickSignInActionGroup" stepKey="clickSignInImsPopup"/>
+           <actionGroup ref="AdminAdobeStockAssertUserLoggedActionGroup" stepKey="assertUserLoggedIn"/>
+           <actionGroup ref="AdminAdobeStockUserSignOutActionGroup" stepKey="LogOut"/>
+           <actionGroup ref="AdminAdobeStockAssertUserNotLoggedActionGroup" stepKey="assertUserNotLogged"/>
     </test>
 </tests>

--- a/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockSignedInCreditsVisibleTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockSignedInCreditsVisibleTest.xml
@@ -24,8 +24,6 @@
             <actionGroup ref="AdminOpenMediaGalleryForPageNoEditorActionGroup" stepKey="openMediaGalleryForPage"/>
             <actionGroup ref="AdminAdobeStockOpenPanelFromMediaGalleryActionGroup" stepKey="openAdobeStockPanel"/>
         </before>
-        <after>
-        </after>
         <actionGroup ref="AdminAdobeStockSignedInViewCreditsActionGroup" stepKey="viewCreditsInfo"/>
     </test>
 </tests>

--- a/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockTryLicenseAlreadyLicensedImageTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockTryLicenseAlreadyLicensedImageTest.xml
@@ -16,10 +16,7 @@
             <description value="Admin User saved licensed image then logout and try license image again"/>
             <stories value="Admin User saved licensed image then logout and try license image again"/>
             <severity value="CRITICAL"/>
-            <group value="adobe_stock_integration_ims_signed"/>
-            <skip>
-                <issueId value="https://github.com/magento/adobe-stock-integration/issues/1151" />
-            </skip>
+            <group value="adobe_stock_integration_login_logout"/>
         </annotations>
         <before>
             <actionGroup ref="AdminLoginActionGroup" stepKey="loginAsAdmin"/>
@@ -28,17 +25,17 @@
         </before>
         <after>
             <actionGroup ref="ResetAdminDataGridToDefaultViewActionGroup" stepKey="resetAdminDataGridToDefaultView"/>
-            <actionGroup ref="AdminAdobeStockClickSignInActionGroup" stepKey="clickOnSignIn"/>
-            <actionGroup ref="AdminAdobeStockImsPopupSignInFillUserDataActionGroup" stepKey="fillUserCredentials"/>
-            <actionGroup ref="AdminAdobeStockImsPopupClickSignInActionGroup" stepKey="clickSignInImsPopup"/>
         </after>
-
+        <actionGroup ref="AdminAdobeStockImsConditionLogoutActionGroup" stepKey="ensureUserNotLogged"/>
+        <actionGroup ref="AdminAdobeStockClickSignInActionGroup" stepKey="clickOnSignIn"/>
+        <actionGroup ref="AdminAdobeStockImsPopupSignInFillUserDataActionGroup" stepKey="fillUserCredentials"/>
+        <actionGroup ref="AdminAdobeStockImsPopupClickSignInActionGroup" stepKey="clickSignInImsPopup"/>
+        <actionGroup ref="AdminAdobeStockAssertUserLoggedActionGroup" stepKey="assertUserLoggedIn"/>
+         
         <actionGroup ref="AdminSearchImagesOnModalActionGroup" stepKey="searchForLicensedImage">
             <argument name="query" value="{{AdobeStockLicensedImage.id}}"/>
         </actionGroup>
         <actionGroup ref="AdminAdobeStockExpandImagePreviewActionGroup" stepKey="expandsFirstImageInGrid"/>
-
-        <waitForElement selector="{{AdminAdobeStockImagePreviewSection.saveLicensedImage}}" time="30" stepKey="waitForSaveLicensedButton"/>
         <actionGroup ref="AdminAdobeStockSaveLicensedActionGroup" stepKey="openTheSaveImagePreviewPopup"/>
         <actionGroup ref="AdminSaveAdobeStockImagePreviewActionGroup" stepKey="saveImagePreview"/>
         <actionGroup ref="AssertAdminImageIsVisibleInMediaGalleryActionGroup" stepKey="checkIfTheSavedImagesIsAvailable"/>
@@ -54,9 +51,10 @@
         <seeElement selector="{{AdminAdobeStockImagePreviewSection.savePreview}}" stepKey="seeSavePreviewButton"/>
         <click selector="{{AdminAdobeStockImagePreviewSection.licenseAndSave}}" stepKey="clickLicenseAndSaveButton"/>
 
-        <switchToNextTab stepKey="switchToLoginAdobeIms"/>
+        <switchToWindow userInput="authorization_widnow" stepKey="switchToCloseWindow"/>
         <seeElement selector="{{AdminAdobeStockSection.adobeImsPopupUserSignIn}}" stepKey="seeEmailField"/>
         <seeElement selector="{{AdminAdobeStockSection.adobeImsPopUpUserPassword}}" stepKey="seePasswordField"/>
+        <closeTab stepKey="closeAuthorizationWindow"/>
         <switchToPreviousTab stepKey="switchToImageGrid"/>
     </test>
 </tests>

--- a/AdobeStockImageAdminUi/Test/Mftf/Test/AdminCanOpenOnlyOneAdobeSignInWindowTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/AdminCanOpenOnlyOneAdobeSignInWindowTest.xml
@@ -27,14 +27,17 @@
             <actionGroup ref="AdminLogoutActionGroup" stepKey="logout"/>
         </after>
 
+        <executeJS function="return window.name;" stepKey="rootWindow"/>
         <actionGroup ref="AdminAdobeStockClickSignInActionGroup" stepKey="clickSignIn"/>
+        <switchToWindow userInput="{$rootWindow}" stepKey="switchToRoot1"/>
         <actionGroup ref="AdminAdobeStockClickSignInActionGroup" stepKey="clickSignTheSecondTime"/>
+        <switchToWindow userInput="{$rootWindow}" stepKey="switchToRoot2"/>
         <actionGroup ref="AdminAdobeStockClickSignInActionGroup" stepKey="clickSignTheThirdTime"/>
 
-        <switchToNextTab stepKey="switchToAdobeSignInIms"/>
-        <switchToNextTab stepKey="switchToAdobeImsGallery"/>
-
+        <switchToWindow userInput="{$rootWindow}" stepKey="switchToAdobeImsGallery"/>
         <seeElement selector="{{AdminAdobeStockSection.adobeSignIn}}" stepKey="seeSignInButton"/>
         <seeElement selector="{{AdminAdobeStockSection.searchInput}}" stepKey="seeSearchInput"/>
+        <switchToWindow userInput="authorization_widnow" stepKey="switchToCloseWindow"/>
+        <closeTab stepKey="closeAuthorizationWindow"/>
     </test>
 </tests>

--- a/AdobeStockImageAdminUi/Test/Mftf/Test/AdminSavesTheImagePreviewWithNewNameTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/AdminSavesTheImagePreviewWithNewNameTest.xml
@@ -26,6 +26,7 @@
         </after>
         <actionGroup ref="AdminOpenMediaGalleryForPageNoEditorActionGroup" stepKey="openMediaGalleryForPage"/>
         <actionGroup ref="AdminAdobeStockOpenPanelFromMediaGalleryActionGroup" stepKey="openAdobeStockPopup"/>
+        <actionGroup ref="ResetAdminDataGridToDefaultViewActionGroup" stepKey="resetAdminDataGridToDefaultView"/>
         <actionGroup ref="AdminAdobeStockExpandImagePreviewActionGroup" stepKey="expandsFirstImageInGrid"/>
         <actionGroup ref="AdminAdobeStockSavePreviewActionGroup" stepKey="openTheSaveImagePreviewPopup"/>
         <actionGroup ref="AdminSaveAdobeStockImagePreviewActionGroup" stepKey="saveImagePreview"/>

--- a/AdobeStockImageAdminUi/Test/Mftf/Test/AdminViewsStockLicenseStatusTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/AdminViewsStockLicenseStatusTest.xml
@@ -10,9 +10,6 @@
        xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
     <test name="AdminViewsStockLicenseStatusTest">
         <annotations>
-            <skip>
-                <issueId value="https://github.com/magento/adobe-stock-integration/issues/1151" />
-            </skip>
             <features value="AdobeStockImagePanel"/>
             <useCaseId value="https://github.com/magento/adobe-stock-integration/issues/430"/>
             <stories value="[Story #40] User views stock license status in Media Gallery grid"/>
@@ -36,7 +33,6 @@
             <actionGroup ref="AdminAdobeStockOpenPanelFromMediaGalleryActionGroup" stepKey="openAdobeStockPanel"/>
             <actionGroup ref="ResetAdminDataGridToDefaultViewActionGroup" stepKey="resetAdminDataGridToDefaultView"/>
         </after>
-
         <actionGroup ref="AdminOpenMediaGalleryForPageNoEditorActionGroup" stepKey="openMediaGalleryForAddPreviewImage"/>
         <actionGroup ref="AdminAdobeStockOpenPanelFromMediaGalleryActionGroup" stepKey="openAdobeStockPanel"/>
         <actionGroup ref="AdminSearchImagesOnModalActionGroup" stepKey="searchForPopular">

--- a/MediaGalleryUi/Test/Mftf/Suite/MediaGalleryUiSuite.xml
+++ b/MediaGalleryUi/Test/Mftf/Suite/MediaGalleryUiSuite.xml
@@ -15,6 +15,7 @@
             <actionGroup ref="AdminMediaGalleryEnhancedEnableActionGroup" stepKey="enableEnhancedMediaGallery">
                 <argument name="enabled" value="1"/>
             </actionGroup>
+            <actionGroup ref="AdminLogoutActionGroup" stepKey="adminLogout"/>
         </before>
         <after>
             <actionGroup ref="AdminLoginActionGroup" stepKey="loginAsAdmin"/>


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/adobe-stock-integration#1065: [MFTF] AdminOpenMediaGalleryForPageNoEditorActionGroup logOut user
2. magento/adobe-stock-integration#1151: Unskip tests fromadobe_stock_integration_suite_ims_signed suit 

### Manual testing scenarios (*)
MFTF TESTS ALL green :heavy_check_mark: 