### PR TITLE
Issue: 1361 - Fixed issue with folders with same name.

### DIFF
--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/media-gallery.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/media-gallery.js
@@ -44,7 +44,7 @@ define([
             var imageFolder,
                 pathId,
                 imagePath = path.replace(/^\/+/, ''),
-                folderPathParts = imagePath.split('/').slice(0,-1);
+                folderPathParts = imagePath.split('/').slice(0, -1);
 
             $.ajaxSetup({
                 async: false
@@ -54,7 +54,7 @@ define([
                 this.openFolderTree(folderPathParts);
             }
 
-            pathId = this.getPathId(folderPathParts.join('/'));
+            pathId = this.encodePath(folderPathParts.join('/'));
             imageFolder = $('.jstree li[data-id="' + pathId + '"]').children('a');
 
             if (!imageFolder.length) {
@@ -96,20 +96,21 @@ define([
          *
          * @param {Array} folderPathParts
          */
-        openFolderTree: function(folderPathParts) {
+        openFolderTree: function (folderPathParts) {
             var i,
                 pathId,
                 openFolderButton,
                 folderPath = '';
 
-            for (i = 0; i < folderPathParts.length -1; i++) {
+            for (i = 0 ; i < folderPathParts.length - 1; i++) {
                 if (folderPath === '') {
                     folderPath = folderPathParts[i];
                 } else {
-                    folderPath = folderPath+'/'+folderPathParts[i];
+                    folderPath = folderPath + '/' + folderPathParts[i];
                 }
-                pathId = this.getPathId(folderPath);
+                pathId = this.encodePath(folderPath);
                 openFolderButton = $('.jstree li[data-id="' + pathId + '"]').children('.jstree-icon');
+
                 if (openFolderButton.length) {
                     openFolderButton.click();
                 }
@@ -122,11 +123,11 @@ define([
          * {String} path
          * @returns {String}
          */
-        getPathId: function (path) {
+        encodePath: function (path) {
             return Base64.encode(path)
-                .replace(/\+/g,':')
-                .replace(/\//g,'_')
-                .replace(/=/g,'-');
+                .replace(/\+/g, ':')
+                .replace(/\//g, '_')
+                .replace(/=/g, '-');
         }
     };
 });

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/media-gallery.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/media-gallery.js
@@ -54,7 +54,7 @@ define([
                 this.openFolderTree(folderPathParts);
             }
 
-            pathId = Base64.mageEncode(folderPathParts.join('/'));
+            pathId = Base64.idEncode(folderPathParts.join('/'));
             imageFolder = $('.jstree li[data-id="' + pathId + '"]').children('a');
 
             if (!imageFolder.length) {
@@ -108,7 +108,7 @@ define([
                 } else {
                     folderPath = folderPath + '/' + folderPathParts[i];
                 }
-                pathId = Base64.mageEncode(folderPath);
+                pathId = Base64.idEncode(folderPath);
                 openFolderButton = $('.jstree li[data-id="' + pathId + '"]').children('.jstree-icon');
 
                 if (openFolderButton.length) {

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/media-gallery.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/media-gallery.js
@@ -54,7 +54,7 @@ define([
                 this.openFolderTree(folderPathParts);
             }
 
-            pathId = this.encodePath(folderPathParts.join('/'));
+            pathId = Base64.mageEncode(folderPathParts.join('/'));
             imageFolder = $('.jstree li[data-id="' + pathId + '"]').children('a');
 
             if (!imageFolder.length) {
@@ -108,26 +108,13 @@ define([
                 } else {
                     folderPath = folderPath + '/' + folderPathParts[i];
                 }
-                pathId = this.encodePath(folderPath);
+                pathId = Base64.mageEncode(folderPath);
                 openFolderButton = $('.jstree li[data-id="' + pathId + '"]').children('.jstree-icon');
 
                 if (openFolderButton.length) {
                     openFolderButton.click();
                 }
             }
-        },
-
-        /**
-         * Encode folder path
-         *
-         * {String} path
-         * @returns {String}
-         */
-        encodePath: function (path) {
-            return Base64.encode(path)
-                .replace(/\+/g, ':')
-                .replace(/\//g, '_')
-                .replace(/=/g, '-');
         }
     };
 });

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/media-gallery.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/media-gallery.js
@@ -102,7 +102,7 @@ define([
                 openFolderButton,
                 folderPath = '';
 
-            for (i = 0 ; i < folderPathParts.length - 1; i++) {
+            for (i = 0; i < folderPathParts.length - 1; i++) {
                 if (folderPath === '') {
                     folderPath = folderPathParts[i];
                 } else {


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
The problem on issue #1361 is related to the way we were fetching and opening the old media gallery folder structure, we were using folder name as a selector, which isn't unique and was causing problems when subfolder had the same name as the folder. I've changed the approach to use the data-id that is generated by base64 encoding of the folder path.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/adobe-stock-integration#1361: "The image cannot be located" message appears if try to Save Preview in a sub-folder with the same name as the main folder.[NOT Enhanced Media Gallery]

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Follow steps on #1361 