### PR TITLE
Fix  Open Images uploaded outside of media gallery are not reflected …

### DIFF
--- a/MediaGalleryIntegration/Plugin/SaveBaseCategoryImageInformation.php
+++ b/MediaGalleryIntegration/Plugin/SaveBaseCategoryImageInformation.php
@@ -84,7 +84,7 @@ class SaveBaseCategoryImageInformation
     {
         $absolutePath = $this->storage->getCmsWysiwygImages()->getStorageRoot() . $imagePath;
         $file = $this->splFileInfoFactory->create($absolutePath);
-        $tmpPath = $subject->getBaseTmpPath() . '/'. $file->getFileName();
+        $tmpPath = $subject->getBaseTmpPath() . '/' . $file->getFileName();
         $tmpAssets = $this->getAssetsByPaths->execute([$tmpPath]);
         
         if (!empty($tmpAssets)) {

--- a/MediaGalleryIntegration/Plugin/SaveBaseCategoryImageInformation.php
+++ b/MediaGalleryIntegration/Plugin/SaveBaseCategoryImageInformation.php
@@ -61,6 +61,7 @@ class SaveBaseCategoryImageInformation
      *
      * @param ImageUploader $subject
      * @param string $imagePath
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function afterMoveFileFromTmp(ImageUploader $subject, string $imagePath): string
     {

--- a/MediaGalleryIntegration/Plugin/SaveBaseCategoryImageInformation.php
+++ b/MediaGalleryIntegration/Plugin/SaveBaseCategoryImageInformation.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\MediaGalleryIntegration\Plugin;
+
+use Magento\MediaGalleryApi\Api\SaveAssetsInterface;
+use Magento\Catalog\Model\ImageUploader;
+use Magento\MediaGallerySynchronization\Model\CreateAssetFromFile;
+use Magento\Cms\Model\Wysiwyg\Images\Storage;
+use Magento\MediaGalleryUi\Model\Filesystem\SplFileInfoFactory;
+
+/**
+ * Save base category image by SaveAssetsInterface.
+ */
+class SaveBaseCategoryImageInformation
+{
+    /**
+     * @var SplFileInfoFactory
+     */
+    private $splFileInfoFactory;
+    
+    /**
+     * @var SaveAssetsInterface
+     */
+    private $saveAsset;
+
+    /**
+     * @var CreateAssetFromFile
+     */
+    private $createAssetFromFile;
+
+    /**
+     * @var Storage
+     */
+    private $storage;
+
+    /**
+     * @param SplFileInfoFactory $splFileInfoFactory
+     * @param Storage $storage
+     * @param CreateAssetFromFile $createAssetFromFile
+     * @param SaveAssetsInterface $saveAsset
+     */
+    public function __construct(
+        SplFileInfoFactory $splFileInfoFactory,
+        CreateAssetFromFile $createAssetFromFile,
+        SaveAssetsInterface $saveAsset,
+        Storage $storage
+    ) {
+        $this->splFileInfoFactory = $splFileInfoFactory;
+        $this->createAssetFromFile = $createAssetFromFile;
+        $this->saveAsset = $saveAsset;
+        $this->storage = $storage;
+    }
+
+    /**
+     * Save base category image information after movinf from tmp folder.
+     *
+     * @param ImageUploader $subject
+     * @param string $imagePath
+     */
+    public function afterMoveFileFromTmp(ImageUploader $subject, string $imagePath): string
+    {
+        $absolutePath = $this->storage->getCmsWysiwygImages()->getStorageRoot() . $imagePath;
+        $file = $this->splFileInfoFactory->create($absolutePath);
+        $this->saveAsset->execute([$this->createAssetFromFile->execute($file)]);
+        $this->storage->resizeFile($absolutePath);
+
+        return $imagePath;
+    }
+}

--- a/MediaGalleryIntegration/Plugin/SaveBaseCategoryImageInformation.php
+++ b/MediaGalleryIntegration/Plugin/SaveBaseCategoryImageInformation.php
@@ -40,9 +40,9 @@ class SaveBaseCategoryImageInformation
 
     /**
      * @param SplFileInfoFactory $splFileInfoFactory
-     * @param Storage $storage
      * @param CreateAssetFromFile $createAssetFromFile
      * @param SaveAssetsInterface $saveAsset
+     * @param Storage $storage
      */
     public function __construct(
         SplFileInfoFactory $splFileInfoFactory,
@@ -57,7 +57,7 @@ class SaveBaseCategoryImageInformation
     }
 
     /**
-     * Save base category image information after movinf from tmp folder.
+     * Saves base category image information after moving from tmp folder.
      *
      * @param ImageUploader $subject
      * @param string $imagePath

--- a/MediaGalleryIntegration/Plugin/SaveImageInformation.php
+++ b/MediaGalleryIntegration/Plugin/SaveImageInformation.php
@@ -106,11 +106,11 @@ class SaveImageInformation
     }
 
     /**
-      * Can asset be saved with provided path
-      *
-      * @param string $path
-      * @return bool
-      */
+     * Can asset be saved with provided path
+     *
+     * @param string $path
+     * @return bool
+     */
     private function isApplicable(string $path): bool
     {
         try {

--- a/MediaGalleryIntegration/Plugin/SaveImageInformation.php
+++ b/MediaGalleryIntegration/Plugin/SaveImageInformation.php
@@ -12,12 +12,23 @@ use Magento\Framework\File\Uploader;
 use Magento\MediaGallerySynchronization\Model\CreateAssetFromFile;
 use Magento\Cms\Model\Wysiwyg\Images\Storage;
 use Magento\MediaGallerySynchronization\Model\Filesystem\SplFileInfoFactory;
+use Magento\MediaGalleryApi\Api\IsPathBlacklistedInterface;
+use Psr\Log\LoggerInterface;
+use Magento\Framework\Filesystem;
+use Magento\Framework\App\Filesystem\DirectoryList;
 
 /**
  * Save image information by SaveAssetsInterface.
  */
 class SaveImageInformation
 {
+    private const IMAGE_FILE_NAME_PATTERN = '#\.(jpg|jpeg|gif|png)$# i';
+
+    /**
+     * @var IsPathBlacklistedInterface
+     */
+    private $isPathBlacklisted;
+    
     /**
      * @var SplFileInfoFactory
      */
@@ -39,21 +50,40 @@ class SaveImageInformation
     private $storage;
 
     /**
+     * @var LoggerInterface
+     */
+    private $log;
+
+    /**
+     * @var Filesystem
+     */
+    private $filesystem;
+    
+    /**
+     * @param Filesystem $filesystem
+     * @param LoggerInterface $log
+     * @param IsPathBlacklistedInterface $isPathBlacklisted
      * @param SplFileInfoFactory $splFileInfoFactory
      * @param CreateAssetFromFile $createAssetFromFile
      * @param SaveAssetsInterface $saveAsset
      * @param Storage $storage
      */
     public function __construct(
+        Filesystem $filesystem,
+        LoggerInterface $log,
+        IsPathBlacklistedInterface $isPathBlacklisted,
         SplFileInfoFactory $splFileInfoFactory,
         CreateAssetFromFile $createAssetFromFile,
         SaveAssetsInterface $saveAsset,
         Storage $storage
     ) {
+        $this->log = $log;
+        $this->isPathBlacklisted = $isPathBlacklisted;
         $this->splFileInfoFactory = $splFileInfoFactory;
         $this->createAssetFromFile = $createAssetFromFile;
         $this->saveAsset = $saveAsset;
         $this->storage = $storage;
+        $this->filesystem = $filesystem;
     }
 
     /**
@@ -66,9 +96,31 @@ class SaveImageInformation
     public function afterSave(Uploader $subject, array $result): array
     {
         $file = $this->splFileInfoFactory->create($result['path'] . '/' . $result['file']);
+        if (!$this->isApplicable($file->getPathName())) {
+            return $result;
+        }
         $this->saveAsset->execute([$this->createAssetFromFile->execute($file)]);
         $this->storage->resizeFile($result['path'] . '/' . $result['file']);
 
         return $result;
+    }
+
+    /**
+      * Can asset be saved with provided path
+      *
+      * @param string $path
+      * @return bool
+      */
+    private function isApplicable(string $path): bool
+    {
+        try {
+            $relativePath = $this->filesystem->getDirectoryRead(DirectoryList::MEDIA)->getRelativePath($path);
+            return $relativePath
+                && !$this->isPathBlacklisted->execute($relativePath)
+                && preg_match(self::IMAGE_FILE_NAME_PATTERN, $path);
+        } catch (\Exception $exception) {
+            $this->log->critical($exception);
+            return false;
+        }
     }
 }

--- a/MediaGalleryIntegration/Plugin/SaveImageInformation.php
+++ b/MediaGalleryIntegration/Plugin/SaveImageInformation.php
@@ -87,7 +87,7 @@ class SaveImageInformation
     }
 
     /**
-     * Saves base category image information after moving from tmp folder.
+     * Saves asset to media gallery after save image.
      *
      * @param Uploader $subject
      * @param array $result

--- a/MediaGalleryIntegration/composer.json
+++ b/MediaGalleryIntegration/composer.json
@@ -4,7 +4,14 @@
     "require": {
         "php": "~7.3.0||~7.4.0",
         "magento/framework": "*",
-        "magento/module-media-gallery-ui-api": "*"
+        "magento/module-media-gallery-ui-api": "*",
+        "magento/module-cms": "*",
+        "magento/module-media-gallery-api": "*",
+        "magento/module-media-gallery-ui": "*",
+        "magento/module-media-gallery-synchronization": "*"
+    },
+    "suggest": {
+        "magento/module-catalog": "*"
     },
     "type": "magento2-module",
     "license": [

--- a/MediaGalleryIntegration/composer.json
+++ b/MediaGalleryIntegration/composer.json
@@ -7,7 +7,6 @@
         "magento/module-media-gallery-ui-api": "*",
         "magento/module-cms": "*",
         "magento/module-media-gallery-api": "*",
-        "magento/module-media-gallery-ui": "*",
         "magento/module-media-gallery-synchronization": "*"
     },
     "suggest": {

--- a/MediaGalleryIntegration/etc/adminhtml/di.xml
+++ b/MediaGalleryIntegration/etc/adminhtml/di.xml
@@ -11,6 +11,9 @@
             <argument name="url" xsi:type="object">Magento\MediaGalleryIntegration\Model\OpenDialogUrlProvider</argument>
         </arguments>
     </type>
+    <type name="Magento\Framework\File\Uploader">
+        <plugin name="save_category_image" type="Magento\MediaGalleryIntegration\Plugin\SaveImageInformation"/>
+    </type>
     <type name="Magento\Catalog\Model\ImageUploader">
         <plugin name="save_category_image" type="Magento\MediaGalleryIntegration\Plugin\SaveBaseCategoryImageInformation"/>
     </type>

--- a/MediaGalleryIntegration/etc/adminhtml/di.xml
+++ b/MediaGalleryIntegration/etc/adminhtml/di.xml
@@ -11,4 +11,7 @@
             <argument name="url" xsi:type="object">Magento\MediaGalleryIntegration\Model\OpenDialogUrlProvider</argument>
         </arguments>
     </type>
+    <type name="Magento\Catalog\Model\ImageUploader">
+        <plugin name="save_category_image" type="Magento\MediaGalleryIntegration\Plugin\SaveBaseCategoryImageInformation"/>
+    </type>
 </config>

--- a/MediaGalleryIntegration/etc/adminhtml/di.xml
+++ b/MediaGalleryIntegration/etc/adminhtml/di.xml
@@ -12,7 +12,7 @@
         </arguments>
     </type>
     <type name="Magento\Framework\File\Uploader">
-        <plugin name="save_category_image" type="Magento\MediaGalleryIntegration\Plugin\SaveImageInformation"/>
+        <plugin name="save_asset_image" type="Magento\MediaGalleryIntegration\Plugin\SaveImageInformation"/>
     </type>
     <type name="Magento\Catalog\Model\ImageUploader">
         <plugin name="save_category_image" type="Magento\MediaGalleryIntegration\Plugin\SaveBaseCategoryImageInformation"/>

--- a/MediaGallerySynchronization/Model/Filesystem/SplFileInfoFactory.php
+++ b/MediaGallerySynchronization/Model/Filesystem/SplFileInfoFactory.php
@@ -5,7 +5,7 @@
  */
 declare(strict_types=1);
 
-namespace Magento\MediaGalleryUi\Model\Filesystem;
+namespace Magento\MediaGallerySynchronization\Model\Filesystem;
 
 /**
  * Creates a new file based on the file name parameter.

--- a/MediaGalleryUi/Model/UploadImage.php
+++ b/MediaGalleryUi/Model/UploadImage.php
@@ -12,7 +12,7 @@ use Magento\Framework\App\Filesystem\DirectoryList;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Filesystem;
 use Magento\MediaGallerySynchronizationApi\Api\SynchronizeFilesInterface;
-use Magento\MediaGalleryUi\Model\Filesystem\SplFileInfoFactory;
+use Magento\MediaGallerySynchronization\Model\Filesystem\SplFileInfoFactory;
 
 /**
  * Uploads an image to storage

--- a/MediaGalleryUi/Test/Mftf/Test/AdminMediaGalleryUploadCategoryImageTest.xml
+++ b/MediaGalleryUi/Test/Mftf/Test/AdminMediaGalleryUploadCategoryImageTest.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+    <test name="AdminMediaGalleryUploadCategoryImageTest">
+        <annotations>
+            <features value="AdminMediaGalleryImagePanel"/>
+            <useCaseId value="https://github.com/magento/adobe-stock-integration/issues/1435"/>
+            <title value="User uploads image outside of the Media Gallery"/>
+            <testCaseId value="https://studio.cucumber.io/projects/131313/test-plan/folders/943908/scenarios/4836631"/>
+            <description value="User uploads image outside of the Media Gallery"/>
+            <severity value="CRITICAL"/>
+            <group value="media_gallery_ui"/>
+        </annotations>
+        <before>
+            <createData entity="SimpleSubCategory" stepKey="category"/>
+            <actionGroup ref="AdminLoginActionGroup" stepKey="loginAsAdmin"/>
+        </before>
+        <after>
+            <actionGroup ref="AdminOpenStandaloneMediaGalleryActionGroup" stepKey="openStandaloneMediaGallery"/>
+            <actionGroup ref="AdminEnhancedMediaGalleryViewImageDetails" stepKey="viewContentImageDetails"/>
+            <actionGroup ref="AdminEnhancedMediaGalleryImageDetailsDeleteActionGroup" stepKey="deleteCategoryImage"/>
+            <actionGroup ref="AdminEnhancedMediaGalleryViewImageDetails" stepKey="viewCategoryImageDetails"/>
+            <deleteData createDataKey="category" stepKey="deleteCategory"/>
+        </after>
+        <actionGroup ref="AdminOpenCategoryPageActionGroup" stepKey="openCategoryPage"/>
+        <actionGroup ref="AdminCategoriesOpenCategoryActionGroup" stepKey="openCategory">
+            <argument name="category" value="$$category$$"/>
+        </actionGroup>
+        <actionGroup ref="AddCategoryImageActionGroup" stepKey="addCategoryImage"/>
+        <actionGroup ref="AdminSaveCategoryFormActionGroup" stepKey="saveCategoryForm"/>
+        <actionGroup ref="AdminOpenMediaGalleryFromCategoryImageUploaderActionGroup" stepKey="openMediaGalleryFromImageUploader"/>
+        <actionGroup ref="AdminMediaGalleryAssertImageInGridActionGroup" stepKey="assertImageInGrid">
+            <argument name="image" value="ProductImage"/>
+        </actionGroup>
+    </test>
+</tests>

--- a/MediaGalleryUi/Test/Mftf/Test/AdminMediaGalleryUploadCategoryImageTest.xml
+++ b/MediaGalleryUi/Test/Mftf/Test/AdminMediaGalleryUploadCategoryImageTest.xml
@@ -25,7 +25,6 @@
             <actionGroup ref="AdminOpenStandaloneMediaGalleryActionGroup" stepKey="openStandaloneMediaGallery"/>
             <actionGroup ref="AdminEnhancedMediaGalleryViewImageDetails" stepKey="viewContentImageDetails"/>
             <actionGroup ref="AdminEnhancedMediaGalleryImageDetailsDeleteActionGroup" stepKey="deleteCategoryImage"/>
-            <actionGroup ref="AdminEnhancedMediaGalleryViewImageDetails" stepKey="viewCategoryImageDetails"/>
             <deleteData createDataKey="category" stepKey="deleteCategory"/>
         </after>
         <actionGroup ref="AdminOpenCategoryPageActionGroup" stepKey="openCategoryPage"/>

--- a/MediaGalleryUi/Test/Unit/Model/UploadImageTest.php
+++ b/MediaGalleryUi/Test/Unit/Model/UploadImageTest.php
@@ -14,7 +14,7 @@ use Magento\Framework\Filesystem;
 use Magento\Framework\Filesystem\Directory\Read;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Magento\MediaGallerySynchronizationApi\Api\SynchronizeFilesInterface;
-use Magento\MediaGalleryUi\Model\Filesystem\SplFileInfoFactory;
+use Magento\MediaGallerySynchronization\Model\Filesystem\SplFileInfoFactory;
 use Magento\MediaGalleryUi\Model\UploadImage;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;


### PR DESCRIPTION
…in the media gallery

<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/adobe-stock-integration#1428: Images uploaded outside of media gallery are not reflected in the media gallery
2. Fixes magento/adobe-stock-integration#1435: [MFTF] Cover uploading images outside of the Media Gallery


### Manual testing scenarios (*)
1. Login to Admin panel
2. Go to Catalog -> Category
3. Upload the Category image using the "Upload button"
4. Save the category
5. Open Media Gallery (i.e. using "Select from Gallery" button for the same Category image field)
6. Go to catalog/category folder in the Media Gallery

**The image saved for the category should be present in the media gallery**
