### PR TITLE
Fix "Image cannot be located" message appears if try to Save Preview …

### DIFF
--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/actions.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/actions.js
@@ -340,7 +340,8 @@ define([
             if (this.isMediaBrowser()) {
                 activeNode = this.getMageMediaBrowserData().activeNode;
 
-                activeNodePath = $('[data-id="' + activeNode.id + '"]').length === 0 || activeNode.id === 'root' ? '' : activeNode.path;
+                activeNodePath = $('[data-id="' + activeNode.id + '"]').length === 0 ||
+                    activeNode.id === 'root' ? '' : activeNode.path;
             } else {
                 activeNodePath = this.imageDirectory().activeNode() || '';
             }

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/actions.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/actions.js
@@ -340,7 +340,7 @@ define([
             if (this.isMediaBrowser()) {
                 activeNode = this.getMageMediaBrowserData().activeNode;
 
-                activeNodePath = $('[data-id="' + activeNode.id + '"]').length === 0 ? '' : activeNode.path;
+                activeNodePath = $('[data-id="' + activeNode.id + '"]').length === 0 || activeNode.id === 'root' ? '' : activeNode.path;
             } else {
                 activeNodePath = this.imageDirectory().activeNode() || '';
             }


### PR DESCRIPTION
…in "Storage Root" folder. The image is saved into new folder named "Undefined"

<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/adobe-stock-integration#1363: "Image cannot be located" message appears if try to Save Preview in "Storage Root" folder. The image is saved into new folder named "Undefined"
2. ...

### Manual testing scenarios (*)
1. Go to _Content - Pages_ click **Add New Page**
2. Expand _Content_ click **Show / Hide Editor** - **Insert Image...**
3. **Select the "Storage Root" folder**
![stor_root](https://user-images.githubusercontent.com/45624059/82218491-a12a5580-9924-11ea-95ba-0e33acfde511.png)
4. Click **Search Adobe Stock** and **Save Preview** of any image
 
### Expected result (*)
The image Preview is saved and no error message appears
