### PR TITLE
Verify if current_tree_path folder exists on jstree initialization

### DIFF
--- a/MediaGalleryUi/view/adminhtml/web/js/directory/directories.js
+++ b/MediaGalleryUi/view/adminhtml/web/js/directory/directories.js
@@ -62,9 +62,10 @@ define([
                                 this.directoryTree().createDirectoryUrl,
                                 [this.getNewFolderPath(folderName)]
                             ).then(function () {
-                                this.directoryTree().reloadJsTree();
-                                $(this.directoryTree().directoryTreeSelector).on('loaded.jstree', function () {
-                                    this.directoryTree().locateNode(this.getNewFolderPath(folderName));
+                                this.directoryTree().reloadJsTree().then(function () {
+                                    $(this.directoryTree().directoryTreeSelector).on('loaded.jstree', function () {
+                                        this.directoryTree().locateNode(this.getNewFolderPath(folderName));
+                                    }.bind(this));
                                 }.bind(this));
 
                             }.bind(this)).fail(function (error) {

--- a/MediaGalleryUi/view/adminhtml/web/js/directory/directoryTree.js
+++ b/MediaGalleryUi/view/adminhtml/web/js/directory/directoryTree.js
@@ -377,8 +377,8 @@ define([
             this.getJsonTree().then(function (data) {
                 this.createTree(data);
                 this.overrideMultiselectBehavior();
-                $(this.directoryTreeSelector).on('select_node.jstree', function (element, data) {
-                    var path = $(data.rslt.obj).data('path');
+                $(this.directoryTreeSelector).on('select_node.jstree', function (element, object) {
+                    var path = $(object.rslt.obj).data('path');
 
                     this.setActiveNodeFilter(path);
                 }.bind(this));

--- a/MediaGalleryUi/view/adminhtml/web/js/directory/directoryTree.js
+++ b/MediaGalleryUi/view/adminhtml/web/js/directory/directoryTree.js
@@ -60,8 +60,8 @@ define([
             this.getJsonTree().then(function (data) {
                 this.createFolderIfNotExists(data).then(function (isFolderCreated) {
                     if (isFolderCreated) {
-                        this.getJsonTree().then(function (data) {
-                            this.createTree(data);
+                        this.getJsonTree().then(function (newData) {
+                            this.createTree(newData);
                         }.bind(this));
                     } else {
                         this.createTree(data);
@@ -101,7 +101,7 @@ define([
                         deferred.resolve({
                             result: true
                         });
-                    }.bind(this));
+                    });
                 } else {
                     deferred.resolve({
                         result: false
@@ -372,16 +372,21 @@ define([
          * Reload jstree and update jstree events
          */
         reloadJsTree: function () {
-            $.ajaxSetup({
-                async: false
-            });
+            var deferred = $.Deferred();
 
-            this.getJsonTree();
-            this.initEvents();
+            this.getJsonTree().then(function (data) {
+                this.createTree(data);
+                this.overrideMultiselectBehavior();
+                $(this.directoryTreeSelector).on('select_node.jstree', function (element, data) {
+                    var path = $(data.rslt.obj).data('path');
 
-            $.ajaxSetup({
-                async: true
-            });
+                    this.setActiveNodeFilter(path);
+                }.bind(this));
+
+                deferred.resolve();
+            }.bind(this));
+
+            return deferred.promise();
         },
 
         /**

--- a/MediaGalleryUi/view/adminhtml/web/js/directory/directoryTree.js
+++ b/MediaGalleryUi/view/adminhtml/web/js/directory/directoryTree.js
@@ -71,7 +71,7 @@ define([
                     createDirectory(
                         this.createDirectoryUrl,
                         this.convertPathToPathsArray(decodedPath)
-                    ).then(function () {
+                    ).always(function () {
                         this.reloadJsTree();
                     }.bind(this));
                 }


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/adobe-stock-integration#1406: 400 Post error appears each time when using _wysiwyg_ or changing _catalog/category_ image
2. ...

### Manual testing scenarios (*)
1. Go to **Content - Media Gallery**
2. Verify that there are no _/wysiwyg_ and _Catalog/category_ Directories
3. Go to **Catalog - Categories**
4. Click **Select from Gallery** button 
_the folder Catalog/category_ Directory appeared and selected in the folder tree_
5.  Observe the dev console 

**No errors in dev console** 
