### PR TITLE
#891 - Fixed licensing image bug

### DIFF
--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/actions.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/actions.js
@@ -13,7 +13,8 @@ define([
     'Magento_AdobeStockImageAdminUi/js/action/licenseAndSave',
     'Magento_AdobeStockImageAdminUi/js/action/confirmQuota',
     'Magento_AdobeStockImageAdminUi/js/media-gallery',
-    'Magento_AdobeStockImageAdminUi/js/confirmation/buyCredits'
+    'Magento_AdobeStockImageAdminUi/js/confirmation/buyCredits',
+    'Magento_AdobeStockImageAdminUi/js/action/getLicenseStatus'
 ], function (
     Component,
     uiRegistry,
@@ -25,7 +26,8 @@ define([
     licenseAndSaveAction,
     confirmQuotaAction,
     mediaGallery,
-    buyCreditsConfirmation
+    buyCreditsConfirmation,
+    getLicenseStatus
 ) {
     'use strict';
 
@@ -364,7 +366,7 @@ define([
             }
 
             provider = uiRegistry.get('index = media_gallery_listing_data_source'),
-            dataStorage = provider.storage();
+                dataStorage = provider.storage();
 
             // this.subscriptionOnImageItems();
             dataStorage.clearRequests();
@@ -437,7 +439,6 @@ define([
                 record.title,
                 record.path,
                 record['content_type'],
-                this.isLicensed(),
                 this.isDownloaded()
             ).then(function (destinationPath) {
                 this.updateLicensedDisplayedRecord(destinationPath);
@@ -457,65 +458,66 @@ define([
          * @param {String} title
          * @param {String} path
          * @param {String} contentType
-         * @param {Boolean} isLicensed
          * @param {Boolean} isDownloaded
          * @return {window.Promise}
          */
-        licenseProcess: function (id, title, path, contentType, isLicensed, isDownloaded) {
+        licenseProcess: function (id, title, path, contentType, isDownloaded) {
             var deferred = $.Deferred();
 
-            $.ajaxSetup({
-                async: false
-            });
             this.login().login()
                 .then(function () {
-                    if (isLicensed) {
-                        saveLicensedAction(
-                            this.preview().saveLicensedAndDownloadUrl,
-                            id,
-                            title,
-                            path,
-                            contentType,
-                            this.getDestinationDirectoryPath()
-                        ).then(function (destinationPath) {
-                            deferred.resolve(destinationPath);
-                        }).fail(function (error) {
-                            deferred.reject(error);
-                        });
-                    } else {
-                        confirmQuotaAction(this.preview().confirmationUrl, id).then(function (data) {
-                            if (data.canLicense === false) {
-                                buyCreditsConfirmation(
-                                    this.preview().buyCreditsUrl,
-                                    title,
-                                    data.message
-                                );
+                    getLicenseStatus(
+                        this.overlay().getImagesUrl,
+                        [id]
+                    ).then(function (licensedInfo) {
+                        var isLicensed = licensedInfo[id] || false;
 
-                                return;
-                            }
-                            licenseAndSaveAction(
-                                this.preview().licenseAndDownloadUrl,
+                        if (isLicensed) {
+                            saveLicensedAction(
+                                this.preview().saveLicensedAndDownloadUrl,
                                 id,
                                 title,
                                 path,
                                 contentType,
-                                isDownloaded,
-                                data.message,
                                 this.getDestinationDirectoryPath()
                             ).then(function (destinationPath) {
                                 deferred.resolve(destinationPath);
                             }).fail(function (error) {
                                 deferred.reject(error);
                             });
-                        }.bind(this));
-                    }
-                    $.ajaxSetup({
-                        async: true
+                        } else {
+                            confirmQuotaAction(this.preview().confirmationUrl, id).then(function (data) {
+                                if (data.canLicense === false) {
+                                    buyCreditsConfirmation(
+                                        this.preview().buyCreditsUrl,
+                                        title,
+                                        data.message
+                                    );
+
+                                    return;
+                                }
+                                licenseAndSaveAction(
+                                    this.preview().licenseAndDownloadUrl,
+                                    id,
+                                    title,
+                                    path,
+                                    contentType,
+                                    isDownloaded,
+                                    data.message,
+                                    this.getDestinationDirectoryPath()
+                                ).then(function (destinationPath) {
+                                    deferred.resolve(destinationPath);
+                                }).fail(function (error) {
+                                    deferred.reject(error);
+                                });
+                            }.bind(this));
+                        }
+                    }.bind(this)).fail(function (error) {
+                        deferred.reject(error);
                     });
-                }.bind(this))
-                .fail(function (error) {
-                    deferred.reject(error);
-                });
+                }.bind(this)).fail(function (error) {
+                deferred.reject(error);
+            });
 
             return deferred.promise();
         },
@@ -558,7 +560,7 @@ define([
          * @returns {String}
          */
         getLicenseButtonTitle: function () {
-            return this.isDownloaded() ?  $.mage.__('License') : $.mage.__('License and Save');
+            return this.isDownloaded() ? $.mage.__('License') : $.mage.__('License and Save');
         },
 
         /**

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/mediaGallery/grid/columns/image/licenseActions.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/mediaGallery/grid/columns/image/licenseActions.js
@@ -7,9 +7,8 @@ define([
     'underscore',
     'Magento_MediaGalleryUi/js/grid/columns/image/actions',
     'Magento_MediaGalleryUi/js/action/getDetails',
-    'Magento_AdobeStockImageAdminUi/js/action/getLicenseStatus',
     'mage/translate'
-], function ($, _, Action, getDetails, getLicenseStatus) {
+], function ($, _, Action, getDetails) {
     'use strict';
 
     return Action.extend({
@@ -84,38 +83,26 @@ define([
          * @param {Number} imageId
          */
         getImageRecord: function (imageId) {
-            this.image().actions().login().login().then(function () {
-                getDetails(this.imageDetailsUrl, imageId).then(function (imageDetails) {
-                    var id = imageDetails['adobe_stock'][0].value;
+            getDetails(this.imageDetailsUrl, imageId).then(function (imageDetails) {
+                var id = imageDetails['adobe_stock'][0].value;
 
-                    getLicenseStatus(
-                        this.image().actions().overlay().getImagesUrl,
-                        [id]
-                    ).then(function (licensedInfo) {
-                        var isLicensed = licensedInfo[id] || false;
-
-                        this.image().actions().licenseProcess(
-                            id,
-                            imageDetails.title,
-                            imageDetails.path,
-                            imageDetails['content_type'],
-                            isLicensed,
-                            true
-                        ).then(function () {
-                            this.image().actions().login().getUserQuota();
-                            this.imageModel().reloadGrid();
-                            this.imageModel().addMessage('success', $.mage.__('The image has been licensed.'));
-                        }.bind(this)).fail(function (error) {
-                            if (error) {
-                                this.imageModel().addMessage('error', error);
-                            }
-                        });
-                    }.bind(this));
-                }.bind(this)).fail(function (message) {
-                    this.imageModel().addMessage('error', message);
+                this.image().actions().licenseProcess(
+                    id,
+                    imageDetails.title,
+                    imageDetails.path,
+                    imageDetails['content_type'],
+                    true
+                ).then(function () {
+                    this.image().actions().login().getUserQuota();
+                    this.imageModel().reloadGrid();
+                    this.imageModel().addMessage('success', $.mage.__('The image has been licensed.'));
+                }.bind(this)).fail(function (error) {
+                    if (error) {
+                        this.imageModel().addMessage('error', error);
+                    }
                 });
-            }.bind(this)).fail(function (error) {
-                this.imageModel().addMessage('error', error);
+            }.bind(this)).fail(function (message) {
+                this.imageModel().addMessage('error', message);
             });
         }
     });


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
Added the getLicenseStatus to the licenseProcess, the problem was that we were getting the isLicensed from the overlay object and that wasn't updated at the execution time, so now we are getting that information from the backend to avoid dependency on the component.

Also removed the login from the licenseAction.js since it is already part of the licenseProcess.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/adobe-stock-integration#891: [Bug] Attempt to license image the second time if user is not logged in when initiating the licensing process

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Follow the steps on #891 
2. It is also important to test the license from the media gallery since this change impacts there.
