### PR TITLE
Added MediaGallery filter pool

### DIFF
--- a/MediaGalleryUi/etc/di.xml
+++ b/MediaGalleryUi/etc/di.xml
@@ -71,11 +71,23 @@
             </argument>
         </arguments>
     </type>
-    <type name="Magento\Framework\View\Element\UiComponent\DataProvider\FilterPool">
+    <virtualType name="mediaGalleryFilterPool" type="Magento\Framework\View\Element\UiComponent\DataProvider\FilterPool">
         <arguments>
             <argument name="appliers" xsi:type="array">
+                <item name="regular" xsi:type="object">Magento\Framework\View\Element\UiComponent\DataProvider\RegularFilter</item>
+                <item name="fulltext" xsi:type="object">Magento\Framework\View\Element\UiComponent\DataProvider\FulltextFilter</item>
                 <item name="media_gallery_keyword" xsi:type="object">Magento\MediaGalleryUi\Ui\Component\DataProvider\KeywordFilter</item>
-            </argument>
+             </argument>
+        </arguments>
+    </virtualType>
+    <virtualType name="mediaGalleryReporting" type="Magento\Framework\View\Element\UiComponent\DataProvider\Reporting">
+        <arguments>
+            <argument name="filterPool" xsi:type="object">mediaGalleryFilterPool</argument>
+        </arguments>
+    </virtualType>
+    <type name="Magento\MediaGalleryUi\Model\Listing\DataProvider">
+        <arguments>
+            <argument name="reporting" xsi:type="object">mediaGalleryReporting</argument>
         </arguments>
     </type>
 </config>


### PR DESCRIPTION
### Description (*)
FilterPool is a being used on Reporting DataProvider and may be used by other DataProviders that are not MediaGallery related.

I've introduced a new FilterPool specifically for the MediaGalleryUi grid, making the KeywordFilter just available to the MediaGalleryUi module.

### Fixed Issues (if relevant)
1. magento/adobe-stock-integration#1395: Remove KeywordFilter from FilterPool 

### Manual testing scenarios (*)
1. Open: Content -> Media Gallery
2. The keyword filter should work as before.