### PR TITLE
Fix image Preview is not closed when Sort by is changed in Adobe Stoc…

### DIFF
--- a/AdobeStockImageAdminUi/view/adminhtml/ui_component/adobe_stock_images_listing.xml
+++ b/AdobeStockImageAdminUi/view/adminhtml/ui_component/adobe_stock_images_listing.xml
@@ -214,7 +214,8 @@
                     <item name="mediaGallerySearchInput" xsi:type="string">media_gallery_listing.media_gallery_listing.listing_top.fulltext</item>
                     <item name="mediaGalleryListingFilters" xsi:type="string">media_gallery_listing.media_gallery_listing.listing_top.listing_filters</item>
                     <item name="listingPaging" xsi:type="string">media_gallery_listing.media_gallery_listing.listing_top.listing_paging</item>
-		</item>
+                    <item name="sortByComponentName" xsi:type="string">adobe_stock_images_listing.adobe_stock_images_listing.listing_top.sorting</item>
+                </item>
             </argument>
             <settings>
                 <label translate="true">Image Preview</label>

--- a/AdobeStockImageAdminUi/view/adminhtml/ui_component/standalone_adobe_stock_images_listing.xml
+++ b/AdobeStockImageAdminUi/view/adminhtml/ui_component/standalone_adobe_stock_images_listing.xml
@@ -214,7 +214,8 @@
                     <item name="mediaGallerySearchInput" xsi:type="string">standalone_media_gallery_listing.standalone_media_gallery_listing.listing_top.fulltext</item>
                     <item name="mediaGalleryListingFilters" xsi:type="string">standalone_media_gallery_listing.standalone_media_gallery_listing.listing_top.listing_filters</item>
                     <item name="listingPaging" xsi:type="string">standalone_media_gallery_listing.standalone_media_gallery_listing.listing_top.listing_paging</item>
-		</item>
+                    <item name="sortByComponentName" xsi:type="string">standalone_adobe_stock_images_listing.standalone_adobe_stock_images_listing.listing_top.sorting</item>
+                </item>
             </argument>
             <settings>
                 <label translate="true">Image Preview</label>

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/image-preview.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/image-preview.js
@@ -46,7 +46,10 @@ define([
                     mediaGalleryListingFilters: '${ $.mediaGalleryListingFilters }',
                     listingPaging: '${ $.listingPaging }'
                 }
-            ]
+            ],
+            listens: {
+                '${ $.sortByComponentName }:applied': 'hide'
+            }
         },
 
         /**


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/adobe-stock-integration#1333: image Preview is not closed when Sort by is changed in Adobe Stock window

### Manual testing scenarios (*)
. Go to **Content - Media Gallery**
2. Click **Search Adobe Stock**
3. Open Preview of an image
4. Click **Sort by:** and change sorting option, for example from _Relevance_ to _Most Recent_

### Expected result (*)
The image preview is closed