### PR TITLE
#1432 :- Remove the "Get User Profile" ACL

### DIFF
--- a/AdobeIms/Controller/Adminhtml/User/Profile.php
+++ b/AdobeIms/Controller/Adminhtml/User/Profile.php
@@ -33,7 +33,7 @@ class Profile extends Action implements HttpGetActionInterface
     /**
      * @see _isAllowed()
      */
-    public const ADMIN_RESOURCE = 'Magento_AdobeIms::profile';
+    public const ADMIN_RESOURCE = 'Magento_AdobeIms::login';
 
     /**
      * @var UserContextInterface

--- a/AdobeIms/etc/acl.xml
+++ b/AdobeIms/etc/acl.xml
@@ -14,7 +14,6 @@
                         <resource id="Magento_AdobeIms::actions" title="Actions" translate="title">
                             <resource id="Magento_AdobeIms::login" title="Login" translate="title"/>
                             <resource id="Magento_AdobeIms::logout" title="Logout" translate="title"/>
-                            <resource id="Magento_AdobeIms::profile" title="Get User Profile" translate="title"/>
                         </resource>
                     </resource>
                 </resource>

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Adobe Stock Integration provides a searchable interface in the Magento Admin to 
 
 - Complete documentation located on the project [wiki pages](https://github.com/magento/adobe-stock-integration/wiki):
   - Project [roadmap](https://github.com/magento/adobe-stock-integration/wiki/Adobe-Stock-Image-Integration-Roadmap) contains information about project phases and stories for each phase 
-  - How to start local development described in the [installation guide](https://github.com/magento/adobe-stock-integration/wiki/Installation-Guide)
+  - How to start local development described in the [installation guide](https://github.com/magento/adobe-stock-integration/wiki/Installation)
   - How to [run the project tests](https://github.com/magento/adobe-stock-integration/wiki/Run-the-Tests)
 
 ## Community Engineering Slack


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR will remove the ACL for the user profile and fixed the broken installation link in README.md
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/adobe-stock-integration#1432: Remove the "Get User Profile" ACL

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
### Expected Result
![image](https://user-images.githubusercontent.com/39480008/84361770-c2abf380-abe9-11ea-908b-6774961a9989.png)
