### PR TITLE
Respect (current_tree_path parameter) on opening media gallery

### DIFF
--- a/MediaGalleryIntegration/Test/Integration/Model/WysiwygDefaultConfigOpenDialogUrlTest.php
+++ b/MediaGalleryIntegration/Test/Integration/Model/WysiwygDefaultConfigOpenDialogUrlTest.php
@@ -52,10 +52,7 @@ class WysiwygDefaultConfigOpenDialogUrlTest extends TestCase
         $imageHelper = $this->objectManger->create(Images::class);
         $this->filesBrowserWindowUrl = $url->getUrl(
             'media_gallery/index/index',
-            [
-                'current_tree_path' => $imageHelper->idEncode(Config::IMAGE_DIRECTORY),
-                'tree_path' => Config::IMAGE_DIRECTORY . '&'
-            ]
+            ['current_tree_path' => $imageHelper->idEncode(Config::IMAGE_DIRECTORY)]
         );
     }
 

--- a/MediaGalleryIntegration/Test/Integration/Model/WysiwygDefaultConfigOpenDialogUrlTest.php
+++ b/MediaGalleryIntegration/Test/Integration/Model/WysiwygDefaultConfigOpenDialogUrlTest.php
@@ -52,7 +52,10 @@ class WysiwygDefaultConfigOpenDialogUrlTest extends TestCase
         $imageHelper = $this->objectManger->create(Images::class);
         $this->filesBrowserWindowUrl = $url->getUrl(
             'media_gallery/index/index',
-            ['current_tree_path' => $imageHelper->idEncode(Config::IMAGE_DIRECTORY)]
+            [
+                'current_tree_path' => $imageHelper->idEncode(Config::IMAGE_DIRECTORY),
+                'tree_path' => Config::IMAGE_DIRECTORY . '&'
+            ]
         );
     }
 

--- a/MediaGalleryUi/view/adminhtml/web/js/directory/directoryTree.js
+++ b/MediaGalleryUi/view/adminhtml/web/js/directory/directoryTree.js
@@ -46,7 +46,6 @@ define([
                 function () {
                     this.getJsonTree();
                     this.initEvents();
-                    this.checkChipFiltersState();
                 }.bind(this)
             );
 
@@ -116,17 +115,38 @@ define([
                 currentTreePath;
 
             if (!isMediaBrowser) {
-                currentFilterPath === '' || this.locateNode(currentFilterPath);
+                this.isFolderExistsInTree(currentFilterPath) ?
+                    this.locateNode(currentFilterPath) :
+                    this.selectStorageRoot();
 
                 return;
             }
 
             if (this.isFiltersApllied(currentFilterPath)) {
-                selectedId === currentFilterPath || this.locateNode(currentFilterPath);
+                if (this.isFolderExistsInTree(currentFilterPath)) {
+                    selectedId === currentFilterPath  || this.locateNode(currentFilterPath);
+                } else {
+                    this.selectStorageRoot();
+                }
             } else {
                 currentTreePath = Base64.idDecode(window.MediabrowserUtility.pathId);
-                selectedId === currentTreePath || this.locateNode(currentTreePath);
+
+                if (this.isFolderExistsInTree(currentTreePath)) {
+                    selectedId === currentTreePath || this.locateNode(currentTreePath);
+                } else {
+                    this.selectStorageRoot();
+                }
+
             }
+        },
+
+        /**
+         * Verify if directory exists in folder tree
+         *
+         * @param {String} path
+         */
+        isFolderExistsInTree: function (path) {
+            return $('#' + path.replace(/\//g, '\\/')).length === 1;
         },
 
         /**

--- a/MediaGalleryUi/view/adminhtml/web/js/directory/directoryTree.js
+++ b/MediaGalleryUi/view/adminhtml/web/js/directory/directoryTree.js
@@ -41,7 +41,6 @@ define([
             this.waitForContainer(function () {
                 this.getJsonTree();
                 this.initEvents();
-                this.checkChipFiltersState();
             }.bind(this));
 
             return this;
@@ -85,6 +84,14 @@ define([
         initEvents: function () {
             this.overrideMultiselectBehavior();
 
+            $(this.directoryTreeSelector).on('loaded.jstree', function () {
+                this.checkChipFiltersState();
+            }.bind(this));
+
+            $(window).on('reload.MediaGallery', function () {
+                this.checkChipFiltersState();
+            }.bind(this));
+
             $(this.directoryTreeSelector).on('select_node.jstree', function (element, data) {
                 var path = $(data.rslt.obj).data('path');
 
@@ -96,10 +103,17 @@ define([
          * Verify directory filter on init event, select folder per directory filter state
          */
         checkChipFiltersState: function () {
-            if (!_.isUndefined(this.filterChips().filters.path) && this.filterChips().filters.path !== '') {
+            var currentFilterPath = this.filterChips().filters.path,
+                currentTreePath = window.MediabrowserUtility.currentTreePath;
+
+            if (!_.isUndefined(currentFilterPath) && currentFilterPath !== '' &&
+                currentFilterPath !== 'wysiwyg' && currentFilterPath !== 'catalog/category') {
                 $(this.directoryTreeSelector).on('loaded.jstree', function () {
                     this.locateNode(this.filterChips().filters.path);
                 }.bind(this));
+            } else {
+                $(this.directoryTreeSelector).jstree('get_selected').attr('id') === currentTreePath ||
+                    this.locateNode(currentTreePath);
             }
         },
 

--- a/MediaGalleryUi/view/adminhtml/web/js/directory/directoryTree.js
+++ b/MediaGalleryUi/view/adminhtml/web/js/directory/directoryTree.js
@@ -111,32 +111,15 @@ define([
         checkChipFiltersState: function () {
             var currentFilterPath = this.filterChips().filters.path,
                 isMediaBrowser = !_.isUndefined(window.MediabrowserUtility),
-                selectedId =  $(this.directoryTreeSelector).jstree('get_selected').attr('id'),
                 currentTreePath;
 
-            if (!isMediaBrowser) {
-                this.isFolderExistsInTree(currentFilterPath) ?
-                    this.locateNode(currentFilterPath) :
-                    this.selectStorageRoot();
+            currentTreePath = (this.isFiltersApplied(currentFilterPath) || !isMediaBrowser) ? currentFilterPath :
+                Base64.idDecode(window.MediabrowserUtility.pathId) ;
 
-                return;
-            }
-
-            if (this.isFiltersApllied(currentFilterPath)) {
-                if (this.isFolderExistsInTree(currentFilterPath)) {
-                    selectedId === currentFilterPath  || this.locateNode(currentFilterPath);
-                } else {
-                    this.selectStorageRoot();
-                }
+            if (this.folderExistsInTree(currentTreePath)) {
+                this.locateNode(currentTreePath);
             } else {
-                currentTreePath = Base64.idDecode(window.MediabrowserUtility.pathId);
-
-                if (this.isFolderExistsInTree(currentTreePath)) {
-                    selectedId === currentTreePath || this.locateNode(currentTreePath);
-                } else {
-                    this.selectStorageRoot();
-                }
-
+                this.selectStorageRoot();
             }
         },
 
@@ -145,7 +128,7 @@ define([
          *
          * @param {String} path
          */
-        isFolderExistsInTree: function (path) {
+        folderExistsInTree: function (path) {
             return $('#' + path.replace(/\//g, '\\/')).length === 1;
         },
 
@@ -154,7 +137,7 @@ define([
          *
          * @param {String} currentFilterPath
          */
-        isFiltersApllied: function (currentFilterPath) {
+        isFiltersApplied: function (currentFilterPath) {
             return !_.isUndefined(currentFilterPath) && currentFilterPath !== '' &&
                 currentFilterPath !== 'wysiwyg' && currentFilterPath !== 'catalog/category';
         },
@@ -165,6 +148,11 @@ define([
          * @param {String} path
          */
         locateNode: function (path) {
+            var selectedId =  $(this.directoryTreeSelector).jstree('get_selected').attr('id');
+
+            if (path === selectedId) {
+                return;
+            }
             path = path.replace(/\//g, '\\/');
             $(this.directoryTreeSelector).jstree('open_node', '#' + path);
             $(this.directoryTreeSelector).jstree('select_node', '#' + path, true);

--- a/MediaGalleryUi/view/adminhtml/web/js/directory/directoryTree.js
+++ b/MediaGalleryUi/view/adminhtml/web/js/directory/directoryTree.js
@@ -105,15 +105,21 @@ define([
          */
         checkChipFiltersState: function () {
             var currentFilterPath = this.filterChips().filters.path,
-                currentTreePath = Base64.decode(window.MediabrowserUtility.pathId.replace(/--|,,/, ''));
+                isMediaBrowser = !_.isUndefined(window.MediabrowserUtility),
+                selectedId =  $(this.directoryTreeSelector).jstree('get_selected').attr('id'),
+                currentTreePath;
+
+            if (!isMediaBrowser) {
+                currentFilterPath === '' || this.locateNode(currentFilterPath);
+
+                return;
+            }
 
             if (this.isFiltersApllied(currentFilterPath)) {
-                $(this.directoryTreeSelector).on('loaded.jstree', function () {
-                    this.locateNode(this.filterChips().filters.path);
-                }.bind(this));
+                selectedId === currentFilterPath || this.locateNode(currentFilterPath);
             } else {
-                $(this.directoryTreeSelector).jstree('get_selected').attr('id') === currentTreePath ||
-                    this.locateNode(currentTreePath);
+                currentTreePath = Base64.decode(window.MediabrowserUtility.pathId.replace(/--|,,/, ''));
+                selectedId === currentTreePath || this.locateNode(currentTreePath);
             }
         },
 

--- a/MediaGalleryUi/view/adminhtml/web/js/directory/directoryTree.js
+++ b/MediaGalleryUi/view/adminhtml/web/js/directory/directoryTree.js
@@ -113,8 +113,8 @@ define([
                 isMediaBrowser = !_.isUndefined(window.MediabrowserUtility),
                 currentTreePath;
 
-            currentTreePath = (this.isFiltersApplied(currentFilterPath) || !isMediaBrowser) ? currentFilterPath :
-                Base64.idDecode(window.MediabrowserUtility.pathId) ;
+            currentTreePath = this.isFiltersApplied(currentFilterPath) || !isMediaBrowser ? currentFilterPath :
+                Base64.idDecode(window.MediabrowserUtility.pathId);
 
             if (this.folderExistsInTree(currentTreePath)) {
                 this.locateNode(currentTreePath);

--- a/MediaGalleryUi/view/adminhtml/web/js/directory/directoryTree.js
+++ b/MediaGalleryUi/view/adminhtml/web/js/directory/directoryTree.js
@@ -118,7 +118,7 @@ define([
             if (this.isFiltersApllied(currentFilterPath)) {
                 selectedId === currentFilterPath || this.locateNode(currentFilterPath);
             } else {
-                currentTreePath = Base64.mageDecode(window.MediabrowserUtility.pathId);
+                currentTreePath = Base64.idDecode(window.MediabrowserUtility.pathId);
                 selectedId === currentTreePath || this.locateNode(currentTreePath);
             }
         },

--- a/MediaGalleryUi/view/adminhtml/web/js/directory/directoryTree.js
+++ b/MediaGalleryUi/view/adminhtml/web/js/directory/directoryTree.js
@@ -118,7 +118,7 @@ define([
             if (this.isFiltersApllied(currentFilterPath)) {
                 selectedId === currentFilterPath || this.locateNode(currentFilterPath);
             } else {
-                currentTreePath = Base64.decode(window.MediabrowserUtility.pathId.replace(/--|,,/, ''));
+                currentTreePath = Base64.mageDecode(window.MediabrowserUtility.pathId);
                 selectedId === currentTreePath || this.locateNode(currentTreePath);
             }
         },

--- a/MediaGalleryUi/view/adminhtml/web/js/directory/directoryTree.js
+++ b/MediaGalleryUi/view/adminhtml/web/js/directory/directoryTree.js
@@ -196,7 +196,15 @@ define([
             delete filters.path;
             this.filterChips().set('applied', filters);
             this.activeNode(null);
-            this.directories().setInActive();
+            this.waitForCondition(
+              function () {
+                return _.isUndefined(this.directories());
+            }.bind(this),
+                function () {
+                this.directories().setInActive();
+            }.bind(this)
+          );
+
         },
 
         /**

--- a/MediaGalleryUi/view/adminhtml/web/js/directory/directoryTree.js
+++ b/MediaGalleryUi/view/adminhtml/web/js/directory/directoryTree.js
@@ -104,7 +104,7 @@ define([
          */
         checkChipFiltersState: function () {
             var currentFilterPath = this.filterChips().filters.path,
-                currentTreePath = window.MediabrowserUtility.currentTreePath;
+                currentTreePath = atob(window.MediabrowserUtility.pathId.replace(/--|,,/, ''));
 
             if (!_.isUndefined(currentFilterPath) && currentFilterPath !== '' &&
                 currentFilterPath !== 'wysiwyg' && currentFilterPath !== 'catalog/category') {

--- a/MediaGalleryUi/view/adminhtml/web/js/directory/directoryTree.js
+++ b/MediaGalleryUi/view/adminhtml/web/js/directory/directoryTree.js
@@ -107,8 +107,7 @@ define([
             var currentFilterPath = this.filterChips().filters.path,
                 currentTreePath = Base64.decode(window.MediabrowserUtility.pathId.replace(/--|,,/, ''));
 
-            if (!_.isUndefined(currentFilterPath) && currentFilterPath !== '' &&
-                currentFilterPath !== 'wysiwyg' && currentFilterPath !== 'catalog/category') {
+            if (this.isFiltersApllied(currentFilterPath)) {
                 $(this.directoryTreeSelector).on('loaded.jstree', function () {
                     this.locateNode(this.filterChips().filters.path);
                 }.bind(this));
@@ -116,6 +115,16 @@ define([
                 $(this.directoryTreeSelector).jstree('get_selected').attr('id') === currentTreePath ||
                     this.locateNode(currentTreePath);
             }
+        },
+
+        /**
+         * Check if need to select directory by filters state
+         *
+         * @param {String} currentFilterPath
+         */
+        isFiltersApllied: function (currentFilterPath) {
+            return !_.isUndefined(currentFilterPath) && currentFilterPath !== '' &&
+                currentFilterPath !== 'wysiwyg' && currentFilterPath !== 'catalog/category';
         },
 
         /**

--- a/MediaGalleryUi/view/adminhtml/web/js/directory/directoryTree.js
+++ b/MediaGalleryUi/view/adminhtml/web/js/directory/directoryTree.js
@@ -1,8 +1,9 @@
 /**
- * Copyright © Magento, Inc. All rights reserved.g
+ * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
 
+/* global Base64 */
 define([
     'jquery',
     'uiComponent',
@@ -104,7 +105,7 @@ define([
          */
         checkChipFiltersState: function () {
             var currentFilterPath = this.filterChips().filters.path,
-                currentTreePath = atob(window.MediabrowserUtility.pathId.replace(/--|,,/, ''));
+                currentTreePath = Base64.decode(window.MediabrowserUtility.pathId.replace(/--|,,/, ''));
 
             if (!_.isUndefined(currentFilterPath) && currentFilterPath !== '' &&
                 currentFilterPath !== 'wysiwyg' && currentFilterPath !== 'catalog/category') {


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->
### DEPEND ON https://github.com/magento/magento2/pull/28219 
<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/adobe-stock-integration#1335: Requested default folder is not selected on opening media gallery (current_tree_path parameter) 
2.  magento/adobe-stock-integration#1362: The Directory filter is applied for non existing folder in Enhanced Media Gallery if Delete a folder from NOT Enhanced Media Gallery

### Manual testing scenarios (*)
1. Open media gallery from the category image field
2. Open media gallery from the WYSIWYG

### Expected result (*)
1. catalog/category directory is selected by default
2. WYSIWYG directory is selected by default