### PR TITLE
Remove duplicated uploaded date filter

### DIFF
--- a/MediaGalleryUi/view/adminhtml/ui_component/media_gallery_listing.xml
+++ b/MediaGalleryUi/view/adminhtml/ui_component/media_gallery_listing.xml
@@ -94,7 +94,7 @@
                     <label translate="true">Directory</label>
                 </settings>
             </filterInput>
-            <filterRange name="created_at_date"
+            <filterRange name="created_at"
                          class="Magento\Ui\Component\Filters\Type\Date"
                          provider="${ $.parentName }"
                          template="ui/grid/filters/elements/group" sortOrder="30">
@@ -225,7 +225,6 @@
             </argument>
             <settings>
                 <label translate="true">Uploaded Date</label>
-                <filter>dateRange</filter>
                 <dataType>date</dataType>
                 <visible>false</visible>
                 <sortable>true</sortable>

--- a/MediaGalleryUi/view/adminhtml/ui_component/standalone_media_gallery_listing.xml
+++ b/MediaGalleryUi/view/adminhtml/ui_component/standalone_media_gallery_listing.xml
@@ -211,6 +211,7 @@
                 </item>
             </argument>
             <settings>
+                <label translate="true">Uploaded Date</label>
                 <dataType>date</dataType>
                 <visible>false</visible>
                 <sortable>true</sortable>

--- a/MediaGalleryUi/view/adminhtml/ui_component/standalone_media_gallery_listing.xml
+++ b/MediaGalleryUi/view/adminhtml/ui_component/standalone_media_gallery_listing.xml
@@ -81,7 +81,7 @@
                     <label translate="true">Directory</label>
                 </settings>
             </filterInput>
-            <filterRange name="created_at_date"
+            <filterRange name="created_at"
                          class="Magento\Ui\Component\Filters\Type\Date"
                          provider="${ $.parentName }"
                          template="ui/grid/filters/elements/group" sortOrder="30">
@@ -211,8 +211,6 @@
                 </item>
             </argument>
             <settings>
-                <label translate="true">Uploaded Date</label>
-                <filter>dateRange</filter>
                 <dataType>date</dataType>
                 <visible>false</visible>
                 <sortable>true</sortable>


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/adobe-stock-integration#1368:"Uploaded Date" filter is duplicated after being applied 
2. ...

### Manual testing scenarios (*)
1. Go to **Content - Media Gallery**
2. Click **Filters** and set any valid date into **Uploaded Date** _from_ field
3. Click **Apply Filters**
4. Click **Filters** button again
![upload_date_double](https://user-images.githubusercontent.com/45624059/82321293-46a10000-99dd-11ea-9a08-e558de1a8f62.gif)
 
### Expected result (*)
The filters are not changed