### PR TITLE
[MFTF] Media Gallery View Details tests

### DIFF
--- a/AdobeStockImageAdminUi/Test/Mftf/ActionGroup/AdminAdobeStockExpandImagePreviewActionGroup.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/ActionGroup/AdminAdobeStockExpandImagePreviewActionGroup.xml
@@ -9,6 +9,12 @@
 <actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
               xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
     <actionGroup name="AdminAdobeStockExpandImagePreviewActionGroup">
+        <conditionalClick stepKey="closeImagePreview"
+                          selector="{{AdminAdobeStockImagePreviewSection.close}}"
+                          dependentSelector="{{AdminAdobeStockImagePreviewSection.close}}"
+                          visible="true"
+        />
+        <waitForLoadingMaskToDisappear stepKey="waitForImagePreviewToClose"/>
         <click selector="{{AdminAdobeStockSection.modal}} {{AdminAdobeStockSection.firstImageInGrid}}" stepKey="clickOnThumbnail"/>
         <waitForLoadingMaskToDisappear stepKey="waitForImagePreviewToExpand"/>
     </actionGroup>

--- a/AdobeStockImageAdminUi/Test/Mftf/ActionGroup/AdminAdobeStockVerifyImageDetailsActionGroup.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/ActionGroup/AdminAdobeStockVerifyImageDetailsActionGroup.xml
@@ -24,12 +24,6 @@
             <expectedResult type="string">{{image.status}}</expectedResult>
         </assertStringContainsString>
 
-        <grabTextFrom selector="{{AdminEnhancedMediaGalleryViewDetailsSection.adobeStockCategory}}" stepKey="grabImageCategory"/>
-        <assertStringContainsString stepKey="verifyImageCategory">
-            <actualResult type="variable">grabImageCategory</actualResult>
-            <expectedResult type="string">{{image.category}}</expectedResult>
-        </assertStringContainsString>
-
         <grabTextFrom selector="{{AdminEnhancedMediaGalleryViewDetailsSection.adobeStockAuthor}}" stepKey="grabImageAuthor"/>
         <assertStringContainsString stepKey="verifyImageAuthor">
             <actualResult type="variable">grabImageAuthor</actualResult>

--- a/AdobeStockImageAdminUi/Test/Mftf/ActionGroup/AdminAdobeStockVerifyImageDetailsActionGroup.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/ActionGroup/AdminAdobeStockVerifyImageDetailsActionGroup.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="AdminAdobeStockVerifyImageDetailsActionGroup">
+        <annotations>
+            <description>Verifies adobe stock image information on the View Details panel</description>
+        </annotations>
+        <arguments>
+            <argument name="image"/>
+        </arguments>
+
+        <executeJS function="document.querySelector('{{AdminEnhancedMediaGalleryViewDetailsSection.adobeStockSection}}').scrollIntoView()" stepKey="scrollToAdobeStockSection"/>
+
+        <grabTextFrom selector="{{AdminEnhancedMediaGalleryViewDetailsSection.adobeStockStatus}}" stepKey="grabImageStatus"/>
+        <assertStringContainsString stepKey="verifyImageStatus">
+            <actualResult type="variable">grabImageStatus</actualResult>
+            <expectedResult type="string">{{image.status}}</expectedResult>
+        </assertStringContainsString>
+
+        <grabTextFrom selector="{{AdminEnhancedMediaGalleryViewDetailsSection.adobeStockCategory}}" stepKey="grabImageCategory"/>
+        <assertStringContainsString stepKey="verifyImageCategory">
+            <actualResult type="variable">grabImageCategory</actualResult>
+            <expectedResult type="string">{{image.category}}</expectedResult>
+        </assertStringContainsString>
+
+        <grabTextFrom selector="{{AdminEnhancedMediaGalleryViewDetailsSection.adobeStockAuthor}}" stepKey="grabImageAuthor"/>
+        <assertStringContainsString stepKey="verifyImageAuthor">
+            <actualResult type="variable">grabImageAuthor</actualResult>
+            <expectedResult type="string">{{image.author}}</expectedResult>
+        </assertStringContainsString>
+    </actionGroup>
+</actionGroups>

--- a/AdobeStockImageAdminUi/Test/Mftf/ActionGroup/AdminEnhancedMediaGallerySearchAdobeStockActionGroup.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/ActionGroup/AdminEnhancedMediaGallerySearchAdobeStockActionGroup.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="AdminEnhancedMediaGallerySearchAdobeStockActionGroup">
+        <annotations>
+            <description>Opens Adobe Stock grid from enhanced media gallery</description>
+        </annotations>
+
+        <click selector="{{AdminEnhancedMediaGalleryActionsSection.searchAdobeStock}}" stepKey="openAdobeStockGrid"/>
+        <waitForLoadingMaskToDisappear stepKey="waitForLoadingMaskToDisappear"/>
+    </actionGroup>
+</actionGroups>

--- a/AdobeStockImageAdminUi/Test/Mftf/Data/AdobeStockImageData.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Data/AdobeStockImageData.xml
@@ -13,8 +13,14 @@
     </entity>
     <entity name="AdobeStockLicensedImage">
         <data key="id">{{_CREDS.magento/adobe_stock_licensed_image}}</data>
+        <data key="status">Licensed</data>
+        <data key="category">Food</data>
+        <data key="author">photopixel</data>
     </entity>
     <entity name="AdobeStockUnlicensedImage">
         <data key="id">{{_CREDS.magento/adobe_stock_not_licensed_image}}</data>
+        <data key="status">Unlicensed</data>
+        <data key="category">People</data>
+        <data key="author">NajmiArif</data>
     </entity>
 </entities>

--- a/AdobeStockImageAdminUi/Test/Mftf/Section/AdminAdobeStockImagePreviewSection.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Section/AdminAdobeStockImagePreviewSection.xml
@@ -15,6 +15,7 @@
         <element name="saveLicensedImage" type="button" selector="//button[@class='action-default primary']//span[text()='Save Licensed']"/>
         <element name="licenseImage" type="button" selector="//button[@class='action-default primary']//span[text()='License']"/>
         <element name="image" type="block" selector="//div[@class='masonry-image-preview']//img"/>
+        <element name="close" type="button" selector="//div[@class='masonry-image-preview']//button[@class='action-close']"/>
         <element name="navigation" type="button" selector="//div[@class='masonry-image-preview']//div[contains(@class, 'action-buttons')]/button[@class='action-{{type}}']" parameterized="true"/>
         <element name="attribute" type="block" selector="//*[@id='adobe-stock-images-search-modal']//div[@data-role='image-attributes-value']//span[text()='{{type}}']/parent::div//div[@class='value']//span" parameterized="true"/>
         <element name="attributeTitle" type="block" selector="//*[@id='adobe-stock-images-search-modal']//div[@data-role='image-attributes-value']//span[text()='{{title}}']" parameterized="true"/>

--- a/AdobeStockImageAdminUi/Test/Mftf/Section/AdminEnhancedMediaGalleryActions.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Section/AdminEnhancedMediaGalleryActions.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+<sections xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:noNamespaceSchemaLocation="urn:magento:mftf:Page/etc/SectionObject.xsd">
+    <section name="AdminEnhancedMediaGalleryActions">
+        <element name="SearchAdobeStock" type="button" selector="[data-ui-id='search-adobe-stock-button']"/>
+    </section>
+</sections>

--- a/AdobeStockImageAdminUi/Test/Mftf/Section/AdminEnhancedMediaGalleryActionsSection.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Section/AdminEnhancedMediaGalleryActionsSection.xml
@@ -7,7 +7,7 @@
 -->
 <sections xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:noNamespaceSchemaLocation="urn:magento:mftf:Page/etc/SectionObject.xsd">
-    <section name="AdminEnhancedMediaGalleryActions">
-        <element name="SearchAdobeStock" type="button" selector="[data-ui-id='search-adobe-stock-button']"/>
+    <section name="AdminEnhancedMediaGalleryActionsSection">
+        <element name="searchAdobeStock" type="button" selector="[data-ui-id='search-adobe-stock-button']"/>
     </section>
 </sections>

--- a/AdobeStockImageAdminUi/Test/Mftf/Section/AdminEnhancedMediaGalleryImageActionsSection.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Section/AdminEnhancedMediaGalleryImageActionsSection.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+<sections xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:noNamespaceSchemaLocation="urn:magento:mftf:Page/etc/SectionObject.xsd">
+    <section name="AdminEnhancedMediaGalleryImageActionsSection">
+        <element name="license" type="button" selector="[data-ui-id='action-license']"/>
+    </section>
+</sections>

--- a/AdobeStockImageAdminUi/Test/Mftf/Section/AdminEnhancedMediaGalleryViewDetailsSection.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Section/AdminEnhancedMediaGalleryViewDetailsSection.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+<sections xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:noNamespaceSchemaLocation="urn:magento:mftf:Page/etc/SectionObject.xsd">
+    <section name="AdminEnhancedMediaGalleryViewDetailsSection">
+        <element name="adobeStockSection" type="block" selector=".adobe-stock-image-details"/>
+        <element name="adobeStockId" type="text" selector="//div[@class='attribute']/span[contains(text(), 'ID')]/following-sibling::div"/>
+        <element name="adobeStockStatus" type="text" selector="//div[@class='attribute']/span[contains(text(), 'Status')]/following-sibling::div"/>
+        <element name="adobeStockCategory" type="text" selector="//div[@class='attribute']/span[contains(text(), 'Category')]/following-sibling::div"/>
+        <element name="adobeStockAuthor" type="text" selector="//div[@class='attribute']/span[contains(text(), 'Author')]/following-sibling::div"/>
+    </section>
+</sections>

--- a/AdobeStockImageAdminUi/Test/Mftf/Suite/AdobeStockMediaGallerySuite.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Suite/AdobeStockMediaGallerySuite.xml
@@ -8,7 +8,7 @@
 
 <suites xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:mftf:Suite/etc/suiteSchema.xsd">
-    <suite name="AdobeStockIntegrationSuite">
+    <suite name="AdobeStockMediaGallerySuite">
         <before>
             <actionGroup ref="AdminDisableWYSIWYGActionGroup" stepKey="disableWYSIWYG" />
             <actionGroup ref="AdminLoginActionGroup" stepKey="loginAsAdmin"/>

--- a/AdobeStockImageAdminUi/Test/Mftf/Suite/AdobeStockMediaGallerySuite.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Suite/AdobeStockMediaGallerySuite.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<suites xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:mftf:Suite/etc/suiteSchema.xsd">
+    <suite name="AdobeStockIntegrationSuite">
+        <before>
+            <actionGroup ref="AdminDisableWYSIWYGActionGroup" stepKey="disableWYSIWYG" />
+            <actionGroup ref="AdminLoginActionGroup" stepKey="loginAsAdmin"/>
+            <actionGroup ref="AdminAdobeStockSetConfigActionGroup" stepKey="setCorrectModuleConfig"/>
+            <actionGroup ref="AdminMediaGalleryEnhancedEnableActionGroup" stepKey="disableEnhancedMediaGallery">
+                <argument name="enabled" value="1"/>
+            </actionGroup>
+        </before>
+        <after>
+            <actionGroup ref="AdminLoginActionGroup" stepKey="loginAsAdmin"/>
+            <actionGroup ref="AdminMediaGalleryEnhancedEnableActionGroup" stepKey="disableEnhancedMediaGallery">
+                <argument name="enabled" value="0"/>
+            </actionGroup>
+            <actionGroup ref="AdminEnableWYSIWYGActionGroup" stepKey="enableWYSIWYG" />
+        </after>
+        <include>
+            <group name="adobe_stock_media_gallery"/>
+        </include>
+    </suite>
+</suites>

--- a/AdobeStockImageAdminUi/Test/Mftf/Test/AdminMediaGalleryViewAdobeStockDetailsTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/AdminMediaGalleryViewAdobeStockDetailsTest.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+    <test name="AdminMediaGalleryViewAdobeStockDetailsTest">
+        <annotations>
+            <features value="AdobeStockMediaGallery"/>
+            <useCaseId value="https://github.com/magento/adobe-stock-integration/issues/428"/>
+            <title value="View adobe stock image details"/>
+            <testCaseId value="https://studio.cucumber.io/projects/131313/test-plan/folders/1054245/scenarios/4653671"/>
+            <description value="User views adobe stock image attributes in Media Gallery"/>
+            <severity value="CRITICAL"/>
+            <group value="adobe_stock_media_gallery"/>
+        </annotations>
+        <before>
+            <actionGroup ref="AdminLoginActionGroup" stepKey="loginAsAdmin"/>
+            <actionGroup ref="AdminOpenMediaGalleryForPageNoEditorActionGroup" stepKey="openMediaGalleryForPage"/>
+        </before>
+        <after>
+            <actionGroup ref="AdminEnhancedMediaGalleryImageDetailsDeleteActionGroup" stepKey="deleteImage"/>
+        </after>
+
+        <actionGroup ref="AdminEnhancedMediaGallerySearchAdobeStockActionGroup" stepKey="openAdobeStockGrid"/>
+        <actionGroup ref="AdminAdobeStockExpandImagePreviewActionGroup" stepKey="expandImagePreview"/>
+        <actionGroup ref="AdminAdobeStockSavePreviewActionGroup" stepKey="saveImagePreview"/>
+        <actionGroup ref="AdminSaveAdobeStockImagePreviewActionGroup" stepKey="confirmSaveImagePreview"/>
+        <actionGroup ref="AdminEnhancedMediaGalleryViewImageDetails" stepKey="viewImageDetails"/>
+        <actionGroup ref="AdminAdobeStockVerifyImageDetailsActionGroup" stepKey="verifyImageDetails">
+            <argument name="image" value="AdobeStockUnlicensedImage"/>
+        </actionGroup>
+    </test>
+</tests>

--- a/AdobeStockImageAdminUi/view/adminhtml/web/template/mediaGallery/grid/columns/image/licenseActions.html
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/template/mediaGallery/grid/columns/image/licenseActions.html
@@ -8,6 +8,6 @@
 <!-- ko  foreach: { data: actionsList, as: 'action' } -->
     <li>
         <a class="action-menu-item" href=""
-           data-bind="visible: $parent.isVisible($row(), action.name), text: action.title, click: $parent[action.handler].bind($parent, $row()), 'data-action': 'item-' + action.name" />
+           data-bind="visible: $parent.isVisible($row(), action.name), text: action.title, click: $parent[action.handler].bind($parent, $row()), attr: {'data-ui-id': 'action-' + action.name}" />
     </li>
 <!-- /ko -->

--- a/MediaGalleryUi/Test/Mftf/ActionGroup/AdminEnhancedMediaGalleryImageDetailsDeleteActionGroup.xml
+++ b/MediaGalleryUi/Test/Mftf/ActionGroup/AdminEnhancedMediaGalleryImageDetailsDeleteActionGroup.xml
@@ -14,6 +14,7 @@
         </annotations>
 
         <click selector="{{AdminEnhancedMediaGalleryViewDetailsSection.delete}}" stepKey="deleteImage"/>
+        <waitForElementVisible selector="{{AdminEnhancedMediaGalleryViewDetailsSection.confirmDelete}}" stepKey="waitForConfirmation"/>
         <click selector="{{AdminEnhancedMediaGalleryViewDetailsSection.confirmDelete}}" stepKey="confirmDelete"/>
         <waitForLoadingMaskToDisappear stepKey="waitForLoadingMaskToDisappear"/>
     </actionGroup>

--- a/MediaGalleryUi/Test/Mftf/ActionGroup/AdminEnhancedMediaGalleryImageDetailsDeleteActionGroup.xml
+++ b/MediaGalleryUi/Test/Mftf/ActionGroup/AdminEnhancedMediaGalleryImageDetailsDeleteActionGroup.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="AdminEnhancedMediaGalleryImageDetailsDeleteActionGroup">
+        <annotations>
+            <description>Delete image from the View Details panel</description>
+        </annotations>
+
+        <click selector="{{AdminEnhancedMediaGalleryViewDetailsSection.delete}}" stepKey="deleteImage"/>
+        <click selector="{{AdminEnhancedMediaGalleryViewDetailsSection.confirmDelete}}" stepKey="confirmDelete"/>
+        <waitForLoadingMaskToDisappear stepKey="waitForLoadingMaskToDisappear"/>
+    </actionGroup>
+</actionGroups>

--- a/MediaGalleryUi/Test/Mftf/ActionGroup/AdminEnhancedMediaGalleryUploadImageActionGroup.xml
+++ b/MediaGalleryUi/Test/Mftf/ActionGroup/AdminEnhancedMediaGalleryUploadImageActionGroup.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="AdminEnhancedMediaGalleryUploadImageActionGroup">
+        <annotations>
+            <description>Uploads the provided Image to Media Gallery.
+                If you use this action group, you MUST add steps to delete the image in the "after" steps.</description>
+        </annotations>
+        <arguments>
+            <argument name="image"/>
+        </arguments>
+
+        <attachFile selector="{{AdminEnhancedMediaGalleryActionsSection.upload}}" userInput="{{image.value}}" stepKey="uploadImage"/>
+        <waitForPageLoad stepKey="waitForPageLoad"/>
+        <waitForLoadingMaskToDisappear stepKey="waitForLoadingMaskToDisappear"/>
+    </actionGroup>
+</actionGroups>

--- a/MediaGalleryUi/Test/Mftf/ActionGroup/AdminEnhancedMediaGalleryVerifyImageDetailsActionGroup.xml
+++ b/MediaGalleryUi/Test/Mftf/ActionGroup/AdminEnhancedMediaGalleryVerifyImageDetailsActionGroup.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="AdminEnhancedMediaGalleryVerifyImageDetailsActionGroup">
+        <annotations>
+            <description>Verifies image information on the View Details panel</description>
+        </annotations>
+        <arguments>
+            <argument name="image"/>
+        </arguments>
+
+        <grabTextFrom selector="{{AdminEnhancedMediaGalleryViewDetailsSection.title}}" stepKey="grabImageTitle"/>
+        <assertStringContainsString stepKey="verifyImageTitle">
+            <actualResult type="variable">grabImageTitle</actualResult>
+            <expectedResult type="string">{{image.fileName}}</expectedResult>
+        </assertStringContainsString>
+
+        <grabTextFrom selector="{{AdminEnhancedMediaGalleryViewDetailsSection.contentType}}" stepKey="grabContentType"/>
+        <assertStringContainsStringIgnoringCase stepKey="verifyContentType">
+            <actualResult type="variable">grabContentType</actualResult>
+            <expectedResult type="string">{{image.extension}}</expectedResult>
+        </assertStringContainsStringIgnoringCase>
+
+        <grabTextFrom selector="{{AdminEnhancedMediaGalleryViewDetailsSection.type}}" stepKey="grabType"/>
+        <assertStringContainsString stepKey="verifyType">
+            <actualResult type="variable">grabType</actualResult>
+            <expectedResult type="string">Image</expectedResult>
+        </assertStringContainsString>
+    </actionGroup>
+</actionGroups>

--- a/MediaGalleryUi/Test/Mftf/ActionGroup/AdminEnhancedMediaGalleryViewImageDetailsActionGroup.xml
+++ b/MediaGalleryUi/Test/Mftf/ActionGroup/AdminEnhancedMediaGalleryViewImageDetailsActionGroup.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="AdminEnhancedMediaGalleryViewImageDetails">
+        <annotations>
+            <description>Opens View Details panel for the first image in the media gallery grid</description>
+        </annotations>
+
+        <click selector="{{AdminEnhancedMediaGalleryImageActionsSection.openContextMenu}}" stepKey="openContextMenu"/>
+        <click selector="{{AdminEnhancedMediaGalleryImageActionsSection.viewDetails}}" stepKey="viewDetails"/>
+        <waitForLoadingMaskToDisappear stepKey="waitForLoadingMaskToDisappear"/>
+    </actionGroup>
+</actionGroups>

--- a/MediaGalleryUi/Test/Mftf/Section/AdminEnhancedMediaGalleryActionsSection.xml
+++ b/MediaGalleryUi/Test/Mftf/Section/AdminEnhancedMediaGalleryActionsSection.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+<sections xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:noNamespaceSchemaLocation="urn:magento:mftf:Page/etc/SectionObject.xsd">
+    <section name="AdminEnhancedMediaGalleryActionsSection">
+        <element name="upload" type="input" selector="#image-uploader-input"/>
+        <element name="cancel" type="button" selector="[data-ui-id='cancel-button']"/>
+        <element name="createFolder" type="button" selector="[data-ui-id='create-folder-button']"/>
+        <element name="deleteFolder" type="button" selector="[data-ui-id='delete-folder-button']"/>
+    </section>
+</sections>

--- a/MediaGalleryUi/Test/Mftf/Section/AdminEnhancedMediaGalleryImageActionsSection.xml
+++ b/MediaGalleryUi/Test/Mftf/Section/AdminEnhancedMediaGalleryImageActionsSection.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+<sections xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:noNamespaceSchemaLocation="urn:magento:mftf:Page/etc/SectionObject.xsd">
+    <section name="AdminEnhancedMediaGalleryImageActionsSection">
+        <element name="openContextMenu" type="button" selector=".three-dots"/>
+        <element name="viewDetails" type="button" selector="[data-ui-id='action-image-details']"/>
+        <element name="delete" type="button" selector="[data-ui-id='action-delete']"/>
+    </section>
+</sections>

--- a/MediaGalleryUi/Test/Mftf/Section/AdminEnhancedMediaGalleryViewDetailsSection.xml
+++ b/MediaGalleryUi/Test/Mftf/Section/AdminEnhancedMediaGalleryViewDetailsSection.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+<sections xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:noNamespaceSchemaLocation="urn:magento:mftf:Page/etc/SectionObject.xsd">
+    <section name="AdminEnhancedMediaGalleryViewDetailsSection">
+        <element name="title" type="text" selector=".image-title"/>
+        <element name="contentType" type="text" selector="[data-ui-id='content-type']"/>
+        <element name="type" type="text" selector="//div[@class='attribute']/span[contains(text(), 'Type')]/following-sibling::div"/>
+        <element name="height" type="text" selector="//div[@class='attribute']/span[contains(text(), 'Height')]/following-sibling::div"/>
+        <element name="delete" type="button" selector=".delete"/>
+        <element name="confirmDelete" type="button" selector=".action-accept"/>
+    </section>
+</sections>

--- a/MediaGalleryUi/Test/Mftf/Test/AdminMediaGalleryCreateDeleteFolderTest.xml
+++ b/MediaGalleryUi/Test/Mftf/Test/AdminMediaGalleryCreateDeleteFolderTest.xml
@@ -9,7 +9,7 @@
 <tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
     <test name="AdminMediaGalleryCreateDeleteFolderTest">
         <annotations>
-            <features value="AdminMediaGalleryImagePanel"/>
+            <features value="MediaGallery"/>
             <useCaseId value="https://github.com/magento/adobe-stock-integration/issues/1046; https://github.com/magento/adobe-stock-integration/issues/1047"/>
             <title value="Creating, deleting new folder functionality in Media Gallery"/>
             <testCaseId value="https://studio.cucumber.io/projects/131313/test-plan/folders/1054245/scenarios/4456547; https://studio.cucumber.io/projects/131313/test-plan/folders/1054245/scenarios/4457075"/>
@@ -21,10 +21,6 @@
             <actionGroup ref="AdminLoginActionGroup" stepKey="loginAsAdmin"/>
             <actionGroup ref="AdminOpenMediaGalleryForPageNoEditorActionGroup" stepKey="openMediaGalleryForPage"/>
         </before>
-        <after>
-            <actionGroup ref="AdminMediaGalleryEnhancedEnableActionGroup" stepKey="disableEnhancedMediaGallery"/>
-            <actionGroup ref="AdminLogoutActionGroup" stepKey="logout"/>
-        </after>
 
         <actionGroup ref="AdminMediaGalleryOpenNewFolderFormActionGroup" stepKey="openNewFolderForm"/>
         <actionGroup ref="AdminMediaGalleryCreateNewFolderActionGroup" stepKey="createNewFolderWithNotValidName">
@@ -32,15 +28,14 @@
         </actionGroup>
 
         <grabTextFrom selector="{{AdminMediaGalleryFolderSection.folderNameValidationMessage}}" stepKey="grabValidationMessage"/>
-        <assertContains stepKey="assertFirst">
+        <assertStringContainsString stepKey="assertFirst">
             <actualResult type="variable">grabValidationMessage</actualResult>
             <expectedResult type="string">Please use only letters (a-z or A-Z) or numbers (0-9) in this field. No spaces or other characters are allowed.</expectedResult>
-        </assertContains>
+        </assertStringContainsString>
 
         <actionGroup ref="AdminMediaGalleryCreateNewFolderActionGroup" stepKey="createNewFolder"/>
         <actionGroup ref="AdminMediaGalleryAssertFolderNameActionGroup" stepKey="assertNewFolderCreated"/>
 
-        <amOnPage url="admin/dashboard" stepKey="goToDashBoard"/>
         <actionGroup ref="AdminOpenMediaGalleryForPageNoEditorActionGroup" stepKey="openMediaGalleryForPage"/>
         <dontSeeElement selector="//span[contains(text(), 'Directory:')]" stepKey="folderNotSelected"/>
         <seeElement selector="{{AdminMediaGalleryFolderSection.folderDeleteButton}}, :disabled" stepKey="deleteFolderButtonIsDisabled"/>

--- a/MediaGalleryUi/Test/Mftf/Test/AdminMediaGalleryViewDetailsTest.xml
+++ b/MediaGalleryUi/Test/Mftf/Test/AdminMediaGalleryViewDetailsTest.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+    <test name="AdminMediaGalleryViewDetailsTest">
+        <annotations>
+            <features value="MediaGallery"/>
+            <useCaseId value="https://github.com/magento/adobe-stock-integration/issues/428"/>
+            <title value="View image details"/>
+            <testCaseId value="https://studio.cucumber.io/projects/131313/test-plan/folders/1054245/scenarios/4653671"/>
+            <description value="User views basic image attributes in Media Gallery"/>
+            <severity value="CRITICAL"/>
+            <group value="media_gallery_ui"/>
+        </annotations>
+        <before>
+            <actionGroup ref="AdminLoginActionGroup" stepKey="loginAsAdmin"/>
+            <actionGroup ref="AdminOpenMediaGalleryForPageNoEditorActionGroup" stepKey="openMediaGalleryForPage"/>
+        </before>
+        <after>
+            <actionGroup ref="AdminEnhancedMediaGalleryImageDetailsDeleteActionGroup" stepKey="deleteImage"/>
+        </after>
+
+        <actionGroup ref="AdminEnhancedMediaGalleryUploadImageActionGroup" stepKey="uploadImage">
+            <argument name="image" value="ImageUpload"/>
+        </actionGroup>
+        <actionGroup ref="AdminEnhancedMediaGalleryViewImageDetails" stepKey="viewImageDetails"/>
+        <actionGroup ref="AdminEnhancedMediaGalleryVerifyImageDetailsActionGroup" stepKey="verifyImageDetails">
+            <argument name="image" value="ImageUpload"/>
+        </actionGroup>
+    </test>
+</tests>

--- a/MediaGalleryUi/Test/Mftf/Test/AdminStandaloneMediaGalleryCreateDeleteFolderTest.xml
+++ b/MediaGalleryUi/Test/Mftf/Test/AdminStandaloneMediaGalleryCreateDeleteFolderTest.xml
@@ -9,7 +9,7 @@
 <tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
     <test name="AdminStandaloneMediaGalleryCreateDeleteFolderTest">
         <annotations>
-            <features value="AdminMediaGalleryImagePanel"/>
+            <features value="MediaGallery"/>
             <useCaseId value="https://github.com/magento/adobe-stock-integration/issues/1119; https://github.com/magento/adobe-stock-integration/issues/1120"/>
             <title value="Creating, deleting new folder functionality in Standalone Media Gallery"/>
             <testCaseId value="https://studio.cucumber.io/projects/131313/test-plan/folders/1337102/scenarios/4503041; https://studio.cucumber.io/projects/131313/test-plan/folders/1337102/scenarios/4503101"/>
@@ -21,9 +21,6 @@
             <actionGroup ref="AdminLoginActionGroup" stepKey="loginAsAdmin"/>
             <actionGroup ref="AdminOpenStandaloneMediaGalleryActionGroup" stepKey="openMediaGalleryForPage"/>
         </before>
-        <after>
-            <actionGroup ref="AdminLogoutActionGroup" stepKey="logout"/>
-        </after>
 
         <actionGroup ref="AdminMediaGalleryOpenNewFolderFormActionGroup" stepKey="openNewFolderForm"/>
         <actionGroup ref="AdminMediaGalleryCreateNewFolderActionGroup" stepKey="createNewFolderWithNotValidName">
@@ -31,15 +28,14 @@
         </actionGroup>
 
         <grabTextFrom selector="{{AdminMediaGalleryFolderSection.folderNameValidationMessage}}" stepKey="grabValidationMessage"/>
-        <assertContains stepKey="assertFirst">
+        <assertStringContainsString stepKey="assertFirst">
             <actualResult type="variable">grabValidationMessage</actualResult>
             <expectedResult type="string">Please use only letters (a-z or A-Z) or numbers (0-9) in this field. No spaces or other characters are allowed.</expectedResult>
-        </assertContains>
+        </assertStringContainsString>
 
         <actionGroup ref="AdminMediaGalleryCreateNewFolderActionGroup" stepKey="createNewFolder"/>
         <actionGroup ref="AdminMediaGalleryAssertFolderNameActionGroup" stepKey="assertNewFolderCreated"/>
 
-        <amOnPage url="admin/dashboard" stepKey="goToDashBoard"/>
         <actionGroup ref="AdminOpenStandaloneMediaGalleryActionGroup" stepKey="openMediaGalleryForPage"/>
         <dontSeeElement selector="//span[contains(text(), 'Directory:')]" stepKey="folderNotSelected"/>
         <seeElement selector="{{AdminMediaGalleryFolderSection.folderDeleteButton}}, :disabled" stepKey="deleteFolderButtonIsDisabled"/>

--- a/MediaGalleryUi/view/adminhtml/web/template/grid/columns/image.html
+++ b/MediaGalleryUi/view/adminhtml/web/template/grid/columns/image.html
@@ -24,12 +24,12 @@
     </div>
     <div class="masonry-image-description">
         <ul class="media-gallery-image-details">
-            <li class="name" data-bind="text: $row().title"></li>
+            <li class="name" data-ui-id="title" data-bind="text: $row().title"></li>
             <li class="source">
                 <img if="$row().source" class="adobe-stock-icon" data-bind="attr: { src: $row().source }" />
             </li>
-            <li class="type" data-bind="text: $row().content_type"></li> &#8226;
-            <li class="dimensions" data-bind="text: $row().width + 'x' + $row().height"></li>
+            <li class="type" data-ui-id="content-type" data-bind="text: $row().content_type"></li> &#8226;
+            <li class="dimensions" data-ui-id="dimensions" data-bind="text: $row().width + 'x' + $row().height"></li>
         </ul>
         <div class="media-gallery-image-actions">
             <div class="action-select-wrap">

--- a/MediaGalleryUi/view/adminhtml/web/template/image/image-details.html
+++ b/MediaGalleryUi/view/adminhtml/web/template/image/image-details.html
@@ -13,7 +13,7 @@
             <h3 class="image-title" data-bind="text: image().title"></h3>
             <div class="image-type">
                 <span class="source"><img if="image().source" class="adobe-stock-icon" data-bind="attr: { src: image().source }" /></span>
-                <span class="type" data-bind="text: image().content_type"></span>
+                <span class="type" data-ui-id="content-type" data-bind="text: image().content_type"></span>
             </div>
         </div>
         <div class="general-details image-details-section" if="image().details">


### PR DESCRIPTION
### Description (*)
Media Gallery View Details MFTF tests for uploaded and adobe stock image

### Fixed Issues (if relevant)
Resolves https://github.com/magento/adobe-stock-integration/issues/456

### Testing

`vendor/bin/mftf run:test AdminMediaGalleryViewAdobeStockDetailsTest --remove`
`vendor/bin/mftf run:test AdminMediaGalleryViewDetailsTest --remove`