### PR TITLE
Fixed scrolling to filters

### DIFF
--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/related.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/related.js
@@ -253,7 +253,7 @@ define([
          * Scrolls user window to the filter bookmarks
          */
         scrollToFilter: function () {
-            $(this.filterBookmarksSelector).get(0).scrollIntoView({
+            $(this.preview().adobeStockModalSelector + ' ' + this.filterBookmarksSelector).get(0).scrollIntoView({
                 behavior: 'smooth',
                 block: 'center',
                 inline: 'nearest'


### PR DESCRIPTION
### Description (*)
Added adobe stock modal selector to the bookmarks selector for scrolling as with enhanced media gallery there are two bookmarks instances on the page

### Fixed Issues (if relevant)
1. Fixes magento/adobe-stock-integration#850: The "See more" button doesn't work when More images are loaded and the same image is previewed again

### Manual testing scenarios (*)
1. From Admin go to **Content** - **Pages**, click **Add New Page**
2. Expand **Content**,click **Show / Hide Editor**, select **Insert Image...**
3. Click **Search Adobe Stock**
4. Click, for example on the first image to open the Preview
5. Click **See more**
![see more link](https://user-images.githubusercontent.com/45624059/70308091-358b7a80-1813-11ea-9867-0ee94a7495a8.png)
6. From the updated grid, select the same image you've opened previously, and click **See more** 
