### PR TITLE
[MFTF] Added test o add image from image details

### DIFF
--- a/MediaGalleryUi/Test/Mftf/ActionGroup/AdminEnhancedMediaGalleryAddImageFromImageDetailsActionGroup.xml
+++ b/MediaGalleryUi/Test/Mftf/ActionGroup/AdminEnhancedMediaGalleryAddImageFromImageDetailsActionGroup.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="AdminEnhancedMediaGalleryAddImageFromImageDetailsActionGroup">
+        <annotations>
+            <description>Adds image to target element from View Details panel</description>
+        </annotations>
+
+        <click selector="{{AdminEnhancedMediaGalleryViewDetailsSection.addImage}}" stepKey="openContextMenu"/>
+        <waitForLoadingMaskToDisappear stepKey="waitForLoadingMaskToDisappear"/>
+    </actionGroup>
+</actionGroups>

--- a/MediaGalleryUi/Test/Mftf/ActionGroup/AssertImageAddedToPageContentActionGroup.xml
+++ b/MediaGalleryUi/Test/Mftf/ActionGroup/AssertImageAddedToPageContentActionGroup.xml
@@ -13,7 +13,7 @@
             <description>Validates that the an image was added to the content.</description>
         </annotations>
         <arguments>
-            <argument name="imageName" type="string" defaultValue="{{AdobeStockImageData.name}}"/>
+            <argument name="imageName" type="string"/>
         </arguments>
        <grabValueFrom selector="{{CmsNewPagePageContentSection.content}}"  stepKey="grabTextFromContent"/>
         <assertStringContainsString stepKey="assertContentContainsAddedImage">

--- a/MediaGalleryUi/Test/Mftf/ActionGroup/AssertImageAddedToPageContentActionGroup.xml
+++ b/MediaGalleryUi/Test/Mftf/ActionGroup/AssertImageAddedToPageContentActionGroup.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="AssertImageAddedToPageContentActionGroup">
+        <annotations>
+            <description>Validates that the an image was added to the content.</description>
+        </annotations>
+        <arguments>
+            <argument name="imageName" type="string" defaultValue="{{AdobeStockImageData.name}}"/>
+        </arguments>
+       <grabValueFrom selector="{{CmsNewPagePageContentSection.content}}"  stepKey="grabTextFromContent"/>
+        <assertStringContainsString stepKey="assertContentContainsAddedImage">
+            <expectedResult type="string">{{imageName}}</expectedResult>
+            <actualResult type="variable">grabTextFromContent</actualResult>
+        </assertStringContainsString>
+    </actionGroup>
+</actionGroups>

--- a/MediaGalleryUi/Test/Mftf/Section/AdminEnhancedMediaGalleryViewDetailsSection.xml
+++ b/MediaGalleryUi/Test/Mftf/Section/AdminEnhancedMediaGalleryViewDetailsSection.xml
@@ -14,5 +14,6 @@
         <element name="height" type="text" selector="//div[@class='attribute']/span[contains(text(), 'Height')]/following-sibling::div"/>
         <element name="delete" type="button" selector=".delete"/>
         <element name="confirmDelete" type="button" selector=".action-accept"/>
+        <element name="addImage" type="button" selector=".add-image-action"/>
     </section>
 </sections>

--- a/MediaGalleryUi/Test/Mftf/Test/AdminMediaGalleryAddFromImageDetailsTest.xml
+++ b/MediaGalleryUi/Test/Mftf/Test/AdminMediaGalleryAddFromImageDetailsTest.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+    <test name="AdminMediaGalleryAddFromImageDetailsTest">
+        <annotations>
+            <features value="MediaGallery"/>
+            <useCaseId value="https://github.com/magento/adobe-stock-integration/issues/1229"/>
+            <stories value="[Story #38] User views basic image attributes in Media Gallery"/>
+            <title value="Adding image from the Image Details"/>
+            <testCaseId value="https://studio.cucumber.io/projects/131313/test-plan/folders/1054245/scenarios/4569982"/>
+            <description value="Adding image from the Image Details"/>
+            <severity value="CRITICAL"/>
+            <group value="media_gallery_ui"/>
+        </annotations>
+        <before>
+            <actionGroup ref="AdminLoginActionGroup" stepKey="loginAsAdmin"/>
+            <actionGroup ref="AdminOpenMediaGalleryForPageNoEditorActionGroup" stepKey="openMediaGalleryForPage"/>
+            <actionGroup ref="AdminEnhancedMediaGalleryUploadImageActionGroup" stepKey="uploadImage">
+                <argument name="image" value="ImageUpload"/>
+            </actionGroup>
+        </before>
+        <after>
+            <actionGroup ref="AdminOpenMediaGalleryForPageNoEditorActionGroup" stepKey="openMediaGalleryForPage"/>
+            <actionGroup ref="AdminEnhancedMediaGalleryViewImageDetails" stepKey="viewImageDetails"/>
+            <actionGroup ref="AdminEnhancedMediaGalleryImageDetailsDeleteActionGroup" stepKey="deleteImage"/>
+        </after>
+        <actionGroup ref="AdminEnhancedMediaGalleryViewImageDetails" stepKey="viewImageDetails"/>
+        <actionGroup ref="AdminEnhancedMediaGalleryAddImageFromImageDetailsActionGroup" stepKey="addImageFromViewDetails"/>
+        <actionGroup ref="AssertImageAddedToPageContentActionGroup" stepKey="assertImageAddedToContent">
+            <argument name="imageName" value="{{ImageUpload.fileName}}"/>
+        </actionGroup>
+    </test>
+</tests>


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
Added test coverage to add image from image details.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/adobe-stock-integration#1229: Cover User add image from Image Details page

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. run `vendor/bin/mftf run:test AdminMediaGalleryAddFromImageDetailsTest --remove`