### PR TITLE
Improve the Sort by name text in drop-down

### DIFF
--- a/MediaGalleryUi/view/adminhtml/ui_component/media_gallery_listing.xml
+++ b/MediaGalleryUi/view/adminhtml/ui_component/media_gallery_listing.xml
@@ -281,7 +281,7 @@
                 </item>
             </argument>
             <settings>
-                <label translate="true">Name A-Z</label>
+                <label translate="true">Name: A to Z</label>
                 <visible>false</visible>
                 <sortable>true</sortable>
             </settings>
@@ -296,7 +296,7 @@
                 </item>
             </argument>
             <settings>
-                <label translate="true">Name Z-A</label>
+                <label translate="true">Name: Z to A</label>
                 <visible>false</visible>
                 <sortable>true</sortable>
             </settings>

--- a/MediaGalleryUi/view/adminhtml/ui_component/standalone_media_gallery_listing.xml
+++ b/MediaGalleryUi/view/adminhtml/ui_component/standalone_media_gallery_listing.xml
@@ -268,7 +268,7 @@
                 </item>
             </argument>
             <settings>
-                <label translate="true">Name A-Z</label>
+                <label translate="true">Name: A to Z</label>
                 <visible>false</visible>
                 <sortable>true</sortable>
             </settings>
@@ -283,7 +283,7 @@
                 </item>
             </argument>
             <settings>
-                <label translate="true">Name Z-A</label>
+                <label translate="true">Name: Z to A</label>
                 <visible>false</visible>
                 <sortable>true</sortable>
             </settings>


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR provides a small improvement for Sort by name text to be similar to [UI Prototype](https://xd.adobe.com/view/0a8fc470-497b-4fd6-4043-62560c21d8db-7cbe/screen/0455ed2c-b377-4927-98df-657671cd58f8/Gallery-sort-order)

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
Before
![before](https://user-images.githubusercontent.com/45624059/81929845-5fca3b00-95f0-11ea-9483-0d6f25fef2f8.png)

After
![after](https://user-images.githubusercontent.com/45624059/81929867-6789df80-95f0-11ea-858d-e0b372afdb85.png)

### Manual testing scenarios (*)
Open Media Gallery
Click **Sort by** drop-down