### PR TITLE
Disable related content tabs arrow navigation

### DIFF
--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/related.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/related.js
@@ -53,7 +53,7 @@ define([
         /**
          * Disable keydown event for related content tabs
          */
-        disableTabsKeyDown: function () {
+        disableTabsKeyDownEvent: function () {
             if ($(this.tabsContainerId + ' li[role=tab]').length === 0) {
                 setTimeout(function () {
                     this.disableTabsKeyDown();

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/related.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/related.js
@@ -5,8 +5,7 @@
 define([
     'uiComponent',
     'underscore',
-    'jquery',
-    'mage/backend/tabs'
+    'jquery'
 ], function (Component, _, $) {
     'use strict';
 
@@ -16,6 +15,7 @@ define([
             filterChipsProvider: 'componentType = filters, ns = ${ $.ns }',
             filterBookmarksSelector: '.admin__data-grid-action-bookmarks',
             tabImagesLimit: 4,
+            tabsContainerId: '#adobe-stock-tabs',
             serieFilterValue: '',
             modelFilterValue: '',
             selectedTab: null,
@@ -48,6 +48,19 @@ define([
             this.filterChips().updateActive();
 
             return this;
+        },
+
+        /**
+         * Disable keydown event for related content tabs
+         */
+        disableTabsKeyDown: function () {
+            if ($(this.tabsContainerId + ' li[role=tab]').length === 0) {
+                setTimeout(function () {
+                    this.disableTabsKeyDown();
+                }.bind(this), 100);
+            } else {
+                $(this.tabsContainerId + ' li[role=tab]').unbind('keydown');
+            }
         },
 
         /**

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/related.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/related.js
@@ -56,7 +56,7 @@ define([
         disableTabsKeyDownEvent: function () {
             if ($(this.tabsContainerId + ' li[role=tab]').length === 0) {
                 setTimeout(function () {
-                    this.disableTabsKeyDown();
+                    this.disableTabsKeyDownEvent();
                 }.bind(this), 100);
             } else {
                 $(this.tabsContainerId + ' li[role=tab]').unbind('keydown');

--- a/AdobeStockImageAdminUi/view/adminhtml/web/template/grid/column/preview/related.html
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/template/grid/column/preview/related.html
@@ -13,7 +13,7 @@
                     destination: '#adobe-stock-tabs-content',
                     shadowTabs: [],
                 }
-            }">
+            }" afterRender="disableTabsKeyDown()">
         <ul class="tabs-horiz">
             <li if="showSeriesTab($row())">
                 <a id="series_tab" attr="'href': '#series_content_' + $row().id">

--- a/AdobeStockImageAdminUi/view/adminhtml/web/template/grid/column/preview/related.html
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/template/grid/column/preview/related.html
@@ -13,7 +13,7 @@
                     destination: '#adobe-stock-tabs-content',
                     shadowTabs: [],
                 }
-            }" afterRender="disableTabsKeyDown()">
+            }" afterRender="disableTabsKeyDownEvent()">
         <ul class="tabs-horiz">
             <li if="showSeriesTab($row())">
                 <a id="series_tab" attr="'href': '#series_content_' + $row().id">


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Removing "keydown" event from related content tabs as there is conflict with same key binding for image preview component

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/adobe-stock-integration#1405: Uncaught Error: jQuery UI..." error appears in dev console if select "More from this Model" and hit arrow key on keyboard


### Manual testing scenarios (*)

1. Go to **Content - Media Gallery**, click **Search Adobe Stock**
2. Select an image from Adobe Stock grid to open its Preview
3. Click **More from this model** tab
4. Hit _Right_ or _Left_ arrow key on your keyboard
5. Open dev console 

### Expected result (*)
Next image preview is displayed
