### PR TITLE
User resource connetion, to cover case with table prefix

### DIFF
--- a/AdobeStockImageAdminUi/Model/FilterParametersProvider/IsLicensed.php
+++ b/AdobeStockImageAdminUi/Model/FilterParametersProvider/IsLicensed.php
@@ -11,22 +11,36 @@ namespace Magento\AdobeStockImageAdminUi\Model\FilterParametersProvider;
 use Magento\Framework\Api\SearchCriteriaInterface;
 use Magento\Framework\DB\Select;
 use Magento\MediaGalleryUi\Model\SelectModifierInterface;
+use Magento\Framework\App\ResourceConnection;
 
 /**
  * Add license state
  */
 class IsLicensed implements SelectModifierInterface
 {
+    private const ADOBE_STOCK_ASSET_TABLE_NAME = 'adobe_stock_asset';
+
+    /**
+     * @var ResourceConnection
+     */
+    private $connection;
+
+    /**
+     * @param ResourceConnection $connection
+     */
+    public function __construct(ResourceConnection $connection)
+    {
+        $this->connection = $connection;
+    }
+    
     /**
      * @inheritdoc
      */
     public function apply(Select $select, SearchCriteriaInterface $searchCriteria): void
     {
-        $connection = $select->getConnection();
-
         $select->joinLeft(
-            $connection->getTableName('adobe_stock_asset'),
-            'adobe_stock_asset.media_gallery_id = main_table.id',
+            ['asa' => $this->connection->getTableName(self::ADOBE_STOCK_ASSET_TABLE_NAME)],
+            'asa.media_gallery_id = main_table.id',
             ['is_licensed']
         );
     }


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/adobe-stock-integration#1374: SQL error is displayed in Media Gallery if Magento is installed with "table prefix"
2. ...

### Manual testing scenarios (*)
1. Install Magento with **table prefix**
![table_prefix_install](https://user-images.githubusercontent.com/45624059/82439037-a9a89a80-9aa2-11ea-8280-cd4f9cfaa51b.png)
2. Open admin page, go to **Content - Media Gallery** 

### Expected result (*)
Media Gallery is opened