### PR TITLE
[MFTF] Added delete image from context menu test

### DIFF
--- a/MediaGalleryUi/Test/Mftf/ActionGroup/AssertEnhancedMediaGalleryImageDeletedActionGroup.xml
+++ b/MediaGalleryUi/Test/Mftf/ActionGroup/AssertEnhancedMediaGalleryImageDeletedActionGroup.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="AssertEnhancedMediaGalleryImageDeletedActionGroup">
+        <annotations>
+            <description>Assert that an image was delete.</description>
+        </annotations>
+        <arguments>
+            <argument name="imageName" type="string"/>
+        </arguments>
+
+        <dontSeeElement selector="{{AdminEnhancedMediaGalleryImageActionsSection.imageInGrid(imageName)}}" stepKey="dontSeeImage"/>
+    </actionGroup>
+</actionGroups>

--- a/MediaGalleryUi/Test/Mftf/Section/AdminEnhancedMediaGalleryImageActionsSection.xml
+++ b/MediaGalleryUi/Test/Mftf/Section/AdminEnhancedMediaGalleryImageActionsSection.xml
@@ -11,5 +11,6 @@
         <element name="openContextMenu" type="button" selector=".three-dots"/>
         <element name="viewDetails" type="button" selector="[data-ui-id='action-image-details']"/>
         <element name="delete" type="button" selector="[data-ui-id='action-delete']"/>
+        <element name="imageInGrid" type="button" selector="//img[@class='media-gallery-image-column'][contains(@src, '{{imageName}}')]" parameterized="true"/>
     </section>
 </sections>

--- a/MediaGalleryUi/Test/Mftf/Test/AdminMediaGalleryDeleteImageContextMenuTest.xml
+++ b/MediaGalleryUi/Test/Mftf/Test/AdminMediaGalleryDeleteImageContextMenuTest.xml
@@ -12,7 +12,8 @@
             <features value="MediaGallery"/>
             <useCaseId value="https://github.com/magento/adobe-stock-integration/issues/710"/>
             <title value="Uploading and deleting an image using context menu"/>
-            <testCaseId value="to-be-added"/>
+            <stories value="[Story #52] User accesses Media Gallery from the main navigation"/>
+            <testCaseId value="https://studio.cucumber.io/projects/131313/test-plan/folders/1054245/scenarios/4753539"/>
             <description value="Uploading and deleting an image using context menu"/>
             <severity value="CRITICAL"/>
             <group value="media_gallery_ui"/>

--- a/MediaGalleryUi/Test/Mftf/Test/AdminMediaGalleryDeleteImageContextMenuTest.xml
+++ b/MediaGalleryUi/Test/Mftf/Test/AdminMediaGalleryDeleteImageContextMenuTest.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+    <test name="AdminMediaGalleryDeleteImageContextMenuTest">
+        <annotations>
+            <features value="MediaGallery"/>
+            <useCaseId value="https://github.com/magento/adobe-stock-integration/issues/710"/>
+            <title value="Uploading and deleting an image using context menu"/>
+            <testCaseId value="to-be-added"/>
+            <description value="Uploading and deleting an image using context menu"/>
+            <severity value="CRITICAL"/>
+            <group value="media_gallery_ui"/>
+        </annotations>
+        <before>
+            <actionGroup ref="AdminLoginActionGroup" stepKey="loginAsAdmin"/>
+            <actionGroup ref="AdminOpenMediaGalleryForPageNoEditorActionGroup" stepKey="openMediaGalleryForPage"/>
+        </before>
+        <actionGroup ref="AdminEnhancedMediaGalleryUploadImageActionGroup" stepKey="uploadImage">
+            <argument name="image" value="ImageUpload"/>
+        </actionGroup>
+        <actionGroup ref="AdminEnhancedMediaGalleryImageDeleteActionGroup" stepKey="deleteImage"/>
+        <actionGroup ref="AssertEnhancedMediaGalleryImageDeletedActionGroup" stepKey="assertImageDeleted">
+            <argument name="imageName" value="{{ImageUpload.fileName}}"/>
+        </actionGroup>
+    </test>
+</tests>


### PR DESCRIPTION

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Added test to cover deletion of an image using the context menu on the enhanced media gallery

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/adobe-stock-integration#710: [MFTF] User deletes images from context menu 

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Run: `vendor/bin/mftf run:test AdminMediaGalleryDeleteImageContextMenuTest --remove`