### PR TITLE
MFTF tests for view image details and delete image on standalone media gallery

### DIFF
--- a/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockVerifyLicensedLabelTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockVerifyLicensedLabelTest.xml
@@ -15,6 +15,7 @@
             <features value="MediaGallery"/>
             <useCaseId value="https://github.com/magento/adobe-stock-integration/issues/460"/>
             <title value="User saves licensed image and verify there is no unlicensed label"/>
+            <stories value="[Story #41] User views limited image information from the image grid in Media Gallery"/>
             <testCaseId value="https://studio.cucumber.io/projects/131313/test-plan/folders/1054245/scenarios/3839218"/>
             <description value="Admin should be able to save licensed image and not see unlicensed label"/>
             <severity value="CRITICAL"/>

--- a/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockVerifyUnlicensedLabelTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockVerifyUnlicensedLabelTest.xml
@@ -12,6 +12,7 @@
             <features value="MediaGallery"/>
             <useCaseId value="https://github.com/magento/adobe-stock-integration/issues/460"/>
             <title value="User saves image preview and verify unlicensed label"/>
+            <stories value="[Story #41] User views limited image information from the image grid in Media Gallery"/>
             <testCaseId value="https://studio.cucumber.io/projects/131313/test-plan/folders/1054245/scenarios/3839218"/>
             <description value="Admin should be able to saves image preview and see unlicensed label"/>
             <severity value="CRITICAL"/>

--- a/AdobeStockImageAdminUi/Test/Mftf/Test/AdminStandaloneMediaGalleryViewAdobeStockDetailsTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/AdminStandaloneMediaGalleryViewAdobeStockDetailsTest.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+    <test name="AdminStandaloneMediaGalleryViewAdobeStockDetailsTest">
+        <annotations>
+            <features value="AdobeStockMediaGallery"/>
+            <useCaseId value="https://github.com/magento/adobe-stock-integration/issues/428"/>
+            <title value="View adobe stock image details in standalone media gallery"/>
+            <testCaseId value="https://studio.cucumber.io/projects/131313/test-plan/folders/1337102/scenarios/4503223"/>
+            <description value="User views adobe stock image attributes in Media Gallery"/>
+            <severity value="CRITICAL"/>
+            <group value="adobe_stock_media_gallery"/>
+        </annotations>
+        <before>
+            <actionGroup ref="AdminLoginActionGroup" stepKey="loginAsAdmin"/>
+            <actionGroup ref="AdminOpenStandaloneMediaGalleryActionGroup" stepKey="openStandaloneMediaGallery"/>
+        </before>
+        <after>
+            <actionGroup ref="AdminEnhancedMediaGalleryImageDetailsDeleteActionGroup" stepKey="deleteImage"/>
+        </after>
+
+        <actionGroup ref="AdminEnhancedMediaGallerySearchAdobeStockActionGroup" stepKey="openAdobeStockGrid"/>
+        <actionGroup ref="AdminAdobeStockExpandImagePreviewActionGroup" stepKey="expandImagePreview"/>
+        <actionGroup ref="AdminAdobeStockSavePreviewActionGroup" stepKey="saveImagePreview"/>
+        <actionGroup ref="AdminSaveAdobeStockImagePreviewActionGroup" stepKey="confirmSaveImagePreview"/>
+        <actionGroup ref="AdminEnhancedMediaGalleryViewImageDetails" stepKey="viewImageDetails"/>
+        <actionGroup ref="AdminAdobeStockVerifyImageDetailsActionGroup" stepKey="verifyImageDetails">
+            <argument name="image" value="AdobeStockUnlicensedImage"/>
+        </actionGroup>
+    </test>
+</tests>

--- a/AdobeStockImageAdminUi/Test/Mftf/Test/AdminStandaloneMediaGalleryViewAdobeStockDetailsTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/AdminStandaloneMediaGalleryViewAdobeStockDetailsTest.xml
@@ -12,6 +12,7 @@
             <features value="AdobeStockMediaGallery"/>
             <useCaseId value="https://github.com/magento/adobe-stock-integration/issues/428"/>
             <title value="View adobe stock image details in standalone media gallery"/>
+            <stories value="[Story # 38] User views basic image attributes in Media Gallery"/>
             <testCaseId value="https://studio.cucumber.io/projects/131313/test-plan/folders/1337102/scenarios/4503223"/>
             <description value="User views adobe stock image attributes in Media Gallery"/>
             <severity value="CRITICAL"/>

--- a/MediaGalleryUi/Test/Mftf/Test/AdminMediaGalleryAddCategoryImageTest.xml
+++ b/MediaGalleryUi/Test/Mftf/Test/AdminMediaGalleryAddCategoryImageTest.xml
@@ -12,6 +12,7 @@
             <features value="AdminMediaGalleryImagePanel"/>
             <useCaseId value="https://github.com/magento/adobe-stock-integration/issues/1073"/>
             <title value="User add category image via wysiwyg"/>
+            <stories value="User add category image via wysiwyg"/>
             <testCaseId value="https://studio.cucumber.io/projects/131313/test-plan/folders/943908/scenarios/4484351"/>
             <description value="User add category image via wysiwyg"/>
             <severity value="CRITICAL"/>

--- a/MediaGalleryUi/Test/Mftf/Test/AdminMediaGallerySaveFiltersStateTest.xml
+++ b/MediaGalleryUi/Test/Mftf/Test/AdminMediaGallerySaveFiltersStateTest.xml
@@ -12,6 +12,7 @@
             <features value="AdminMediaGalleryImagePanel"/>
             <useCaseId value="https://github.com/magento/adobe-stock-integration/issues/1397"/>
             <title value="User is able to use bookmarks controls for filter views in Standalone Media Gallery"/>
+            <stories value="User is able to use bookmarks controls in Standalone Media Gallery"/>
             <testCaseId value="https://studio.cucumber.io/projects/131313/test-plan/folders/1337102/scenarios/4763040"/>
             <description value="User is able to use bookmarks controls for filter views in Standalone Media Gallery"/>
             <severity value="CRITICAL"/>

--- a/MediaGalleryUi/Test/Mftf/Test/AdminMediaGalleryViewDetailsDeleteImageTest.xml
+++ b/MediaGalleryUi/Test/Mftf/Test/AdminMediaGalleryViewDetailsDeleteImageTest.xml
@@ -25,7 +25,8 @@
         <actionGroup ref="AdminEnhancedMediaGalleryUploadImageActionGroup" stepKey="uploadImage">
             <argument name="image" value="ImageUpload3"/>
         </actionGroup>
-        <actionGroup ref="AdminEnhancedMediaGalleryImageDeleteActionGroup" stepKey="deleteImage"/>
+        <actionGroup ref="AdminEnhancedMediaGalleryViewImageDetails" stepKey="viewImageDetails"/>
+        <actionGroup ref="AdminEnhancedMediaGalleryImageDetailsDeleteActionGroup" stepKey="deleteImage"/>
         <actionGroup ref="AssertAdminEnhancedMediaGalleryImageDeletedActionGroup" stepKey="assertImageDeleted">
             <argument name="imageName" value="{{ImageUpload3.fileName}}"/>
         </actionGroup>

--- a/MediaGalleryUi/Test/Mftf/Test/AdminMediaGalleryViewDetailsDeleteImageTest.xml
+++ b/MediaGalleryUi/Test/Mftf/Test/AdminMediaGalleryViewDetailsDeleteImageTest.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+    <test name="AdminMediaGalleryViewDetailsDeleteImageTest">
+        <annotations>
+            <features value="MediaGallery"/>
+            <useCaseId value="https://github.com/magento/adobe-stock-integration/issues/461"/>
+            <title value="Deleting an image from view details panel"/>
+            <stories value="[Story #42] User deletes images"/>
+            <testCaseId value="https://studio.cucumber.io/projects/131313/test-plan/folders/1337102/scenarios/4516773"/>
+            <description value="Deleting an image from view details panel"/>
+            <severity value="CRITICAL"/>
+            <group value="media_gallery_ui"/>
+        </annotations>
+        <before>
+            <actionGroup ref="AdminLoginActionGroup" stepKey="loginAsAdmin"/>
+            <actionGroup ref="AdminOpenStandaloneMediaGalleryActionGroup" stepKey="openStandaloneMediaGallery"/>
+        </before>
+        <actionGroup ref="AdminEnhancedMediaGalleryUploadImageActionGroup" stepKey="uploadImage">
+            <argument name="image" value="ImageUpload3"/>
+        </actionGroup>
+        <actionGroup ref="AdminEnhancedMediaGalleryImageDeleteActionGroup" stepKey="deleteImage"/>
+        <actionGroup ref="AssertAdminEnhancedMediaGalleryImageDeletedActionGroup" stepKey="assertImageDeleted">
+            <argument name="imageName" value="{{ImageUpload3.fileName}}"/>
+        </actionGroup>
+    </test>
+</tests>

--- a/MediaGalleryUi/Test/Mftf/Test/AdminMediaGalleryViewDetailsTest.xml
+++ b/MediaGalleryUi/Test/Mftf/Test/AdminMediaGalleryViewDetailsTest.xml
@@ -12,6 +12,7 @@
             <features value="MediaGallery"/>
             <useCaseId value="https://github.com/magento/adobe-stock-integration/issues/428"/>
             <title value="View image details"/>
+            <stories value="[Story # 38] User views basic image attributes in Media Gallery"/>
             <testCaseId value="https://studio.cucumber.io/projects/131313/test-plan/folders/1054245/scenarios/4653671"/>
             <description value="User views basic image attributes in Media Gallery"/>
             <severity value="CRITICAL"/>

--- a/MediaGalleryUi/Test/Mftf/Test/AdminStandaloneMediaGalleryCreateDeleteFolderTest.xml
+++ b/MediaGalleryUi/Test/Mftf/Test/AdminStandaloneMediaGalleryCreateDeleteFolderTest.xml
@@ -20,7 +20,7 @@
         </annotations>
         <before>
             <actionGroup ref="AdminLoginActionGroup" stepKey="loginAsAdmin"/>
-            <actionGroup ref="AdminOpenStandaloneMediaGalleryActionGroup" stepKey="openMediaGalleryForPage"/>
+            <actionGroup ref="AdminOpenStandaloneMediaGalleryActionGroup" stepKey="openStandaloneMediaGallery"/>
         </before>
 
         <actionGroup ref="AdminMediaGalleryOpenNewFolderFormActionGroup" stepKey="openNewFolderForm"/>

--- a/MediaGalleryUi/Test/Mftf/Test/AdminStandaloneMediaGalleryViewDetailsTest.xml
+++ b/MediaGalleryUi/Test/Mftf/Test/AdminStandaloneMediaGalleryViewDetailsTest.xml
@@ -12,6 +12,7 @@
             <features value="MediaGallery"/>
             <useCaseId value="https://github.com/magento/adobe-stock-integration/issues/428"/>
             <title value="View image details in standalone media gallery"/>
+            <stories value="[Story # 38] User views basic image attributes in Media Gallery"/>
             <testCaseId value="https://studio.cucumber.io/projects/131313/test-plan/folders/1337102/scenarios/4503223"/>
             <description value="User views basic image attributes in Media Gallery"/>
             <severity value="CRITICAL"/>

--- a/MediaGalleryUi/Test/Mftf/Test/AdminStandaloneMediaGalleryViewDetailsTest.xml
+++ b/MediaGalleryUi/Test/Mftf/Test/AdminStandaloneMediaGalleryViewDetailsTest.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+    <test name="AdminStandaloneMediaGalleryViewDetailsTest">
+        <annotations>
+            <features value="MediaGallery"/>
+            <useCaseId value="https://github.com/magento/adobe-stock-integration/issues/428"/>
+            <title value="View image details in standalone media gallery"/>
+            <testCaseId value="https://studio.cucumber.io/projects/131313/test-plan/folders/1337102/scenarios/4503223"/>
+            <description value="User views basic image attributes in Media Gallery"/>
+            <severity value="CRITICAL"/>
+            <group value="media_gallery_ui"/>
+        </annotations>
+        <before>
+            <actionGroup ref="AdminLoginActionGroup" stepKey="loginAsAdmin"/>
+            <actionGroup ref="AdminOpenStandaloneMediaGalleryActionGroup" stepKey="openStandaloneMediaGallery"/>
+        </before>
+        <after>
+            <actionGroup ref="AdminEnhancedMediaGalleryImageDetailsDeleteActionGroup" stepKey="deleteImage"/>
+        </after>
+
+        <actionGroup ref="AdminEnhancedMediaGalleryUploadImageActionGroup" stepKey="uploadImage">
+            <argument name="image" value="ImageUpload"/>
+        </actionGroup>
+        <actionGroup ref="AdminEnhancedMediaGalleryViewImageDetails" stepKey="viewImageDetails"/>
+        <actionGroup ref="AdminEnhancedMediaGalleryVerifyImageDetailsActionGroup" stepKey="verifyImageDetails">
+            <argument name="image" value="ImageUpload"/>
+        </actionGroup>
+    </test>
+</tests>


### PR DESCRIPTION
### Description

MFTF tests

### Fixed Issues (if relevant)
1. https://github.com/magento/adobe-stock-integration/issues/1137 User views basic image attributes in Standalone Media Gallery
2. https://github.com/magento/adobe-stock-integration/issues/1156 Cover User delete the image from Image Details page in Standalone Media Gallery

### Manual testing scenarios (*)
1. `vendor/bin/mftf run:test AdminStandaloneMediaGalleryViewAdobeStockDetailsTest`
2. `vendor/bin/mftf run:test AdminStandaloneMediaGalleryViewDetailsTest`