### PR TITLE
#1458 :- The Vertical images in "More from this series..." are not centered

### DIFF
--- a/AdobeStockImageAdminUi/view/adminhtml/web/css/source/_module.less
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/css/source/_module.less
@@ -22,7 +22,7 @@
             top: 2px;
             width: 12px;
         }
-        
+
         .masonry-image {
             &-grid {
                 display: inline-block;
@@ -242,8 +242,9 @@
 
                         img {
                             max-width: initial;
-                            position: absolute;
+                            position: relative;
                             width: auto;
+                            margin: 0 auto;
                         }
                     }
 

--- a/AdobeStockImageAdminUi/view/adminhtml/web/css/source/_module.less
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/css/source/_module.less
@@ -241,10 +241,10 @@
                         width: 100%;
 
                         img {
+                            margin: 0 auto;
                             max-width: initial;
                             position: relative;
                             width: auto;
-                            margin: 0 auto;
                         }
                     }
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR will fix the issue with the vertical images are not centered properly
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/adobe-stock-integration#1458: The Vertical images in "More from this series..." are not centered

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Go to Content - Media Gallery, click Search Adobe Stock
2. Open preview of an image which has both Horizontal and Vertical imaged in More from this... tab
(for example, search for the image 345873592)
3. Observe the four images in More from this series

### Expected Result
![image](https://user-images.githubusercontent.com/39480008/84732450-6534ef80-afb9-11ea-8b15-3e3d12b78ea5.png)

