### PR TITLE
Handle custom product attributes for used in functionality

### DIFF
--- a/MediaContentSynchronizationCatalog/Model/Synchronizer/Product.php
+++ b/MediaContentSynchronizationCatalog/Model/Synchronizer/Product.php
@@ -92,6 +92,8 @@ class Product implements SynchronizerInterface
      */
     private function synchronizeItem(array $item): void
     {
+        $this->synchronizeCustomAttributes($item);
+        
         foreach ($this->fields as $field) {
             $contentIdentity = $this->contentIdentityFactory->create(
                 [
@@ -105,5 +107,26 @@ class Product implements SynchronizerInterface
                 implode(PHP_EOL, $this->getEntityContents->execute($contentIdentity))
             );
         }
+    }
+
+    /**
+     * Synchronize custom product attributes fields.
+     *
+     * @param array $item
+     */
+    private function synchronizeCustomAttributes(array $item)
+    {
+        $fields = $this->getCustomAttributesContents->execute($contentIdentity);
+        $contentIdentity = $this->contentIdentityFactory->create(
+            [
+                    self::TYPE => self::CONTENT_TYPE,
+                    self::FIELD => $field,
+                    self::ENTITY_ID => $item[self::PRODUCT_TABLE_ENTITY_ID]
+                ]
+        );
+        $this->updateContentAssetLinks->execute(
+            $contentIdentity,
+            implode(PHP_EOL, $this->getCustomAttributesContents->execute($contentIdentity))
+        );
     }
 }

--- a/MediaContentSynchronizationCatalog/Model/Synchronizer/Product.php
+++ b/MediaContentSynchronizationCatalog/Model/Synchronizer/Product.php
@@ -128,10 +128,10 @@ class Product implements SynchronizerInterface
     {
         $contentIdentity = $this->contentIdentityFactory->create(
             [
-                    self::TYPE => self::CONTENT_TYPE,
-                    self::FIELD => self::CUSTOM_ATTRIBUTES_FIELD,
-                    self::ENTITY_ID => $item[self::PRODUCT_TABLE_ENTITY_ID]
-                ]
+                self::TYPE => self::CONTENT_TYPE,
+                self::FIELD => self::CUSTOM_ATTRIBUTES_FIELD,
+                self::ENTITY_ID => $item[self::PRODUCT_TABLE_ENTITY_ID]
+            ]
         );
         $this->updateContentAssetLinks->execute(
             $contentIdentity,

--- a/MediaContentSynchronizationCatalog/Model/Synchronizer/Product.php
+++ b/MediaContentSynchronizationCatalog/Model/Synchronizer/Product.php
@@ -26,7 +26,8 @@ class Product implements SynchronizerInterface
     private const PRODUCT_TABLE = 'catalog_product_entity';
     private const PRODUCT_TABLE_ENTITY_ID = 'entity_id';
     private const PRODUCT_TABLE_UPDATED_AT_FIELD = 'updated_at';
-
+    private const CUSTOM_ATTRIBUTES_FIELD = 'product_custom_attribute';
+    
     /**
      * @var UpdateContentAssetLinksInterface
      */
@@ -128,7 +129,7 @@ class Product implements SynchronizerInterface
         $contentIdentity = $this->contentIdentityFactory->create(
             [
                     self::TYPE => self::CONTENT_TYPE,
-                    self::FIELD => 'product_custom_attribute',
+                    self::FIELD => self::CUSTOM_ATTRIBUTES_FIELD,
                     self::ENTITY_ID => $item[self::PRODUCT_TABLE_ENTITY_ID]
                 ]
         );

--- a/MediaContentSynchronizationCatalog/Model/Synchronizer/Product.php
+++ b/MediaContentSynchronizationCatalog/Model/Synchronizer/Product.php
@@ -74,7 +74,7 @@ class Product implements SynchronizerInterface
         FetchBatchesInterface $fetchBatches,
         array $fields = []
     ) {
-        $this->getCustomAttributesContents = $getCustomAttributesContent;
+        $this->getCustomAttributesContent = $getCustomAttributesContent;
         $this->contentIdentityFactory = $contentIdentityFactory;
         $this->getEntityContents = $getEntityContents;
         $this->updateContentAssetLinks = $updateContentAssetLinks;
@@ -137,7 +137,7 @@ class Product implements SynchronizerInterface
             $contentIdentity,
             implode(
                 PHP_EOL,
-                $this->getCustomAttributesContents->execute(
+                $this->getCustomAttributesContent->execute(
                     self::CONTENT_TYPE,
                     (int) $item[self::PRODUCT_TABLE_ENTITY_ID]
                 )

--- a/MediaContentSynchronizationCatalog/Model/Synchronizer/Product.php
+++ b/MediaContentSynchronizationCatalog/Model/Synchronizer/Product.php
@@ -12,7 +12,7 @@ use Magento\MediaContentApi\Api\UpdateContentAssetLinksInterface;
 use Magento\MediaContentApi\Model\GetEntityContentsInterface;
 use Magento\MediaContentSynchronizationApi\Api\SynchronizerInterface;
 use Magento\MediaGallerySynchronizationApi\Model\FetchBatchesInterface;
-use Magento\MediaContentCatalog\Model\ResourceModel\GetCustomAnttributesContent;
+use Magento\MediaContentApi\Model\GetCustomAttributesContentInterface;
 
 /**
  * Synchronize product content with assets
@@ -53,12 +53,12 @@ class Product implements SynchronizerInterface
     private $fetchBatches;
 
     /**
-     * @var GetCustomAttributesContent
+     * @var GetCustomAttributesContentInterface
      */
     private $getCustomAttributesContent;
 
     /**
-     * @param GetCustomAttributesContent $getCustomAttributesContent
+     * @param GetCustomAttributesContentInterface $getCustomAttributesContent
      * @param ContentIdentityInterfaceFactory $contentIdentityFactory
      * @param GetEntityContentsInterface $getEntityContents
      * @param UpdateContentAssetLinksInterface $updateContentAssetLinks
@@ -66,7 +66,7 @@ class Product implements SynchronizerInterface
      * @param array $fields
      */
     public function __construct(
-        GetCustomAnttributesContent $getCustomAttributesContent,
+        GetCustomAttributesContentInterface $getCustomAttributesContent,
         ContentIdentityInterfaceFactory $contentIdentityFactory,
         GetEntityContentsInterface $getEntityContents,
         UpdateContentAssetLinksInterface $updateContentAssetLinks,
@@ -138,8 +138,7 @@ class Product implements SynchronizerInterface
                 PHP_EOL,
                 $this->getCustomAttributesContents->execute(
                     self::CONTENT_TYPE,
-                    $item[self::PRODUCT_TABLE_ENTITY_ID],
-                    $this->fields
+                    (int) $item[self::PRODUCT_TABLE_ENTITY_ID]
                 )
             )
         );

--- a/MediaContentSynchronizationCatalog/etc/di.xml
+++ b/MediaContentSynchronizationCatalog/etc/di.xml
@@ -19,6 +19,7 @@
             <argument name="fields" xsi:type="array">
                 <item name="description" xsi:type="string">description</item>
                 <item name="short_description" xsi:type="string">short_description</item>
+                <item name="custom_attributes" xsi:type="string">custom_attributes</item>
             </argument>
         </arguments>
     </type>


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
DEPEND ON  https://github.com/magento/magento2/pull/28709
### Related Pull Requests
https://github.com/magento/magento2/pull/28709
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/adobe-stock-integration#1420: The "Used in- Product" doesn't consider images added from Custom Product Attribute
2. ...

### Manual testing scenarios (*)
1. Create a custom **Product Attribute**, type _Text Editor_
2. Create a new Product and add the previously created attribute 
3. From the added Attribute, insert an image from the Media Gallery and Save the Product
4. Go to Standalone Media Gallery and view the Image Details of the previously used image
 
**The image Used in Product should be displayed**

