### PR TITLE
Set property when component initialized

### DIFF
--- a/MediaGalleryUi/view/adminhtml/web/js/directory/directoryTree.js
+++ b/MediaGalleryUi/view/adminhtml/web/js/directory/directoryTree.js
@@ -170,7 +170,7 @@ define([
 
             this.waitForCondition(
                 function () {
-                    return !_.isUndefined(this.directories());
+                    return _.isUndefined(this.directories());
                 }.bind(this),
                 function () {
                     this.directories().setActive(path);

--- a/MediaGalleryUi/view/adminhtml/web/js/directory/directoryTree.js
+++ b/MediaGalleryUi/view/adminhtml/web/js/directory/directoryTree.js
@@ -72,6 +72,19 @@ define([
         },
 
         /**
+         * Wait for component to initialize
+         */
+        waitForComponent: function (callback, component) {
+            if (_.isUndefined(component)) {
+                setTimeout(function () {
+                    this.waitForComponent(callback, component);
+                }.bind(this), 100);
+            } else {
+                callback();
+            }
+        },
+
+        /**
          * Remove ability to multiple select on nodes
          */
         overrideMultiselectBehavior: function () {
@@ -162,7 +175,10 @@ define([
          */
         selectFolder: function (path) {
             this.activeNode(path);
-            this.directories().setActive(path);
+            this.waitForComponent(function () {
+                this.directories().setActive(path);
+            }.bind(this), this.directories());
+
             this.applyFilter(path);
         },
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/adobe-stock-integration#1356: 
"Uncaught TypeError: Cannot read property 'setActive' of undefined" appears in dev console if select a directory in Media Gallery and refresh the web page
2. ...

### Manual testing scenarios (*)
1. Go to **Content - Media Gallery** click **Search Adobe Stock**
2. Select any folder from the folder tree
(Directory filter becomes active)
3. Refresh the web page
4. Observe the dev console 

### Expected result (*)
No error message in dev console 
