### PR TITLE
Use the preidentified image for identification for ViewAdobeStockDetailsTests

### DIFF
--- a/AdobeStockImageAdminUi/Test/Mftf/ActionGroup/AdminAdobeStockExpandImagePreviewActionGroup.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/ActionGroup/AdminAdobeStockExpandImagePreviewActionGroup.xml
@@ -10,7 +10,7 @@
               xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
     <actionGroup name="AdminAdobeStockExpandImagePreviewActionGroup">
         <annotations>
-            <description>Expands image preview by provided selector, default value first image in grid</description>
+            <description>Expands first image in grid.</description>
         </annotations>
         <conditionalClick stepKey="closeImagePreview"
                           selector="{{AdminAdobeStockImagePreviewSection.close}}"

--- a/AdobeStockImageAdminUi/Test/Mftf/ActionGroup/AdminAdobeStockExpandImagePreviewActionGroup.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/ActionGroup/AdminAdobeStockExpandImagePreviewActionGroup.xml
@@ -9,6 +9,9 @@
 <actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
               xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
     <actionGroup name="AdminAdobeStockExpandImagePreviewActionGroup">
+        <annotations>
+            <description>Expands image preview by provided selector, default value first image in grid</description>
+        </annotations>
         <conditionalClick stepKey="closeImagePreview"
                           selector="{{AdminAdobeStockImagePreviewSection.close}}"
                           dependentSelector="{{AdminAdobeStockImagePreviewSection.close}}"

--- a/AdobeStockImageAdminUi/Test/Mftf/Data/AdobeStockImageData.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Data/AdobeStockImageData.xml
@@ -21,7 +21,7 @@
     <entity name="AdobeStockUnlicensedImage">
         <data key="id">{{_CREDS.magento/adobe_stock_not_licensed_image}}</data>
         <data key="status">Unlicensed</data>
-        <data key="category">People</data>
-        <data key="author">NajmiArif</data>
+        <data key="category">Castles</data>
+        <data key="author">gam16</data>
     </entity>
 </entities>

--- a/AdobeStockImageAdminUi/Test/Mftf/Section/AdminAdobeStockSection.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Section/AdminAdobeStockSection.xml
@@ -13,7 +13,7 @@
         <element name="unlicensedImageLabel" type="button" selector="//span[text()='Unlicensed']"/>
         <element name="modal" type="block" selector="aside.adobe-stock-modal"/>
         <element name="panelTitle" type="block" selector="[data-role=title]"/>
-        <element name="searchInput" type="input" selector="input.data-grid-search-control"/>
+        <element name="searchInput" type="input" selector="//div[@class='adobe-stock-images-search-modal-content']//input[contains(@class, 'data-grid-search-control')]"/>
         <element name="firstImageInGrid" type="block" selector="[data-role=grid-wrapper] img[data-role=thumbnail]"/>
         <element name="searchButton" type="button" selector="#words + button.action-submit"/>
         <element name="imageSrc" type="text" selector="//div[@class='masonry-image-column' and contains(@data-repeat-index, '0')]//img[@src='{{src}}']" parameterized="true"/>

--- a/AdobeStockImageAdminUi/Test/Mftf/Test/AdminMediaGalleryViewAdobeStockDetailsTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/AdminMediaGalleryViewAdobeStockDetailsTest.xml
@@ -26,6 +26,9 @@
         </after>
 
         <actionGroup ref="AdminEnhancedMediaGallerySearchAdobeStockActionGroup" stepKey="openAdobeStockGrid"/>
+        <actionGroup ref="AdminSearchImagesOnModalActionGroup" stepKey="searchForUnlicensedImage">
+            <argument name="query" value="{{AdobeStockUnlicensedImage.id}}"/>
+        </actionGroup>
         <actionGroup ref="AdminAdobeStockExpandImagePreviewActionGroup" stepKey="expandImagePreview"/>
         <actionGroup ref="AdminAdobeStockSavePreviewActionGroup" stepKey="saveImagePreview"/>
         <actionGroup ref="AdminSaveAdobeStockImagePreviewActionGroup" stepKey="confirmSaveImagePreview"/>

--- a/AdobeStockImageAdminUi/Test/Mftf/Test/AdminMediaGalleryViewAdobeStockDetailsTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/AdminMediaGalleryViewAdobeStockDetailsTest.xml
@@ -9,9 +9,6 @@
 <tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
     <test name="AdminMediaGalleryViewAdobeStockDetailsTest">
         <annotations>
-            <skip>
-                <issueId value="https://github.com/magento/adobe-stock-integration/issues/1438"/>
-            </skip>
             <features value="AdobeStockMediaGallery"/>
             <useCaseId value="https://github.com/magento/adobe-stock-integration/issues/428"/>
             <title value="View adobe stock image details"/>

--- a/AdobeStockImageAdminUi/Test/Mftf/Test/AdminStandaloneMediaGalleryViewAdobeStockDetailsTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/AdminStandaloneMediaGalleryViewAdobeStockDetailsTest.xml
@@ -27,6 +27,9 @@
         </after>
 
         <actionGroup ref="AdminEnhancedMediaGallerySearchAdobeStockActionGroup" stepKey="openAdobeStockGrid"/>
+        <actionGroup ref="AdminSearchImagesOnModalActionGroup" stepKey="searchForUnlicensedImage">
+            <argument name="query" value="{{AdobeStockUnlicensedImage.id}}"/>
+        </actionGroup>
         <actionGroup ref="AdminAdobeStockExpandImagePreviewActionGroup" stepKey="expandImagePreview"/>
         <actionGroup ref="AdminAdobeStockSavePreviewActionGroup" stepKey="saveImagePreview"/>
         <actionGroup ref="AdminSaveAdobeStockImagePreviewActionGroup" stepKey="confirmSaveImagePreview"/>

--- a/AdobeStockImageAdminUi/Test/Mftf/Test/AdminStandaloneMediaGalleryViewAdobeStockDetailsTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/AdminStandaloneMediaGalleryViewAdobeStockDetailsTest.xml
@@ -9,9 +9,6 @@
 <tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
     <test name="AdminStandaloneMediaGalleryViewAdobeStockDetailsTest">
         <annotations>
-            <skip>
-                <issueId value="https://github.com/magento/adobe-stock-integration/issues/1438"/>
-            </skip>
             <features value="AdobeStockMediaGallery"/>
             <useCaseId value="https://github.com/magento/adobe-stock-integration/issues/428"/>
             <title value="View adobe stock image details in standalone media gallery"/>


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/adobe-stock-integration#1438:ViewAdobeStockDetailsTests should use the preidentified image for identification 
2. ...

### Manual testing scenarios (*)
n/a