### PR TITLE
ACL. If user doesn't have permission to "Save Preview", the 'Search Adobe Stock' button is displayed but doesn't work 

### DIFF
--- a/AdobeStockImageAdminUi/Ui/Component/Listing/SearchAdobeStockButton.php
+++ b/AdobeStockImageAdminUi/Ui/Component/Listing/SearchAdobeStockButton.php
@@ -9,6 +9,7 @@ namespace Magento\AdobeStockImageAdminUi\Ui\Component\Listing;
 
 use Magento\AdobeStockImageAdminUi\Model\IsAdobeStockIntegrationEnabled;
 use Magento\Framework\View\Element\UiComponent\Control\ButtonProviderInterface;
+use Magento\Framework\AuthorizationInterface;
 
 /**
  * Adobe Stock Search Button
@@ -21,11 +22,24 @@ class SearchAdobeStockButton implements ButtonProviderInterface
     private $isAdobeStockIntegrationEnabled;
 
     /**
+     * Acl for images preview
+     */
+    private const ACL_SAVE_PREVIEW_IMAGES = 'Magento_AdobeStockImageAdminUi::save_preview_images';
+
+    /**
+     * @var AuthorizationInterface
+     */
+    private $authorization;
+  
+    /**
+     * @param AuthorizationInterface $authorization
      * @param IsAdobeStockIntegrationEnabled $isAdobeStockIntegrationEnabled
      */
     public function __construct(
+        AuthorizationInterface $authorization,
         IsAdobeStockIntegrationEnabled $isAdobeStockIntegrationEnabled
     ) {
+        $this->authorization = $authorization;
         $this->isAdobeStockIntegrationEnabled = $isAdobeStockIntegrationEnabled;
     }
 
@@ -34,7 +48,7 @@ class SearchAdobeStockButton implements ButtonProviderInterface
      */
     public function getButtonData()
     {
-        if (!$this->isAdobeStockIntegrationEnabled->execute()) {
+        if (!$this->isAllowed()) {
             return [];
         }
 
@@ -44,5 +58,14 @@ class SearchAdobeStockButton implements ButtonProviderInterface
             'class' => 'media-gallery-actions-buttons',
             'on_click' => 'jQuery(".adobe-search-images-modal").trigger("openModal");'
         ];
+    }
+
+    /**
+     * Verify if  Adobe Stock Search button allowed
+     */
+    private function isAllowed(): bool
+    {
+        return $this->isAdobeStockIntegrationEnabled->execute() &&
+            $this->authorization->isAllowed(self::ACL_SAVE_PREVIEW_IMAGES);
     }
 }


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/adobe-stock-integration#1424: ACL. If user doesn't have permission to "Save Preview", the 'Search Adobe Stock' button is displayed but doesn't work 
2. ...

### Manual testing scenarios (*)
Same as in issue

Expected result (*)
Search Adobe Stock button is not available
