### PR TITLE
#1404 - Removed default profile image feature

### DIFF
--- a/AdobeIms/Block/Adminhtml/SignIn.php
+++ b/AdobeIms/Block/Adminhtml/SignIn.php
@@ -188,7 +188,7 @@ class SignIn extends Template
             'isAuthorized' => false,
             'name' => '',
             'email' => '',
-            'image' => $this->config->getDefaultProfileImage(),
+            'image' => '',
         ];
     }
 }

--- a/AdobeIms/Model/Config.php
+++ b/AdobeIms/Model/Config.php
@@ -22,7 +22,6 @@ class Config implements ConfigInterface
     private const XML_PATH_TOKEN_URL = 'adobe_ims/integration/token_url';
     private const XML_PATH_AUTH_URL_PATTERN = 'adobe_ims/integration/auth_url_pattern';
     private const XML_PATH_LOGOUT_URL_PATTERN = 'adobe_ims/integration/logout_url';
-    private const XML_PATH_DEFAULT_PROFILE_IMAGE = 'adobe_ims/integration/default_profile_image';
     private const XML_PATH_IMAGE_URL_PATTERN = 'adobe_ims/integration/image_url';
     private const OAUTH_CALLBACK_URL = 'adobe_ims/oauth/callback';
 
@@ -126,13 +125,5 @@ class Config implements ConfigInterface
             [$this->getApiKey()],
             $this->scopeConfig->getValue(self::XML_PATH_IMAGE_URL_PATTERN)
         );
-    }
-
-    /**
-     * @inheritdoc
-     */
-    public function getDefaultProfileImage(): string
-    {
-        return $this->scopeConfig->getValue(self::XML_PATH_DEFAULT_PROFILE_IMAGE);
     }
 }

--- a/AdobeIms/Model/GetImage.php
+++ b/AdobeIms/Model/GetImage.php
@@ -73,7 +73,7 @@ class GetImage implements GetImageInterface
             $result = $this->json->unserialize($curl->getBody());
             $image = $result['user']['images'][$size];
         } catch (\Exception $exception) {
-            $image = $this->config->getDefaultProfileImage();
+            $image = '';
             $this->logger->critical($exception);
         }
 

--- a/AdobeIms/Test/Unit/Block/Adminhtml/SignInTest.php
+++ b/AdobeIms/Test/Unit/Block/Adminhtml/SignInTest.php
@@ -31,7 +31,6 @@ class SignInTest extends TestCase
     private const PROFILE_URL = 'https://url.test/';
     private const LOGOUT_URL = 'https://url.test/';
     private const AUTH_URL = '';
-    private const DEFAULT_PROFILE_IMAGE = 'default_image.png';
     private const RESPONSE_REGEXP_PATTERN = 'auth\\[code=(success|error);message=(.+)\\]';
     private const RESPONSE_CODE_INDEX = 1;
     private const RESPONSE_MESSAGE_INDEX = 2;
@@ -72,8 +71,6 @@ class SignInTest extends TestCase
         $configMock->expects($this->once())
             ->method('getAuthUrl')
             ->willReturn(self::AUTH_URL);
-        $configMock->method('getDefaultProfileImage')
-            ->willReturn(self::DEFAULT_PROFILE_IMAGE);
 
         $urlBuilderMock = $this->createMock(UrlInterface::class);
         $urlBuilderMock->method('getUrl')
@@ -216,7 +213,7 @@ class SignInTest extends TestCase
             'isAuthorized' => false,
             'name' => '',
             'email' => '',
-            'image' => self::DEFAULT_PROFILE_IMAGE,
+            'image' => '',
         ];
     }
 

--- a/AdobeIms/Test/Unit/Model/ConfigTest.php
+++ b/AdobeIms/Test/Unit/Model/ConfigTest.php
@@ -215,16 +215,4 @@ class ConfigTest extends TestCase
             $this->config->getProfileImageUrl()
         );
     }
-
-    /**
-     * Test for \Magento\AdobeIms\Model\Config::getDefaultProfileImage
-     */
-    public function testGetDefaultProfileImage(): void
-    {
-        $this->scopeConfigMock->method('getValue')
-            ->with(self::XML_PATH_DEFAULT_PROFILE_IMAGE)
-            ->willReturn(self::IMAGE_URL_DEFAULT);
-
-        $this->assertEquals(self::IMAGE_URL_DEFAULT, $this->config->getDefaultProfileImage());
-    }
 }

--- a/AdobeIms/etc/config.xml
+++ b/AdobeIms/etc/config.xml
@@ -14,7 +14,6 @@
                 <token_url>https://ims-na1.adobelogin.com/ims/token</token_url>
                 <logout_url><![CDATA[https://ims-na1.adobelogin.com/ims/logout?access_token=#{access_token}&redirect_uri=#{redirect_uri}]]></logout_url>
                 <image_url><![CDATA[https://cc-api-behance.adobe.io/v2/users/me?api_key=#{api_key}]]></image_url>
-                <default_profile_image>https://a5.behance.net/27000444e0c8b62c56deff3fc491e1a92d07f0cb/img/profile/no-image-276.png</default_profile_image>
                 <auth_url_pattern><![CDATA[https://ims-na1.adobelogin.com/ims/authorize?client_id=#{client_id}&redirect_uri=#{redirect_uri}&locale=#{locale}&scope=openid,creative_sdk&response_type=code]]></auth_url_pattern>
             </integration>
         </adobe_ims>

--- a/AdobeIms/view/adminhtml/web/js/signIn.js
+++ b/AdobeIms/view/adminhtml/web/js/signIn.js
@@ -14,8 +14,7 @@ define([
         defaults: {
             profileUrl: 'adobe_ims/user/profile',
             logoutUrl: 'adobe_ims/user/logout',
-            defaultProfileImage:
-                'https://a5.behance.net/27000444e0c8b62c56deff3fc491e1a92d07f0cb/img/profile/no-image-276.png',
+            defaultProfileImage: '',
             user: {
                 isAuthorized: false,
                 name: '',

--- a/AdobeIms/view/adminhtml/web/js/signIn.js
+++ b/AdobeIms/view/adminhtml/web/js/signIn.js
@@ -14,7 +14,6 @@ define([
         defaults: {
             profileUrl: 'adobe_ims/user/profile',
             logoutUrl: 'adobe_ims/user/logout',
-            defaultProfileImage: '',
             user: {
                 isAuthorized: false,
                 name: '',
@@ -127,7 +126,7 @@ define([
                         isAuthorized: false,
                         name: '',
                         email: '',
-                        image: this.defaultProfileImage
+                        image: ''
                     });
                 }.bind(this),
 

--- a/AdobeImsApi/Api/ConfigInterface.php
+++ b/AdobeImsApi/Api/ConfigInterface.php
@@ -65,11 +65,4 @@ interface ConfigInterface
      * @return string
      */
     public function getProfileImageUrl(): string;
-
-    /**
-     * Returns default profile image.
-     *
-     * @return string
-     */
-    public function getDefaultProfileImage(): string;
 }


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
Removed the default profile image feature, the hardcoded image wasn't accessible anymore and that may occur in the future. That was also used if an exception occurs when we try to fetch profile image, on this PR that field will be empty but it doesn't cause any problem on the frontend.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/adobe-stock-integration#1404: Broken profile image leads to a 403 error in dev-console

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Follow the steps described in #1404 
or
1. Open Content -> Media Gallery
2. Click on Search Adobe Stock
3. Sign in and then Sign out, you should not receive any error on console.  