### PR TITLE
Fix styles for AdobeStok, IMprove AdobeStock Buttons to check configuration

### DIFF
--- a/AdobeStockImageAdminUi/Ui/Component/Listing/SearchAdobeStockButton.php
+++ b/AdobeStockImageAdminUi/Ui/Component/Listing/SearchAdobeStockButton.php
@@ -34,7 +34,7 @@ class SearchAdobeStockButton implements ButtonProviderInterface
      */
     public function getButtonData()
     {
-        if ($this->isAdobeStockIntegrationEnabled->execute()) {
+        if (!$this->isAdobeStockIntegrationEnabled->execute()) {
             return [];
         }
 

--- a/AdobeStockImageAdminUi/Ui/Component/Listing/SearchAdobeStockButton.php
+++ b/AdobeStockImageAdminUi/Ui/Component/Listing/SearchAdobeStockButton.php
@@ -11,7 +11,7 @@ use Magento\AdobeStockImageAdminUi\Model\IsAdobeStockIntegrationEnabled;
 use Magento\Framework\View\Element\UiComponent\Control\ButtonProviderInterface;
 
 /**
- * ADobe Stock Search Button
+ * Adobe Stock Search Button
  */
 class SearchAdobeStockButton implements ButtonProviderInterface
 {
@@ -21,8 +21,6 @@ class SearchAdobeStockButton implements ButtonProviderInterface
     private $isAdobeStockIntegrationEnabled;
 
     /**
-     * Define block template
-     *
      * @param IsAdobeStockIntegrationEnabled $isAdobeStockIntegrationEnabled
      */
     public function __construct(

--- a/AdobeStockImageAdminUi/Ui/Component/Listing/SearchAdobeStockButton.php
+++ b/AdobeStockImageAdminUi/Ui/Component/Listing/SearchAdobeStockButton.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\AdobeStockImageAdminUi\Ui\Component\Listing;
+
+use Magento\AdobeStockImageAdminUi\Model\IsAdobeStockIntegrationEnabled;
+use Magento\Framework\View\Element\UiComponent\Control\ButtonProviderInterface;
+
+/**
+ * ADobe Stock Search Button
+ */
+class SearchAdobeStockButton implements ButtonProviderInterface
+{
+    /**
+     * @var IsAdobeStockIntegrationEnabled
+     */
+    private $isAdobeStockIntegrationEnabled;
+
+    /**
+     * Define block template
+     *
+     * @param IsAdobeStockIntegrationEnabled $isAdobeStockIntegrationEnabled
+     */
+    public function __construct(
+        IsAdobeStockIntegrationEnabled $isAdobeStockIntegrationEnabled
+    ) {
+        $this->isAdobeStockIntegrationEnabled = $isAdobeStockIntegrationEnabled;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getButtonData()
+    {
+        if ($this->isAdobeStockIntegrationEnabled->execute()) {
+            return [];
+        }
+
+        return [
+            'label' => __('Search Adobe Stock'),
+            'sort_order' => '100',
+            'class' => 'media-gallery-actions-buttons',
+            'on_click' => 'jQuery(".adobe-search-images-modal").trigger("openModal");'
+        ];
+    }
+}

--- a/AdobeStockImageAdminUi/view/adminhtml/ui_component/media_gallery_listing.xml
+++ b/AdobeStockImageAdminUi/view/adminhtml/ui_component/media_gallery_listing.xml
@@ -9,12 +9,7 @@
          xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Ui:etc/ui_configuration.xsd">
     <settings>
         <buttons>
-            <button name="search_adobe_stock">
-                <param name="on_click" xsi:type="string">jQuery(".adobe-search-images-modal").trigger("openModal");</param>
-                <param name="sort_order" xsi:type="number">100</param>
-                <class>media-gallery-actions-buttons</class>
-                <label translate="true">Search Adobe Stock</label>
-            </button>
+            <button class="Magento\AdobeStockImageAdminUi\Ui\Component\Listing\SearchAdobeStockButton" name="search_adobe_stock" />
         </buttons>
     </settings>
     <listingToolbar name="listing_top">

--- a/AdobeStockImageAdminUi/view/adminhtml/ui_component/standalone_media_gallery_listing.xml
+++ b/AdobeStockImageAdminUi/view/adminhtml/ui_component/standalone_media_gallery_listing.xml
@@ -9,12 +9,7 @@
          xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Ui:etc/ui_configuration.xsd">
     <settings>
         <buttons>
-            <button name="search_adobe_stock">
-                <param name="on_click" xsi:type="string">jQuery(".adobe-search-images-modal").trigger("openModal");</param>
-                <param name="sort_order" xsi:type="number">100</param>
-                <class>media-gallery-actions-buttons</class>
-                <label translate="true">Search Adobe Stock</label>
-            </button>
+            <button class="Magento\AdobeStockImageAdminUi\Ui\Component\Listing\SearchAdobeStockButton" name="search_adobe_stock" />
         </buttons>
     </settings>
     <listingToolbar name="listing_top">

--- a/MediaGalleryUi/view/adminhtml/web/css/source/_module.less
+++ b/MediaGalleryUi/view/adminhtml/web/css/source/_module.less
@@ -40,16 +40,16 @@
         color: @color-media-gallery-buttons-text;
     }
 
-    .masonry-image-grid .no-data-message-container,
-    .masonry-image-grid .error-message-container {
-        left: 50%;
-        margin-right: -50%;
-        position: sticky;
-        top: 50%;
-    }
-    
     .media-gallery-container {
-        
+
+        .masonry-image-grid .no-data-message-container,
+        .masonry-image-grid .error-message-container {
+            left: 50%;
+            margin-right: -50%;
+            position: sticky;
+            top: 50%;
+        }
+
         .admin__action-dropdown-wrap._active .admin__action-dropdown-text::after {
             margin-right: 6px;
         }

--- a/MediaGalleryUi/view/adminhtml/web/js/image-uploader.js
+++ b/MediaGalleryUi/view/adminhtml/web/js/image-uploader.js
@@ -90,6 +90,8 @@ define([
                                       '</b>. file exceeds maximum file size limit.')
                         );
 
+                        this.count() < 2 || this.mediaGridMessages().scheduleCleanup();
+
                         return;
                     }
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/adobe-stock-integration#1326: The "Search Adobe Stock" button is available in Enhanced Media Gallery when the Adobe Stock Integration is disabled
2. magento/adobe-stock-integration#1327: The Configuration link is not visible in Adobe Stock window
3.  magento/adobe-stock-integration#1324:  The "...exceeds maximum file size limit." error message doesn't disappear within several seconds

### Manual testing scenarios (*)
. Installed Magento with Adobe Stock Integration
2. Enabled Adobe Stock Integration in _Stores - Configuration  - Advanced - System - Adobe Stock Integration_ but the API keys are not provided
3. Enhanced Media Gallery in Enabled 

### Steps to reproduce (*)
1. From Admin go to **Content** - **Pages**, click **Add New Page**
2. Expand **Content**,click **Show / Hide Editor**, click **Insert Image...** 
3. Click **Search Adobe Stock** button 
![configuration_link_expected](https://user-images.githubusercontent.com/45624059/81293020-47e53b00-9075-11ea-9326-055cfa06aeb4.png)

1. Installed Magento with Adobe Stock Integration
2. Disabled Adobe Stock Integration in _Stores - Configuration  - Advanced - System - Adobe Stock Integration_ 
3. Enhanced Media Gallery in Enabled 

### Steps to reproduce (*)
1. From Admin go to **Content** - **Pages**, click **Add New Page**
2. Expand **Content**,click **Show / Hide Editor**, click **Insert Image...** 
3. Verify if the **Search Adobe Stock** button is available

### Expected result (*)
The Search Adobe Stock button is not available as the integration is disabled

### Steps to reproduce (*)
1. From Admin go to **Content** - **Pages**, click **Add New Page**
2. Expand **Content**,click **Show / Hide Editor**, click **Insert Image...**
3. Select a folder from the folder tree 
4. Click **Upload Image** button
5. Select an image file from your local machine, which has size over 2 MB, and click Open
6. Verify if the appeared _"cannot upload 'filename"... exceeds maximum file size limit."_ message disappears within several seconds

### Expected result (*)
The error message disappears
