### PR TITLE
Fix Images in grid is not correctly aligned after clear filters

### DIFF
--- a/AdobeStockImageAdminUi/view/adminhtml/ui_component/adobe_stock_images_listing.xml
+++ b/AdobeStockImageAdminUi/view/adminhtml/ui_component/adobe_stock_images_listing.xml
@@ -182,7 +182,7 @@
             </filterInput>
         </filters>
     </listingToolbar>
-    <columns name="adobe_stock_images_columns" component="Magento_Ui/js/grid/masonry" template="ui/grid/masonry">
+    <columns name="adobe_stock_images_columns" component="Magento_AdobeStockImageAdminUi/js/components/grid/masonry" template="ui/grid/masonry">
         <argument name="data" xsi:type="array">
             <item name="config" xsi:type="array">
                 <item name="containerId" xsi:type="string">adobe-stock-images-masonry-grid</item>
@@ -214,7 +214,7 @@
                     <item name="mediaGallerySearchInput" xsi:type="string">media_gallery_listing.media_gallery_listing.listing_top.fulltext</item>
                     <item name="mediaGalleryListingFilters" xsi:type="string">media_gallery_listing.media_gallery_listing.listing_top.listing_filters</item>
                     <item name="listingPaging" xsi:type="string">media_gallery_listing.media_gallery_listing.listing_top.listing_paging</item>
-		</item>
+                </item>
             </argument>
             <settings>
                 <label translate="true">Image Preview</label>

--- a/AdobeStockImageAdminUi/view/adminhtml/ui_component/standalone_adobe_stock_images_listing.xml
+++ b/AdobeStockImageAdminUi/view/adminhtml/ui_component/standalone_adobe_stock_images_listing.xml
@@ -182,7 +182,7 @@
             </filterInput>
         </filters>
     </listingToolbar>
-    <columns name="adobe_stock_images_columns" component="Magento_Ui/js/grid/masonry" template="ui/grid/masonry">
+    <columns name="adobe_stock_images_columns" component="Magento_AdobeStockImageAdminUi/js/components/grid/masonry" template="ui/grid/masonry">
         <argument name="data" xsi:type="array">
             <item name="config" xsi:type="array">
                 <item name="containerId" xsi:type="string">adobe-stock-images-masonry-grid</item>
@@ -214,7 +214,7 @@
                     <item name="mediaGallerySearchInput" xsi:type="string">standalone_media_gallery_listing.standalone_media_gallery_listing.listing_top.fulltext</item>
                     <item name="mediaGalleryListingFilters" xsi:type="string">standalone_media_gallery_listing.standalone_media_gallery_listing.listing_top.listing_filters</item>
                     <item name="listingPaging" xsi:type="string">standalone_media_gallery_listing.standalone_media_gallery_listing.listing_top.listing_paging</item>
-		</item>
+                </item>
             </argument>
             <settings>
                 <label translate="true">Image Preview</label>

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/actions.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/actions.js
@@ -44,6 +44,7 @@ define([
                 '${ $.provider }:data.items': 'updateActions'
             },
             modules: {
+                masonry: '${ $.parentName }',
                 login: '${ $.loginProvider }',
                 preview: '${ $.parentName }.preview',
                 overlay: '${ $.parentName }.overlay',
@@ -82,6 +83,8 @@ define([
                 updatedDisplayedRecord = this.preview().displayedRecord(),
                 records = this.source().data.items,
                 index;
+
+            this.masonry().updateStylesDynamically();
 
             if (typeof displayedRecord.id === 'undefined') {
                 return;

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/masonry.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/masonry.js
@@ -1,0 +1,22 @@
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+define([
+    'Magento_Ui/js/grid/masonry',
+    'Magento_Ui/js/lib/view/utils/raf'
+], function (Masonry, raf) {
+    'use strict';
+
+    return Masonry.extend({
+
+        /**
+         * Update grid styles when data changed
+         */
+        updateStylesDynamically: function () {
+            raf(function () {
+                this.setLayoutStyles();
+            }.bind(this), this.refreshFPS);
+        }
+    });
+});


### PR DESCRIPTION
…k window

<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/adobe-stock-integration#824: Images in grid is not correctly aligned after clear filters
2. magento/adobe-stock-integration#972: Some images on the grid are not correctly aligned if open Preview in resized browser, and then maximize the web browser

### Manual testing scenarios (*)

- Login to admin panel
- Navigate to Cms Pages
- User clicks Add New Page button
- Expand "Content" section
- User clicks "Insert Image..." button
- Click "Search Adobe Stock" button to open images grid
- Select and apply filter **Orientation=Square**
- Click **Clear All**


### Expected result (*)
Images in grid is properly aligned
