### PR TITLE
Cover case with non existing folder when apllying path filter

### DIFF
--- a/MediaGalleryUi/view/adminhtml/web/js/directory/directoryTree.js
+++ b/MediaGalleryUi/view/adminhtml/web/js/directory/directoryTree.js
@@ -96,9 +96,15 @@ define([
          * Verify directory filter on init event, select folder per directory filter state
          */
         checkChipFiltersState: function () {
-            if (!_.isUndefined(this.filterChips().filters.path) && this.filterChips().filters.path !== '') {
+            var currentFilterPath = this.filterChips().filters.path;
+
+            if (!_.isUndefined(currentFilterPath) && currentFilterPath !== '') {
                 $(this.directoryTreeSelector).on('loaded.jstree', function () {
-                    this.locateNode(this.filterChips().filters.path);
+                    if ($('#' + currentFilterPath.replace(/\//g, '\\/')).length === 1) {
+                        this.locateNode(this.filterChips().filters.path);
+                    } else {
+                        this.selectStorageRoot();
+                    }
                 }.bind(this));
             }
         },


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
DEPEND ON https://github.com/magento/adobe-stock-integration/pull/1350
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/adobe-stock-integration#1362: The Directory filter is applied for non existing folder in Enhanced Media Gallery if Delete a folder from NOT Enhanced Media Gallery
2. ...

### Manual testing scenarios (*)
1. Go to **Content - Media Gallery**
2. **Create Folder**, name it "Unlicensed" for example 
3. Select the previously created folder from the folder tree, so that the _Directory_ filter is applied
4. Go to _Content - Pages_ click **Add New Page**
5. Expand _Content_ click **Show / Hide Editor** - **Insert Image...**
6. **Delete** the previously created folder
7. Go to **Content - Media Gallery** again

### Expected result (*)
The _Directory_ filter is not applied
