### PR TITLE
[MFTF] Cover filtering images by their keywords in Standalone Media Gallery

### DIFF
--- a/AdobeStockImageAdminUi/Test/Mftf/Test/AdminStandaloneMediaGallerySearchByKeywordTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/AdminStandaloneMediaGallerySearchByKeywordTest.xml
@@ -15,7 +15,7 @@
             <title value="User searches for an image using search by keyword from standalone media gallery"/>
             <description value="User searches for an image using search by keyword from standalone media gallery"/>
             <severity value="CRITICAL"/>
-            <group value="media_gallery_ui"/>
+            <group value="adobe_stock_media_gallery"/>
         </annotations>
 
         <before>
@@ -28,6 +28,7 @@
         </after>
         <actionGroup ref="AdminEnhancedMediaGallerySearchAdobeStockActionGroup" stepKey="openAdobeStockGrid"/>
         <actionGroup ref="AdminAdobeStockExpandImagePreviewActionGroup" stepKey="expandImagePreview"/>
+        <grabTextFrom selector="{{AdminAdobeStockImagePreviewSection.firstKeyword}}" stepKey="grabKeyword"/>
         <grabAttributeFrom selector="{{AdminAdobeStockImagePreviewSection.image}}" userInput="alt" stepKey="grabImageName"/>
         <click selector="{{AdminAdobeStockImagePreviewSection.savePreview}}" stepKey="clickSavePreviewButton"/>
         <waitForPageLoad stepKey="waitForPromptModal"/>
@@ -37,7 +38,14 @@
         <actionGroup ref="SearchStandaloneMediaGalleryAdminDataGridByKeywordActionGroup" stepKey="searchImage">
             <argument name="keyword" value="$grabImageName"/>
         </actionGroup>
-        <actionGroup ref="AdminAssertImageInStandaloneMediaGalleryActionGroup" stepKey="assertImageIsAvailableInStandaloneGrid">
+        <actionGroup ref="AdminAssertImageInStandaloneMediaGalleryActionGroup" stepKey="assertImageIsAvailableInStandaloneGridUsingImageName">
+            <argument name="imageName" value="$grabImageFileName"/>
+        </actionGroup>
+        <actionGroup ref="ResetAdminDataGridToDefaultViewActionGroup" stepKey="resetAdminDataGridToDefaultView"/>
+        <actionGroup ref="SearchStandaloneMediaGalleryAdminDataGridByKeywordActionGroup" stepKey="searchImageByKeyword">
+            <argument name="keyword" value="$grabKeyword"/>
+        </actionGroup>
+        <actionGroup ref="AdminAssertImageInStandaloneMediaGalleryActionGroup" stepKey="assertImageIsAvailableInStandaloneGridUsingKeyword">
             <argument name="imageName" value="$grabImageFileName"/>
         </actionGroup>
     </test>

--- a/MediaGalleryUi/Test/Mftf/ActionGroup/AdminAssertImageInStandaloneMediaGalleryActionGroup.xml
+++ b/MediaGalleryUi/Test/Mftf/ActionGroup/AdminAssertImageInStandaloneMediaGalleryActionGroup.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="AdminAssertImageInStandaloneMediaGalleryActionGroup">
+        <annotations>
+            <description>Validates that the provided image is present and correct in the standalone media gallery.</description>
+        </annotations>
+        <arguments>
+            <argument name="imageName" type="string" defaultValue=""/>
+        </arguments>
+
+        <seeElement selector="{{AdminEnhancedMediaGalleryActionsSection.imageSrc(imageName)}}"
+                        stepKey="checkFirstImageAfterSearch"/>
+    </actionGroup>
+</actionGroups>

--- a/MediaGalleryUi/Test/Mftf/ActionGroup/AdminAssertImageInStandaloneMediaGalleryActionGroup.xml
+++ b/MediaGalleryUi/Test/Mftf/ActionGroup/AdminAssertImageInStandaloneMediaGalleryActionGroup.xml
@@ -12,7 +12,7 @@
             <description>Validates that the provided image is present and correct in the standalone media gallery.</description>
         </annotations>
         <arguments>
-            <argument name="imageName" type="string" defaultValue=""/>
+            <argument name="imageName" type="string"/>
         </arguments>
 
         <seeElement selector="{{AdminEnhancedMediaGalleryActionsSection.imageSrc(imageName)}}"

--- a/MediaGalleryUi/Test/Mftf/ActionGroup/SearchStandaloneMediaGalleryAdminDataGridByKeywordActionGroup.xml
+++ b/MediaGalleryUi/Test/Mftf/ActionGroup/SearchStandaloneMediaGalleryAdminDataGridByKeywordActionGroup.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="SearchStandaloneMediaGalleryAdminDataGridByKeywordActionGroup" extends="SearchAdminDataGridByKeywordActionGroup">
+        <annotations>
+            <description>EXTENDS: SearchAdminDataGridByKeywordActionGroup. Fills 'Search by keyword' on an Standalone Media Gallery Admin Grid page. Clicks on Submit Search.</description>
+        </annotations>
+        <arguments>
+            <argument name="keyword" type="string" defaultValue=""/>
+        </arguments>
+    </actionGroup>
+</actionGroups>

--- a/MediaGalleryUi/Test/Mftf/Section/AdminEnhancedMediaGalleryActionsSection.xml
+++ b/MediaGalleryUi/Test/Mftf/Section/AdminEnhancedMediaGalleryActionsSection.xml
@@ -12,5 +12,6 @@
         <element name="cancel" type="button" selector="[data-ui-id='cancel-button']"/>
         <element name="createFolder" type="button" selector="[data-ui-id='create-folder-button']"/>
         <element name="deleteFolder" type="button" selector="[data-ui-id='delete-folder-button']"/>
+        <element name="imageSrc" type="text" selector="//div[@class='masonry-image-column' and contains(@data-repeat-index, '0')]//img[contains(@src,'{{src}}')]" parameterized="true"/>
     </section>
 </sections>

--- a/MediaGalleryUi/Test/Mftf/Test/AdminStandaloneMediaGallerySearchByKeywordTest.xml
+++ b/MediaGalleryUi/Test/Mftf/Test/AdminStandaloneMediaGallerySearchByKeywordTest.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+    <test name="AdminStandaloneMediaGallerySearchByKeywordTest">
+        <annotations>
+            <features value="MediaGallery"/>
+            <stories value="User searches for an image using search by keyword from standalone media gallery"/>
+            <useCaseId value="https://github.com/magento/adobe-stock-integration/issues/1121"/>
+            <testCaseId value=" https://studio.cucumber.io/projects/131313/test-plan/folders/1337102/scenarios/4503803"/>
+            <title value="User searches for an image using search by keyword from standalone media gallery"/>
+            <description value="User searches for an image using search by keyword from standalone media gallery"/>
+            <severity value="CRITICAL"/>
+            <group value="media_gallery_ui"/>
+        </annotations>
+
+        <before>
+            <actionGroup ref="AdminLoginActionGroup" stepKey="loginAsAdmin"/>
+            <actionGroup ref="AdminOpenStandaloneMediaGalleryActionGroup" stepKey="openMediaGalleryForPage"/>
+        </before>
+        <after>
+            <actionGroup ref="ResetAdminDataGridToDefaultViewActionGroup" stepKey="resetAdminDataGridToDefaultView"/>
+            <actionGroup ref="AdminEnhancedMediaGalleryImageDeleteActionGroup" stepKey="deleteImage"/>
+        </after>
+        <actionGroup ref="AdminEnhancedMediaGallerySearchAdobeStockActionGroup" stepKey="openAdobeStockGrid"/>
+        <actionGroup ref="AdminAdobeStockExpandImagePreviewActionGroup" stepKey="expandImagePreview"/>
+        <grabAttributeFrom selector="{{AdminAdobeStockImagePreviewSection.image}}" userInput="alt" stepKey="grabImageName"/>
+        <click selector="{{AdminAdobeStockImagePreviewSection.savePreview}}" stepKey="clickSavePreviewButton"/>
+        <waitForPageLoad stepKey="waitForPromptModal"/>
+        <grabValueFrom selector="{{AdminAdobeStockImagePreviewSection.imageNameField}}" stepKey="grabImageFileName"/>
+        <click selector="{{AdminAdobeStockImagePreviewSection.confirm}}" stepKey="clickOnPopupConfirm"/>
+        <waitForPageLoad stepKey="waitForMediaGalleryOpen"/>
+        <actionGroup ref="SearchStandaloneMediaGalleryAdminDataGridByKeywordActionGroup" stepKey="searchImage">
+            <argument name="keyword" value="$grabImageName"/>
+        </actionGroup>
+        <actionGroup ref="AdminAssertImageInStandaloneMediaGalleryActionGroup" stepKey="assertImageIsAvailableInStandaloneGrid">
+            <argument name="imageName" value="$grabImageFileName"/>
+        </actionGroup>
+    </test>
+</tests>


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

This PR will add the MFTF test for search by keyword functionality for standalone media gallery

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/adobe-stock-integration#1121: [MFTF] Cover filtering images by their keywords in Standalone Media Gallery

