### PR TITLE
fix typo. sentence in error message starts from lower case 

### DIFF
--- a/MediaGalleryUi/view/adminhtml/web/js/image-uploader.js
+++ b/MediaGalleryUi/view/adminhtml/web/js/image-uploader.js
@@ -87,7 +87,7 @@ define([
                         this.mediaGridMessages().add(
                             'error',
                             $.mage.__('Cannot upload <b>' + data.files[0].name +
-                                      '</b>. file exceeds maximum file size limit.')
+                                      '</b>. File exceeds maximum file size limit.')
                         );
 
                         return;


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->


<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
When trying to upload an image that exceeds file size limit, an error message appears. The error message consists of two sentences. The second sentence starts from lower case 

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
![file_name](https://user-images.githubusercontent.com/45624059/81279995-8a504d00-9060-11ea-8658-11aa6b80de8f.png)


### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Open Media Gallery
2. Click Upload image
3. Select an image sized more than 2MB