### PR TITLE
Fix Name && path sorting, fix Overlay label styles

### DIFF
--- a/AdobeStockImageAdminUi/view/adminhtml/web/css/source/_module.less
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/css/source/_module.less
@@ -32,11 +32,16 @@
 
             &-column {
                 overflow: visible;
-                position: relative;
+                position: static;
             }
 
             &-overlay {
-                right: 0;
+                float: right;
+                margin-bottom: -30px;
+                padding-left: 5%;
+                padding-right: 5%;
+                position: relative;
+                width: auto;
             }
 
             &-preview {

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/overlay.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/overlay.js
@@ -111,7 +111,7 @@ define([
          * @returns {Object}
          */
         getStyles: function (record) {
-            var height = record.styles().height.replace('px', '') - 50;
+            var height = record.styles().height.replace('px', '') - 40;
 
             return {
                 top: height + 'px'

--- a/MediaGalleryUi/view/adminhtml/ui_component/media_gallery_listing.xml
+++ b/MediaGalleryUi/view/adminhtml/ui_component/media_gallery_listing.xml
@@ -232,9 +232,16 @@
             </settings>
         </column>
         <column name="path">
+          <argument name="data" xsi:type="array">
+                <item name="config" xsi:type="array">
+                    <item name="sort_by" xsi:type="array">
+                        <item name="excluded" xsi:type="boolean">true</item>
+                    </item>
+                </item>
+            </argument>
             <settings>
                 <visible>false</visible>
-                <sortable>false</sortable>
+                <sortable>true</sortable>
             </settings>
         </column>
         <column name="directory_desc">
@@ -267,9 +274,16 @@
             </settings>
         </column>
         <column name="title">
+            <argument name="data" xsi:type="array">
+                <item name="config" xsi:type="array">
+                    <item name="sort_by" xsi:type="array">
+                        <item name="excluded" xsi:type="boolean">true</item>
+                    </item>
+                </item>
+            </argument>
             <settings>
                 <visible>false</visible>
-                <sortable>false</sortable>
+                <sortable>true</sortable>
             </settings>
         </column>
         <column name="name_az">

--- a/MediaGalleryUi/view/adminhtml/ui_component/standalone_media_gallery_listing.xml
+++ b/MediaGalleryUi/view/adminhtml/ui_component/standalone_media_gallery_listing.xml
@@ -219,9 +219,16 @@
             </settings>
         </column>
         <column name="path">
+            <argument name="data" xsi:type="array">
+                <item name="config" xsi:type="array">
+                    <item name="sort_by" xsi:type="array">
+                        <item name="excluded" xsi:type="boolean">true</item>
+                    </item>
+                </item>
+            </argument>
             <settings>
                 <visible>false</visible>
-                <sortable>false</sortable>
+                <sortable>true</sortable>
             </settings>
         </column>
         <column name="directory_desc">
@@ -254,9 +261,16 @@
             </settings>
         </column>
         <column name="title">
+           <argument name="data" xsi:type="array">
+                <item name="config" xsi:type="array">
+                    <item name="sort_by" xsi:type="array">
+                        <item name="excluded" xsi:type="boolean">true</item>
+                    </item>
+                </item>
+            </argument>
             <settings>
                 <visible>false</visible>
-                <sortable>false</sortable>
+                <sortable>true</sortable>
             </settings>
         </column>
         <column name="name_az">

--- a/MediaGalleryUi/view/adminhtml/web/css/source/_module.less
+++ b/MediaGalleryUi/view/adminhtml/web/css/source/_module.less
@@ -126,11 +126,13 @@
 
         .masonry-image-overlay {
             background-color: @color-masonry-overlay;
+            float: right;
             font-size: 11px;
             margin-left: 120px;
             margin-top: 170px;
             padding: .3rem;
             pointer-events: none;
+            position: relative;
         }
 
         .media-gallery-image-details {

--- a/dev/tests/js/jasmine/tests/app/code/Magento/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/overlay.test.js
+++ b/dev/tests/js/jasmine/tests/app/code/Magento/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/overlay.test.js
@@ -138,7 +138,7 @@ define([
                         styles: function () {}
                     },
                     returnValue = {
-                        top: '150px'
+                        top: '160px'
                     };
 
                 spyOn(record, 'styles').and.callFake(function () {


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/adobe-stock-integration#1330: Sorting by Name and by Directory doesn't work in Media Gallery 
2. magento/adobe-stock-integration#1331: Incorrect position of "Licensed" labels in Adobe Stock window 
### Manual testing scenarios (*)
1. Go to **Content - Media Gallery**
2. Click **Sort by** and verify if the following sort options work
_- Directory: Descending_ 
_- Directory: Ascending_
_- Name: A-Z_
_- Name: Z-A_

### Expected result (*)
The Sorting options work and the images are sorted

1. Go to **Content - Media Gallery**
2. Click **Search Adobe Stock**
3. **Sign In** Adobe Stock
4. Observe the position of _Licensed_ label

### Expected result (*)
The position of Licensed labels is correct