### PR TITLE
[2.0.0-master] Bugfixes

### DIFF
--- a/AdobeIms/Controller/Adminhtml/User/Profile.php
+++ b/AdobeIms/Controller/Adminhtml/User/Profile.php
@@ -33,7 +33,7 @@ class Profile extends Action implements HttpGetActionInterface
     /**
      * @see _isAllowed()
      */
-    public const ADMIN_RESOURCE = 'Magento_AdobeIms::profile';
+    public const ADMIN_RESOURCE = 'Magento_AdobeIms::login';
 
     /**
      * @var UserContextInterface

--- a/AdobeIms/etc/acl.xml
+++ b/AdobeIms/etc/acl.xml
@@ -14,7 +14,6 @@
                         <resource id="Magento_AdobeIms::actions" title="Actions" translate="title">
                             <resource id="Magento_AdobeIms::login" title="Login" translate="title"/>
                             <resource id="Magento_AdobeIms::logout" title="Logout" translate="title"/>
-                            <resource id="Magento_AdobeIms::profile" title="Get User Profile" translate="title"/>
                         </resource>
                     </resource>
                 </resource>

--- a/AdobeStockImageAdminUi/Test/Mftf/ActionGroup/AdminAdobeStockExpandImagePreviewActionGroup.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/ActionGroup/AdminAdobeStockExpandImagePreviewActionGroup.xml
@@ -10,7 +10,7 @@
               xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
     <actionGroup name="AdminAdobeStockExpandImagePreviewActionGroup">
         <annotations>
-            <description>Expands image preview by provided selector, default value first image in grid</description>
+            <description>Expands first image in grid.</description>
         </annotations>
         <conditionalClick stepKey="closeImagePreview"
                           selector="{{AdminAdobeStockImagePreviewSection.close}}"

--- a/AdobeStockImageAdminUi/Test/Mftf/ActionGroup/AdminAdobeStockExpandImagePreviewActionGroup.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/ActionGroup/AdminAdobeStockExpandImagePreviewActionGroup.xml
@@ -9,6 +9,9 @@
 <actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
               xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
     <actionGroup name="AdminAdobeStockExpandImagePreviewActionGroup">
+        <annotations>
+            <description>Expands image preview by provided selector, default value first image in grid</description>
+        </annotations>
         <conditionalClick stepKey="closeImagePreview"
                           selector="{{AdminAdobeStockImagePreviewSection.close}}"
                           dependentSelector="{{AdminAdobeStockImagePreviewSection.close}}"

--- a/AdobeStockImageAdminUi/Test/Mftf/Data/AdobeStockImageData.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Data/AdobeStockImageData.xml
@@ -21,7 +21,7 @@
     <entity name="AdobeStockUnlicensedImage">
         <data key="id">{{_CREDS.magento/adobe_stock_not_licensed_image}}</data>
         <data key="status">Unlicensed</data>
-        <data key="category">People</data>
-        <data key="author">NajmiArif</data>
+        <data key="category">Castles</data>
+        <data key="author">gam16</data>
     </entity>
 </entities>

--- a/AdobeStockImageAdminUi/Test/Mftf/Section/AdminAdobeStockSection.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Section/AdminAdobeStockSection.xml
@@ -13,7 +13,7 @@
         <element name="unlicensedImageLabel" type="button" selector="//span[text()='Unlicensed']"/>
         <element name="modal" type="block" selector="aside.adobe-stock-modal"/>
         <element name="panelTitle" type="block" selector="[data-role=title]"/>
-        <element name="searchInput" type="input" selector="input.data-grid-search-control"/>
+        <element name="searchInput" type="input" selector="//div[@class='adobe-stock-images-search-modal-content']//input[contains(@class, 'data-grid-search-control')]"/>
         <element name="firstImageInGrid" type="block" selector="[data-role=grid-wrapper] img[data-role=thumbnail]"/>
         <element name="searchButton" type="button" selector="#words + button.action-submit"/>
         <element name="imageSrc" type="text" selector="//div[@class='masonry-image-column' and contains(@data-repeat-index, '0')]//img[@src='{{src}}']" parameterized="true"/>

--- a/AdobeStockImageAdminUi/Test/Mftf/Test/AdminMediaGalleryViewAdobeStockDetailsTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/AdminMediaGalleryViewAdobeStockDetailsTest.xml
@@ -26,6 +26,9 @@
         </after>
 
         <actionGroup ref="AdminEnhancedMediaGallerySearchAdobeStockActionGroup" stepKey="openAdobeStockGrid"/>
+        <actionGroup ref="AdminSearchImagesOnModalActionGroup" stepKey="searchForUnlicensedImage">
+            <argument name="query" value="{{AdobeStockUnlicensedImage.id}}"/>
+        </actionGroup>
         <actionGroup ref="AdminAdobeStockExpandImagePreviewActionGroup" stepKey="expandImagePreview"/>
         <actionGroup ref="AdminAdobeStockSavePreviewActionGroup" stepKey="saveImagePreview"/>
         <actionGroup ref="AdminSaveAdobeStockImagePreviewActionGroup" stepKey="confirmSaveImagePreview"/>

--- a/AdobeStockImageAdminUi/Test/Mftf/Test/AdminMediaGalleryViewAdobeStockDetailsTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/AdminMediaGalleryViewAdobeStockDetailsTest.xml
@@ -9,9 +9,6 @@
 <tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
     <test name="AdminMediaGalleryViewAdobeStockDetailsTest">
         <annotations>
-            <skip>
-                <issueId value="https://github.com/magento/adobe-stock-integration/issues/1438"/>
-            </skip>
             <features value="AdobeStockMediaGallery"/>
             <useCaseId value="https://github.com/magento/adobe-stock-integration/issues/428"/>
             <title value="View adobe stock image details"/>

--- a/AdobeStockImageAdminUi/Test/Mftf/Test/AdminStandaloneMediaGalleryViewAdobeStockDetailsTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/AdminStandaloneMediaGalleryViewAdobeStockDetailsTest.xml
@@ -27,6 +27,9 @@
         </after>
 
         <actionGroup ref="AdminEnhancedMediaGallerySearchAdobeStockActionGroup" stepKey="openAdobeStockGrid"/>
+        <actionGroup ref="AdminSearchImagesOnModalActionGroup" stepKey="searchForUnlicensedImage">
+            <argument name="query" value="{{AdobeStockUnlicensedImage.id}}"/>
+        </actionGroup>
         <actionGroup ref="AdminAdobeStockExpandImagePreviewActionGroup" stepKey="expandImagePreview"/>
         <actionGroup ref="AdminAdobeStockSavePreviewActionGroup" stepKey="saveImagePreview"/>
         <actionGroup ref="AdminSaveAdobeStockImagePreviewActionGroup" stepKey="confirmSaveImagePreview"/>

--- a/AdobeStockImageAdminUi/Test/Mftf/Test/AdminStandaloneMediaGalleryViewAdobeStockDetailsTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/AdminStandaloneMediaGalleryViewAdobeStockDetailsTest.xml
@@ -9,9 +9,6 @@
 <tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
     <test name="AdminStandaloneMediaGalleryViewAdobeStockDetailsTest">
         <annotations>
-            <skip>
-                <issueId value="https://github.com/magento/adobe-stock-integration/issues/1438"/>
-            </skip>
             <features value="AdobeStockMediaGallery"/>
             <useCaseId value="https://github.com/magento/adobe-stock-integration/issues/428"/>
             <title value="View adobe stock image details in standalone media gallery"/>

--- a/AdobeStockImageAdminUi/Ui/Component/Listing/SearchAdobeStockButton.php
+++ b/AdobeStockImageAdminUi/Ui/Component/Listing/SearchAdobeStockButton.php
@@ -9,6 +9,7 @@ namespace Magento\AdobeStockImageAdminUi\Ui\Component\Listing;
 
 use Magento\AdobeStockImageAdminUi\Model\IsAdobeStockIntegrationEnabled;
 use Magento\Framework\View\Element\UiComponent\Control\ButtonProviderInterface;
+use Magento\Framework\AuthorizationInterface;
 
 /**
  * Adobe Stock Search Button
@@ -21,11 +22,24 @@ class SearchAdobeStockButton implements ButtonProviderInterface
     private $isAdobeStockIntegrationEnabled;
 
     /**
+     * Acl for images preview
+     */
+    private const ACL_SAVE_PREVIEW_IMAGES = 'Magento_AdobeStockImageAdminUi::save_preview_images';
+
+    /**
+     * @var AuthorizationInterface
+     */
+    private $authorization;
+  
+    /**
+     * @param AuthorizationInterface $authorization
      * @param IsAdobeStockIntegrationEnabled $isAdobeStockIntegrationEnabled
      */
     public function __construct(
+        AuthorizationInterface $authorization,
         IsAdobeStockIntegrationEnabled $isAdobeStockIntegrationEnabled
     ) {
+        $this->authorization = $authorization;
         $this->isAdobeStockIntegrationEnabled = $isAdobeStockIntegrationEnabled;
     }
 
@@ -34,7 +48,7 @@ class SearchAdobeStockButton implements ButtonProviderInterface
      */
     public function getButtonData()
     {
-        if (!$this->isAdobeStockIntegrationEnabled->execute()) {
+        if (!$this->isAllowed()) {
             return [];
         }
 
@@ -44,5 +58,14 @@ class SearchAdobeStockButton implements ButtonProviderInterface
             'class' => 'media-gallery-actions-buttons',
             'on_click' => 'jQuery(".adobe-search-images-modal").trigger("openModal");'
         ];
+    }
+
+    /**
+     * Verify if  Adobe Stock Search button allowed
+     */
+    private function isAllowed(): bool
+    {
+        return $this->isAdobeStockIntegrationEnabled->execute() &&
+            $this->authorization->isAllowed(self::ACL_SAVE_PREVIEW_IMAGES);
     }
 }

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/actions.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/actions.js
@@ -13,7 +13,8 @@ define([
     'Magento_AdobeStockImageAdminUi/js/action/licenseAndSave',
     'Magento_AdobeStockImageAdminUi/js/action/confirmQuota',
     'Magento_AdobeStockImageAdminUi/js/media-gallery',
-    'Magento_AdobeStockImageAdminUi/js/confirmation/buyCredits'
+    'Magento_AdobeStockImageAdminUi/js/confirmation/buyCredits',
+    'Magento_AdobeStockImageAdminUi/js/action/getLicenseStatus'
 ], function (
     Component,
     uiRegistry,
@@ -25,7 +26,8 @@ define([
     licenseAndSaveAction,
     confirmQuotaAction,
     mediaGallery,
-    buyCreditsConfirmation
+    buyCreditsConfirmation,
+    getLicenseStatus
 ) {
     'use strict';
 
@@ -364,7 +366,7 @@ define([
             }
 
             provider = uiRegistry.get('index = media_gallery_listing_data_source'),
-            dataStorage = provider.storage();
+                dataStorage = provider.storage();
 
             // this.subscriptionOnImageItems();
             dataStorage.clearRequests();
@@ -437,7 +439,6 @@ define([
                 record.title,
                 record.path,
                 record['content_type'],
-                this.isLicensed(),
                 this.isDownloaded()
             ).then(function (destinationPath) {
                 this.updateLicensedDisplayedRecord(destinationPath);
@@ -457,65 +458,66 @@ define([
          * @param {String} title
          * @param {String} path
          * @param {String} contentType
-         * @param {Boolean} isLicensed
          * @param {Boolean} isDownloaded
          * @return {window.Promise}
          */
-        licenseProcess: function (id, title, path, contentType, isLicensed, isDownloaded) {
+        licenseProcess: function (id, title, path, contentType, isDownloaded) {
             var deferred = $.Deferred();
 
-            $.ajaxSetup({
-                async: false
-            });
             this.login().login()
                 .then(function () {
-                    if (isLicensed) {
-                        saveLicensedAction(
-                            this.preview().saveLicensedAndDownloadUrl,
-                            id,
-                            title,
-                            path,
-                            contentType,
-                            this.getDestinationDirectoryPath()
-                        ).then(function (destinationPath) {
-                            deferred.resolve(destinationPath);
-                        }).fail(function (error) {
-                            deferred.reject(error);
-                        });
-                    } else {
-                        confirmQuotaAction(this.preview().confirmationUrl, id).then(function (data) {
-                            if (data.canLicense === false) {
-                                buyCreditsConfirmation(
-                                    this.preview().buyCreditsUrl,
-                                    title,
-                                    data.message
-                                );
+                    getLicenseStatus(
+                        this.overlay().getImagesUrl,
+                        [id]
+                    ).then(function (licensedInfo) {
+                        var isLicensed = licensedInfo[id] || false;
 
-                                return;
-                            }
-                            licenseAndSaveAction(
-                                this.preview().licenseAndDownloadUrl,
+                        if (isLicensed) {
+                            saveLicensedAction(
+                                this.preview().saveLicensedAndDownloadUrl,
                                 id,
                                 title,
                                 path,
                                 contentType,
-                                isDownloaded,
-                                data.message,
                                 this.getDestinationDirectoryPath()
                             ).then(function (destinationPath) {
                                 deferred.resolve(destinationPath);
                             }).fail(function (error) {
                                 deferred.reject(error);
                             });
-                        }.bind(this));
-                    }
-                    $.ajaxSetup({
-                        async: true
+                        } else {
+                            confirmQuotaAction(this.preview().confirmationUrl, id).then(function (data) {
+                                if (data.canLicense === false) {
+                                    buyCreditsConfirmation(
+                                        this.preview().buyCreditsUrl,
+                                        title,
+                                        data.message
+                                    );
+
+                                    return;
+                                }
+                                licenseAndSaveAction(
+                                    this.preview().licenseAndDownloadUrl,
+                                    id,
+                                    title,
+                                    path,
+                                    contentType,
+                                    isDownloaded,
+                                    data.message,
+                                    this.getDestinationDirectoryPath()
+                                ).then(function (destinationPath) {
+                                    deferred.resolve(destinationPath);
+                                }).fail(function (error) {
+                                    deferred.reject(error);
+                                });
+                            }.bind(this));
+                        }
+                    }.bind(this)).fail(function (error) {
+                        deferred.reject(error);
                     });
-                }.bind(this))
-                .fail(function (error) {
-                    deferred.reject(error);
-                });
+                }.bind(this)).fail(function (error) {
+                deferred.reject(error);
+            });
 
             return deferred.promise();
         },
@@ -558,7 +560,7 @@ define([
          * @returns {String}
          */
         getLicenseButtonTitle: function () {
-            return this.isDownloaded() ?  $.mage.__('License') : $.mage.__('License and Save');
+            return this.isDownloaded() ? $.mage.__('License') : $.mage.__('License and Save');
         },
 
         /**

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/related.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/related.js
@@ -53,7 +53,7 @@ define([
         /**
          * Disable keydown event for related content tabs
          */
-        disableTabsKeyDown: function () {
+        disableTabsKeyDownEvent: function () {
             if ($(this.tabsContainerId + ' li[role=tab]').length === 0) {
                 setTimeout(function () {
                     this.disableTabsKeyDown();

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/related.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/related.js
@@ -5,8 +5,7 @@
 define([
     'uiComponent',
     'underscore',
-    'jquery',
-    'mage/backend/tabs'
+    'jquery'
 ], function (Component, _, $) {
     'use strict';
 
@@ -16,6 +15,7 @@ define([
             filterChipsProvider: 'componentType = filters, ns = ${ $.ns }',
             filterBookmarksSelector: '.admin__data-grid-action-bookmarks',
             tabImagesLimit: 4,
+            tabsContainerId: '#adobe-stock-tabs',
             serieFilterValue: '',
             modelFilterValue: '',
             selectedTab: null,
@@ -48,6 +48,19 @@ define([
             this.filterChips().updateActive();
 
             return this;
+        },
+
+        /**
+         * Disable keydown event for related content tabs
+         */
+        disableTabsKeyDown: function () {
+            if ($(this.tabsContainerId + ' li[role=tab]').length === 0) {
+                setTimeout(function () {
+                    this.disableTabsKeyDown();
+                }.bind(this), 100);
+            } else {
+                $(this.tabsContainerId + ' li[role=tab]').unbind('keydown');
+            }
         },
 
         /**

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/related.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/related.js
@@ -56,7 +56,7 @@ define([
         disableTabsKeyDownEvent: function () {
             if ($(this.tabsContainerId + ' li[role=tab]').length === 0) {
                 setTimeout(function () {
-                    this.disableTabsKeyDown();
+                    this.disableTabsKeyDownEvent();
                 }.bind(this), 100);
             } else {
                 $(this.tabsContainerId + ' li[role=tab]').unbind('keydown');

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/mediaGallery/grid/columns/image/licenseActions.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/mediaGallery/grid/columns/image/licenseActions.js
@@ -7,9 +7,8 @@ define([
     'underscore',
     'Magento_MediaGalleryUi/js/grid/columns/image/actions',
     'Magento_MediaGalleryUi/js/action/getDetails',
-    'Magento_AdobeStockImageAdminUi/js/action/getLicenseStatus',
     'mage/translate'
-], function ($, _, Action, getDetails, getLicenseStatus) {
+], function ($, _, Action, getDetails) {
     'use strict';
 
     return Action.extend({
@@ -84,38 +83,26 @@ define([
          * @param {Number} imageId
          */
         getImageRecord: function (imageId) {
-            this.image().actions().login().login().then(function () {
-                getDetails(this.imageDetailsUrl, imageId).then(function (imageDetails) {
-                    var id = imageDetails['adobe_stock'][0].value;
+            getDetails(this.imageDetailsUrl, imageId).then(function (imageDetails) {
+                var id = imageDetails['adobe_stock'][0].value;
 
-                    getLicenseStatus(
-                        this.image().actions().overlay().getImagesUrl,
-                        [id]
-                    ).then(function (licensedInfo) {
-                        var isLicensed = licensedInfo[id] || false;
-
-                        this.image().actions().licenseProcess(
-                            id,
-                            imageDetails.title,
-                            imageDetails.path,
-                            imageDetails['content_type'],
-                            isLicensed,
-                            true
-                        ).then(function () {
-                            this.image().actions().login().getUserQuota();
-                            this.imageModel().reloadGrid();
-                            this.imageModel().addMessage('success', $.mage.__('The image has been licensed.'));
-                        }.bind(this)).fail(function (error) {
-                            if (error) {
-                                this.imageModel().addMessage('error', error);
-                            }
-                        });
-                    }.bind(this));
-                }.bind(this)).fail(function (message) {
-                    this.imageModel().addMessage('error', message);
+                this.image().actions().licenseProcess(
+                    id,
+                    imageDetails.title,
+                    imageDetails.path,
+                    imageDetails['content_type'],
+                    true
+                ).then(function () {
+                    this.image().actions().login().getUserQuota();
+                    this.imageModel().reloadGrid();
+                    this.imageModel().addMessage('success', $.mage.__('The image has been licensed.'));
+                }.bind(this)).fail(function (error) {
+                    if (error) {
+                        this.imageModel().addMessage('error', error);
+                    }
                 });
-            }.bind(this)).fail(function (error) {
-                this.imageModel().addMessage('error', error);
+            }.bind(this)).fail(function (message) {
+                this.imageModel().addMessage('error', message);
             });
         }
     });

--- a/AdobeStockImageAdminUi/view/adminhtml/web/template/grid/column/preview/related.html
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/template/grid/column/preview/related.html
@@ -13,7 +13,7 @@
                     destination: '#adobe-stock-tabs-content',
                     shadowTabs: [],
                 }
-            }">
+            }" afterRender="disableTabsKeyDown()">
         <ul class="tabs-horiz">
             <li if="showSeriesTab($row())">
                 <a id="series_tab" attr="'href': '#series_content_' + $row().id">

--- a/AdobeStockImageAdminUi/view/adminhtml/web/template/grid/column/preview/related.html
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/template/grid/column/preview/related.html
@@ -13,7 +13,7 @@
                     destination: '#adobe-stock-tabs-content',
                     shadowTabs: [],
                 }
-            }" afterRender="disableTabsKeyDown()">
+            }" afterRender="disableTabsKeyDownEvent()">
         <ul class="tabs-horiz">
             <li if="showSeriesTab($row())">
                 <a id="series_tab" attr="'href': '#series_content_' + $row().id">

--- a/MediaGalleryIntegration/Plugin/SaveBaseCategoryImageInformation.php
+++ b/MediaGalleryIntegration/Plugin/SaveBaseCategoryImageInformation.php
@@ -84,7 +84,7 @@ class SaveBaseCategoryImageInformation
     {
         $absolutePath = $this->storage->getCmsWysiwygImages()->getStorageRoot() . $imagePath;
         $file = $this->splFileInfoFactory->create($absolutePath);
-        $tmpPath = $subject->getBaseTmpPath() . '/'. $file->getFileName();
+        $tmpPath = $subject->getBaseTmpPath() . '/' . $file->getFileName();
         $tmpAssets = $this->getAssetsByPaths->execute([$tmpPath]);
         
         if (!empty($tmpAssets)) {

--- a/MediaGalleryIntegration/Plugin/SaveBaseCategoryImageInformation.php
+++ b/MediaGalleryIntegration/Plugin/SaveBaseCategoryImageInformation.php
@@ -61,6 +61,7 @@ class SaveBaseCategoryImageInformation
      *
      * @param ImageUploader $subject
      * @param string $imagePath
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function afterMoveFileFromTmp(ImageUploader $subject, string $imagePath): string
     {

--- a/MediaGalleryIntegration/Plugin/SaveBaseCategoryImageInformation.php
+++ b/MediaGalleryIntegration/Plugin/SaveBaseCategoryImageInformation.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\MediaGalleryIntegration\Plugin;
+
+use Magento\MediaGalleryApi\Api\SaveAssetsInterface;
+use Magento\Catalog\Model\ImageUploader;
+use Magento\MediaGallerySynchronization\Model\CreateAssetFromFile;
+use Magento\Cms\Model\Wysiwyg\Images\Storage;
+use Magento\MediaGalleryUi\Model\Filesystem\SplFileInfoFactory;
+
+/**
+ * Save base category image by SaveAssetsInterface.
+ */
+class SaveBaseCategoryImageInformation
+{
+    /**
+     * @var SplFileInfoFactory
+     */
+    private $splFileInfoFactory;
+    
+    /**
+     * @var SaveAssetsInterface
+     */
+    private $saveAsset;
+
+    /**
+     * @var CreateAssetFromFile
+     */
+    private $createAssetFromFile;
+
+    /**
+     * @var Storage
+     */
+    private $storage;
+
+    /**
+     * @param SplFileInfoFactory $splFileInfoFactory
+     * @param Storage $storage
+     * @param CreateAssetFromFile $createAssetFromFile
+     * @param SaveAssetsInterface $saveAsset
+     */
+    public function __construct(
+        SplFileInfoFactory $splFileInfoFactory,
+        CreateAssetFromFile $createAssetFromFile,
+        SaveAssetsInterface $saveAsset,
+        Storage $storage
+    ) {
+        $this->splFileInfoFactory = $splFileInfoFactory;
+        $this->createAssetFromFile = $createAssetFromFile;
+        $this->saveAsset = $saveAsset;
+        $this->storage = $storage;
+    }
+
+    /**
+     * Save base category image information after movinf from tmp folder.
+     *
+     * @param ImageUploader $subject
+     * @param string $imagePath
+     */
+    public function afterMoveFileFromTmp(ImageUploader $subject, string $imagePath): string
+    {
+        $absolutePath = $this->storage->getCmsWysiwygImages()->getStorageRoot() . $imagePath;
+        $file = $this->splFileInfoFactory->create($absolutePath);
+        $this->saveAsset->execute([$this->createAssetFromFile->execute($file)]);
+        $this->storage->resizeFile($absolutePath);
+
+        return $imagePath;
+    }
+}

--- a/MediaGalleryIntegration/Plugin/SaveBaseCategoryImageInformation.php
+++ b/MediaGalleryIntegration/Plugin/SaveBaseCategoryImageInformation.php
@@ -40,9 +40,9 @@ class SaveBaseCategoryImageInformation
 
     /**
      * @param SplFileInfoFactory $splFileInfoFactory
-     * @param Storage $storage
      * @param CreateAssetFromFile $createAssetFromFile
      * @param SaveAssetsInterface $saveAsset
+     * @param Storage $storage
      */
     public function __construct(
         SplFileInfoFactory $splFileInfoFactory,
@@ -57,7 +57,7 @@ class SaveBaseCategoryImageInformation
     }
 
     /**
-     * Save base category image information after movinf from tmp folder.
+     * Saves base category image information after moving from tmp folder.
      *
      * @param ImageUploader $subject
      * @param string $imagePath

--- a/MediaGalleryIntegration/Plugin/SaveImageInformation.php
+++ b/MediaGalleryIntegration/Plugin/SaveImageInformation.php
@@ -106,11 +106,11 @@ class SaveImageInformation
     }
 
     /**
-      * Can asset be saved with provided path
-      *
-      * @param string $path
-      * @return bool
-      */
+     * Can asset be saved with provided path
+     *
+     * @param string $path
+     * @return bool
+     */
     private function isApplicable(string $path): bool
     {
         try {

--- a/MediaGalleryIntegration/Plugin/SaveImageInformation.php
+++ b/MediaGalleryIntegration/Plugin/SaveImageInformation.php
@@ -12,7 +12,7 @@ use Magento\Framework\File\Uploader;
 use Magento\MediaGallerySynchronization\Model\CreateAssetFromFile;
 use Magento\Cms\Model\Wysiwyg\Images\Storage;
 use Magento\MediaGallerySynchronization\Model\Filesystem\SplFileInfoFactory;
-use Magento\MediaGalleryApi\Api\IsPathBlacklistedInterface;
+use Magento\MediaGalleryApi\Api\IsPathExcludedInterface;
 use Psr\Log\LoggerInterface;
 use Magento\Framework\Filesystem;
 use Magento\Framework\App\Filesystem\DirectoryList;
@@ -25,15 +25,15 @@ class SaveImageInformation
     private const IMAGE_FILE_NAME_PATTERN = '#\.(jpg|jpeg|gif|png)$# i';
 
     /**
-     * @var IsPathBlacklistedInterface
+     * @var IsPathExcludedInterface
      */
-    private $isPathBlacklisted;
-    
+    private $isPathExcluded;
+
     /**
      * @var SplFileInfoFactory
      */
     private $splFileInfoFactory;
-    
+
     /**
      * @var SaveAssetsInterface
      */
@@ -62,7 +62,7 @@ class SaveImageInformation
     /**
      * @param Filesystem $filesystem
      * @param LoggerInterface $log
-     * @param IsPathBlacklistedInterface $isPathBlacklisted
+     * @param IsPathExcludedInterface $isPathExcluded
      * @param SplFileInfoFactory $splFileInfoFactory
      * @param CreateAssetFromFile $createAssetFromFile
      * @param SaveAssetsInterface $saveAsset
@@ -71,14 +71,14 @@ class SaveImageInformation
     public function __construct(
         Filesystem $filesystem,
         LoggerInterface $log,
-        IsPathBlacklistedInterface $isPathBlacklisted,
+        IsPathExcludedInterface $isPathExcluded,
         SplFileInfoFactory $splFileInfoFactory,
         CreateAssetFromFile $createAssetFromFile,
         SaveAssetsInterface $saveAsset,
         Storage $storage
     ) {
         $this->log = $log;
-        $this->isPathBlacklisted = $isPathBlacklisted;
+        $this->isPathExcluded = $isPathExcluded;
         $this->splFileInfoFactory = $splFileInfoFactory;
         $this->createAssetFromFile = $createAssetFromFile;
         $this->saveAsset = $saveAsset;
@@ -116,7 +116,7 @@ class SaveImageInformation
         try {
             $relativePath = $this->filesystem->getDirectoryRead(DirectoryList::MEDIA)->getRelativePath($path);
             return $relativePath
-                && !$this->isPathBlacklisted->execute($relativePath)
+                && !$this->isPathExcluded->execute($relativePath)
                 && preg_match(self::IMAGE_FILE_NAME_PATTERN, $path);
         } catch (\Exception $exception) {
             $this->log->critical($exception);

--- a/MediaGalleryIntegration/Plugin/SaveImageInformation.php
+++ b/MediaGalleryIntegration/Plugin/SaveImageInformation.php
@@ -12,12 +12,23 @@ use Magento\Framework\File\Uploader;
 use Magento\MediaGallerySynchronization\Model\CreateAssetFromFile;
 use Magento\Cms\Model\Wysiwyg\Images\Storage;
 use Magento\MediaGallerySynchronization\Model\Filesystem\SplFileInfoFactory;
+use Magento\MediaGalleryApi\Api\IsPathBlacklistedInterface;
+use Psr\Log\LoggerInterface;
+use Magento\Framework\Filesystem;
+use Magento\Framework\App\Filesystem\DirectoryList;
 
 /**
  * Save image information by SaveAssetsInterface.
  */
 class SaveImageInformation
 {
+    private const IMAGE_FILE_NAME_PATTERN = '#\.(jpg|jpeg|gif|png)$# i';
+
+    /**
+     * @var IsPathBlacklistedInterface
+     */
+    private $isPathBlacklisted;
+    
     /**
      * @var SplFileInfoFactory
      */
@@ -39,21 +50,40 @@ class SaveImageInformation
     private $storage;
 
     /**
+     * @var LoggerInterface
+     */
+    private $log;
+
+    /**
+     * @var Filesystem
+     */
+    private $filesystem;
+    
+    /**
+     * @param Filesystem $filesystem
+     * @param LoggerInterface $log
+     * @param IsPathBlacklistedInterface $isPathBlacklisted
      * @param SplFileInfoFactory $splFileInfoFactory
      * @param CreateAssetFromFile $createAssetFromFile
      * @param SaveAssetsInterface $saveAsset
      * @param Storage $storage
      */
     public function __construct(
+        Filesystem $filesystem,
+        LoggerInterface $log,
+        IsPathBlacklistedInterface $isPathBlacklisted,
         SplFileInfoFactory $splFileInfoFactory,
         CreateAssetFromFile $createAssetFromFile,
         SaveAssetsInterface $saveAsset,
         Storage $storage
     ) {
+        $this->log = $log;
+        $this->isPathBlacklisted = $isPathBlacklisted;
         $this->splFileInfoFactory = $splFileInfoFactory;
         $this->createAssetFromFile = $createAssetFromFile;
         $this->saveAsset = $saveAsset;
         $this->storage = $storage;
+        $this->filesystem = $filesystem;
     }
 
     /**
@@ -66,9 +96,31 @@ class SaveImageInformation
     public function afterSave(Uploader $subject, array $result): array
     {
         $file = $this->splFileInfoFactory->create($result['path'] . '/' . $result['file']);
+        if (!$this->isApplicable($file->getPathName())) {
+            return $result;
+        }
         $this->saveAsset->execute([$this->createAssetFromFile->execute($file)]);
         $this->storage->resizeFile($result['path'] . '/' . $result['file']);
 
         return $result;
+    }
+
+    /**
+      * Can asset be saved with provided path
+      *
+      * @param string $path
+      * @return bool
+      */
+    private function isApplicable(string $path): bool
+    {
+        try {
+            $relativePath = $this->filesystem->getDirectoryRead(DirectoryList::MEDIA)->getRelativePath($path);
+            return $relativePath
+                && !$this->isPathBlacklisted->execute($relativePath)
+                && preg_match(self::IMAGE_FILE_NAME_PATTERN, $path);
+        } catch (\Exception $exception) {
+            $this->log->critical($exception);
+            return false;
+        }
     }
 }

--- a/MediaGalleryIntegration/Plugin/SaveImageInformation.php
+++ b/MediaGalleryIntegration/Plugin/SaveImageInformation.php
@@ -87,7 +87,7 @@ class SaveImageInformation
     }
 
     /**
-     * Saves base category image information after moving from tmp folder.
+     * Saves asset to media gallery after save image.
      *
      * @param Uploader $subject
      * @param array $result

--- a/MediaGalleryIntegration/composer.json
+++ b/MediaGalleryIntegration/composer.json
@@ -4,7 +4,14 @@
     "require": {
         "php": "~7.3.0||~7.4.0",
         "magento/framework": "*",
-        "magento/module-media-gallery-ui-api": "*"
+        "magento/module-media-gallery-ui-api": "*",
+        "magento/module-cms": "*",
+        "magento/module-media-gallery-api": "*",
+        "magento/module-media-gallery-ui": "*",
+        "magento/module-media-gallery-synchronization": "*"
+    },
+    "suggest": {
+        "magento/module-catalog": "*"
     },
     "type": "magento2-module",
     "license": [

--- a/MediaGalleryIntegration/composer.json
+++ b/MediaGalleryIntegration/composer.json
@@ -7,7 +7,6 @@
         "magento/module-media-gallery-ui-api": "*",
         "magento/module-cms": "*",
         "magento/module-media-gallery-api": "*",
-        "magento/module-media-gallery-ui": "*",
         "magento/module-media-gallery-synchronization": "*"
     },
     "suggest": {

--- a/MediaGalleryIntegration/etc/adminhtml/di.xml
+++ b/MediaGalleryIntegration/etc/adminhtml/di.xml
@@ -11,6 +11,9 @@
             <argument name="url" xsi:type="object">Magento\MediaGalleryIntegration\Model\OpenDialogUrlProvider</argument>
         </arguments>
     </type>
+    <type name="Magento\Framework\File\Uploader">
+        <plugin name="save_category_image" type="Magento\MediaGalleryIntegration\Plugin\SaveImageInformation"/>
+    </type>
     <type name="Magento\Catalog\Model\ImageUploader">
         <plugin name="save_category_image" type="Magento\MediaGalleryIntegration\Plugin\SaveBaseCategoryImageInformation"/>
     </type>

--- a/MediaGalleryIntegration/etc/adminhtml/di.xml
+++ b/MediaGalleryIntegration/etc/adminhtml/di.xml
@@ -11,4 +11,7 @@
             <argument name="url" xsi:type="object">Magento\MediaGalleryIntegration\Model\OpenDialogUrlProvider</argument>
         </arguments>
     </type>
+    <type name="Magento\Catalog\Model\ImageUploader">
+        <plugin name="save_category_image" type="Magento\MediaGalleryIntegration\Plugin\SaveBaseCategoryImageInformation"/>
+    </type>
 </config>

--- a/MediaGalleryIntegration/etc/adminhtml/di.xml
+++ b/MediaGalleryIntegration/etc/adminhtml/di.xml
@@ -12,7 +12,7 @@
         </arguments>
     </type>
     <type name="Magento\Framework\File\Uploader">
-        <plugin name="save_category_image" type="Magento\MediaGalleryIntegration\Plugin\SaveImageInformation"/>
+        <plugin name="save_asset_image" type="Magento\MediaGalleryIntegration\Plugin\SaveImageInformation"/>
     </type>
     <type name="Magento\Catalog\Model\ImageUploader">
         <plugin name="save_category_image" type="Magento\MediaGalleryIntegration\Plugin\SaveBaseCategoryImageInformation"/>

--- a/MediaGallerySynchronization/Model/Filesystem/SplFileInfoFactory.php
+++ b/MediaGallerySynchronization/Model/Filesystem/SplFileInfoFactory.php
@@ -5,7 +5,7 @@
  */
 declare(strict_types=1);
 
-namespace Magento\MediaGalleryUi\Model\Filesystem;
+namespace Magento\MediaGallerySynchronization\Model\Filesystem;
 
 /**
  * Creates a new file based on the file name parameter.

--- a/MediaGalleryUi/Model/UploadImage.php
+++ b/MediaGalleryUi/Model/UploadImage.php
@@ -12,7 +12,7 @@ use Magento\Framework\App\Filesystem\DirectoryList;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Filesystem;
 use Magento\MediaGallerySynchronizationApi\Api\SynchronizeFilesInterface;
-use Magento\MediaGalleryUi\Model\Filesystem\SplFileInfoFactory;
+use Magento\MediaGallerySynchronization\Model\Filesystem\SplFileInfoFactory;
 
 /**
  * Uploads an image to storage

--- a/MediaGalleryUi/Test/Mftf/Test/AdminMediaGalleryUploadCategoryImageTest.xml
+++ b/MediaGalleryUi/Test/Mftf/Test/AdminMediaGalleryUploadCategoryImageTest.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+    <test name="AdminMediaGalleryUploadCategoryImageTest">
+        <annotations>
+            <features value="AdminMediaGalleryImagePanel"/>
+            <useCaseId value="https://github.com/magento/adobe-stock-integration/issues/1435"/>
+            <title value="User uploads image outside of the Media Gallery"/>
+            <testCaseId value="https://studio.cucumber.io/projects/131313/test-plan/folders/943908/scenarios/4836631"/>
+            <description value="User uploads image outside of the Media Gallery"/>
+            <severity value="CRITICAL"/>
+            <group value="media_gallery_ui"/>
+        </annotations>
+        <before>
+            <createData entity="SimpleSubCategory" stepKey="category"/>
+            <actionGroup ref="AdminLoginActionGroup" stepKey="loginAsAdmin"/>
+        </before>
+        <after>
+            <actionGroup ref="AdminOpenStandaloneMediaGalleryActionGroup" stepKey="openStandaloneMediaGallery"/>
+            <actionGroup ref="AdminEnhancedMediaGalleryViewImageDetails" stepKey="viewContentImageDetails"/>
+            <actionGroup ref="AdminEnhancedMediaGalleryImageDetailsDeleteActionGroup" stepKey="deleteCategoryImage"/>
+            <actionGroup ref="AdminEnhancedMediaGalleryViewImageDetails" stepKey="viewCategoryImageDetails"/>
+            <deleteData createDataKey="category" stepKey="deleteCategory"/>
+        </after>
+        <actionGroup ref="AdminOpenCategoryPageActionGroup" stepKey="openCategoryPage"/>
+        <actionGroup ref="AdminCategoriesOpenCategoryActionGroup" stepKey="openCategory">
+            <argument name="category" value="$$category$$"/>
+        </actionGroup>
+        <actionGroup ref="AddCategoryImageActionGroup" stepKey="addCategoryImage"/>
+        <actionGroup ref="AdminSaveCategoryFormActionGroup" stepKey="saveCategoryForm"/>
+        <actionGroup ref="AdminOpenMediaGalleryFromCategoryImageUploaderActionGroup" stepKey="openMediaGalleryFromImageUploader"/>
+        <actionGroup ref="AdminMediaGalleryAssertImageInGridActionGroup" stepKey="assertImageInGrid">
+            <argument name="image" value="ProductImage"/>
+        </actionGroup>
+    </test>
+</tests>

--- a/MediaGalleryUi/Test/Mftf/Test/AdminMediaGalleryUploadCategoryImageTest.xml
+++ b/MediaGalleryUi/Test/Mftf/Test/AdminMediaGalleryUploadCategoryImageTest.xml
@@ -25,7 +25,6 @@
             <actionGroup ref="AdminOpenStandaloneMediaGalleryActionGroup" stepKey="openStandaloneMediaGallery"/>
             <actionGroup ref="AdminEnhancedMediaGalleryViewImageDetails" stepKey="viewContentImageDetails"/>
             <actionGroup ref="AdminEnhancedMediaGalleryImageDetailsDeleteActionGroup" stepKey="deleteCategoryImage"/>
-            <actionGroup ref="AdminEnhancedMediaGalleryViewImageDetails" stepKey="viewCategoryImageDetails"/>
             <deleteData createDataKey="category" stepKey="deleteCategory"/>
         </after>
         <actionGroup ref="AdminOpenCategoryPageActionGroup" stepKey="openCategoryPage"/>

--- a/MediaGalleryUi/Test/Unit/Model/UploadImageTest.php
+++ b/MediaGalleryUi/Test/Unit/Model/UploadImageTest.php
@@ -14,7 +14,7 @@ use Magento\Framework\Filesystem;
 use Magento\Framework\Filesystem\Directory\Read;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Magento\MediaGallerySynchronizationApi\Api\SynchronizeFilesInterface;
-use Magento\MediaGalleryUi\Model\Filesystem\SplFileInfoFactory;
+use Magento\MediaGallerySynchronization\Model\Filesystem\SplFileInfoFactory;
 use Magento\MediaGalleryUi\Model\UploadImage;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Adobe Stock Integration provides a searchable interface in the Magento Admin to 
 
 - Complete documentation located on the project [wiki pages](https://github.com/magento/adobe-stock-integration/wiki):
   - Project [roadmap](https://github.com/magento/adobe-stock-integration/wiki/Adobe-Stock-Image-Integration-Roadmap) contains information about project phases and stories for each phase 
-  - How to start local development described in the [installation guide](https://github.com/magento/adobe-stock-integration/wiki/Installation-Guide)
+  - How to start local development described in the [installation guide](https://github.com/magento/adobe-stock-integration/wiki/Installation)
   - How to [run the project tests](https://github.com/magento/adobe-stock-integration/wiki/Run-the-Tests)
 
 ## Community Engineering Slack


### PR DESCRIPTION
## Bugfixes

 - https://github.com/magento/adobe-stock-integration/pull/1425 Fixed attempt to license image the second time if user is not logged in when initiating the licensing process
 - https://github.com/magento/adobe-stock-integration/pull/1429 Disabled related content tabs arrow navigation
 - https://github.com/magento/adobe-stock-integration/pull/1427 Fixed ACL. If user doesn't have permission to "Save Preview", the 'Search Adobe Stock' button is displayed but doesn't work
 - https://github.com/magento/adobe-stock-integration/pull/1433 Removed the "Get User Profile" ACL
 - https://github.com/magento/adobe-stock-integration/pull/1455 MFTF used the preidentified image for identification for ViewAdobeStockDetailsTests
 - https://github.com/magento/adobe-stock-integration/pull/1431 Fixed Open Images uploaded outside of media gallery are not reflected