### PR TITLE
Issue #1342 - Fixed issue with bookmarks when close preview

### DIFF
--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/image-preview.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/image-preview.js
@@ -20,6 +20,7 @@ define([
             mediaGallerySelector: '.media-gallery-modal:has(#search_adobe_stock)',
             adobeStockModalSelector: '.adobe-search-images-modal',
             activeMediaGallerySelector: 'aside.modal-slide.adobe-stock-modal._show',
+            lastOpenedImage: false,
             modules: {
                 keywords: '${ $.name }_keywords',
                 related: '${ $.name }_related',


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
The problem is related to the lastOpenedImage property which isn't saved on the Default bookmark, the preview object looked like this: `"preview":{"visible":true,"sorting":false}`

The issue here is that lastOpenedImage is a state of the preview component, and when we close the preview, that is set to null, as consequence the bookmark object gets updated with this: `"preview":{"visible":true,"sorting":false,"lastOpenedImage":null}`

As a result, the comparison of the bookmarks is different from the Default, so the component allows us to save a new bookmark.

From my investigation, the state wasn't being saved on the Default bookmark because the lastOpenedImage is defined as null, and from what I could see, it's ignored. By setting that property as false, it allows the component to initialize the state correctly and the Default bookmarks receive the lastOpenedImage as null.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/adobe-stock-integration#1342: Possible to save Adobe Stock grid view to bookmarks after opening and closing image preview

### Manual testing scenarios (*)
1. Create a new admin user (otherwise, the user will have the Default bookmark saved on the DB) or truncate ui_bookmarks table.
2. Follow the steps here #1342 
