### PR TITLE
[2.0.0-develop] Remove obsolete content after content synchronization

### DIFF
--- a/MediaContentSynchronization/Model/RemoveObsoleteContentAsset.php
+++ b/MediaContentSynchronization/Model/RemoveObsoleteContentAsset.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\MediaContentSynchronization\Model;
+
+use Magento\MediaContentSynchronizationApi\Model\GetEntitiesInterface;
+use Magento\MediaContentSynchronization\Model\ResourceModel\GetOutdatedRelations;
+use Magento\MediaContentApi\Api\DeleteContentAssetLinksInterface;
+
+/**
+ * Remove obsolete content asset from deleted entities
+ */
+class RemoveObsoleteContentAsset
+{
+    private const MEDIA_CONTENT_ASSET_TABLE = 'media_content_asset';
+
+    /**
+     * @var GetEntitiesInterface
+     */
+    private $getEntities;
+
+    /**
+     * @var GetOutdatedRelations
+     */
+    private $getOutdatedRelations;
+
+    /**
+     * @var DeleteContentAssetLinksInterface
+     */
+    private $deleteContentAssetLinks;
+    
+    /**
+     * @param DeleteContentAssetLinksInterface $deleteContentAssetLinks
+     * @param GetEntitiesInterface $getEntities
+     * @param GetOutdatedRelations $getOutdatedRelations
+     */
+    public function __construct(
+        DeleteContentAssetLinksInterface $deleteContentAssetLinks,
+        GetEntitiesInterface $getEntities,
+        GetOutdatedRelations $getOutdatedRelations
+    ) {
+        $this->deleteContentAssetLinks = $deleteContentAssetLinks;
+        $this->getEntities = $getEntities;
+        $this->getOutdatedRelations = $getOutdatedRelations;
+    }
+
+    /**
+     * Remove media content if entity already deleted.
+     */
+    public function execute(): void
+    {
+        foreach ($this->getEntities->execute() as $entity) {
+            $assetsLinks = $this->getOutdatedRelations->execute($entity);
+            if (!empty($assetsLinks)) {
+                $this->deleteContentAssetLinks->execute($assetsLinks);
+            }
+        }
+    }
+}

--- a/MediaContentSynchronization/Model/RemoveObsoleteContentAsset.php
+++ b/MediaContentSynchronization/Model/RemoveObsoleteContentAsset.php
@@ -16,8 +16,6 @@ use Magento\MediaContentApi\Api\DeleteContentAssetLinksInterface;
  */
 class RemoveObsoleteContentAsset
 {
-    private const MEDIA_CONTENT_ASSET_TABLE = 'media_content_asset';
-
     /**
      * @var GetEntitiesInterface
      */
@@ -32,7 +30,7 @@ class RemoveObsoleteContentAsset
      * @var DeleteContentAssetLinksInterface
      */
     private $deleteContentAssetLinks;
-    
+
     /**
      * @param DeleteContentAssetLinksInterface $deleteContentAssetLinks
      * @param GetEntitiesInterface $getEntities

--- a/MediaContentSynchronization/Model/ResourceModel/GetOutdatedRelations.php
+++ b/MediaContentSynchronization/Model/ResourceModel/GetOutdatedRelations.php
@@ -92,7 +92,7 @@ class GetOutdatedRelations
             );
             $select->where('et.' . $entityData->getIdentifierField() . ' IS NULL');
             $select->where('mca.entity_type = ?', $entityData->getEavEntityType() ?? $entityData->getEntityTable());
-            $assets = $connection->fetchAssoc($select);
+            $assets = $connection->fetchAll($select);
         } catch (\Exception $exception) {
             $this->logger->critical($exception);
             throw new CouldNotDeleteException(__('Could not fetch media content links data'), $exception);

--- a/MediaContentSynchronization/Model/ResourceModel/GetOutdatedRelations.php
+++ b/MediaContentSynchronization/Model/ResourceModel/GetOutdatedRelations.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\MediaContentSynchronization\Model\ResourceModel;
+
+use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\EntityManager\MetadataPool;
+use Magento\Framework\Exception\CouldNotDeleteException;
+use Psr\Log\LoggerInterface;
+use Magento\MediaContentApi\Api\Data\ContentAssetLinkInterface;
+use Magento\MediaContentApi\Api\Data\ContentAssetLinkInterfaceFactory;
+use Magento\MediaContentApi\Api\Data\ContentIdentityInterfaceFactory;
+
+/**
+ * Returns asset links which entities has been deleted.
+ */
+class GetOutdatedRelations
+{
+    private const MEDIA_CONTENT_ASSET_TABLE = 'media_content_asset';
+
+    /**
+     * @var ResourceConnection
+     */
+    private $resourceConnection;
+
+    /**
+     * @var MetadataPool
+     */
+    private $metadataPool;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @var ContentAssetLinkInterfaceFactory
+     */
+    private $contentAssetLinkFactory;
+
+    /**
+     * @var ContentIdentityInterfaceFactory
+     */
+    private $contentIdentityFactory;
+
+    /**
+     * @param ContentIdentityInterfaceFactory $contentIdentityFactory
+     * @param ContentAssetLinkInterfaceFactory $contentAssetLinkFactory
+     * @param MetadataPool $metadataPool
+     * @param ResourceConnection $resourceConnection
+     * @param LoggerInterface $logger
+     */
+    public function __construct(
+        ContentIdentityInterfaceFactory $contentIdentityFactory,
+        ContentAssetLinkInterfaceFactory $contentAssetLinkFactory,
+        MetadataPool $metadataPool,
+        ResourceConnection $resourceConnection,
+        LoggerInterface $logger
+    ) {
+        $this->contentIdentityFactory = $contentIdentityFactory;
+        $this->contentAssetLinkFactory = $contentAssetLinkFactory;
+        $this->metadataPool = $metadataPool;
+        $this->resourceConnection = $resourceConnection;
+        $this->logger = $logger;
+    }
+
+    /**
+     * Returns content asset links wichs entity_id not exist anymore.
+     *
+     * @param string $entityType
+     * @throws CouldNotDeleteException
+     * @return ContentAssetLinkInterface[]
+     */
+    public function execute(string $entityType): array
+    {
+        $contentAssetLinks= [];
+        try {
+            $entityData = $this->metadataPool->getMetadata($entityType);
+            $connection = $this->resourceConnection->getConnection();
+            $mediaContentTable = $this->resourceConnection->getTableName(self::MEDIA_CONTENT_ASSET_TABLE);
+            $select = $connection->select();
+            
+            $select->from(['mca' => $mediaContentTable], ['asset_id', 'entity_id',  'entity_type', 'field']);
+            $select->joinLeft(
+                ['et' => $entityData->getEntityTable()],
+                'et.' . $entityData->getIdentifierField() . ' =  mca.entity_id ',
+                [$entityData->getIdentifierField(). ' AS entity_identifier']
+            );
+            $select->where('et.' . $entityData->getIdentifierField() . ' IS NULL');
+            $select->where('mca.entity_type = ?', $entityData->getEavEntityType() ?? $entityData->getEntityTable());
+            $assets = $connection->fetchAssoc($select);
+        } catch (\Exception $exception) {
+            $this->logger->critical($exception);
+            $message = __('Could not fetch media content links data');
+            throw new CouldNotDeleteException($message, $exception);
+        }
+
+        foreach ($assets as $asset) {
+            $contentIdentity = $this->contentIdentityFactory->create(
+                [
+                    'entityType' => $asset['entity_type'],
+                    'entityId' => $asset['entity_id'],
+                    'field' => $asset['field']
+                ]
+            );
+            $contentAssetLinks[] = $this->contentAssetLinkFactory->create(
+                [
+                    'assetId' => $asset['asset_id'],
+                    'contentIdentity' => $contentIdentity
+                ]
+            );
+        }
+
+        return $contentAssetLinks;
+    }
+}

--- a/MediaContentSynchronization/Model/ResourceModel/GetOutdatedRelations.php
+++ b/MediaContentSynchronization/Model/ResourceModel/GetOutdatedRelations.php
@@ -83,7 +83,7 @@ class GetOutdatedRelations
             $connection = $this->resourceConnection->getConnection();
             $mediaContentTable = $this->resourceConnection->getTableName(self::MEDIA_CONTENT_ASSET_TABLE);
             $select = $connection->select();
-            
+
             $select->from(['mca' => $mediaContentTable], ['asset_id', 'entity_id',  'entity_type', 'field']);
             $select->joinLeft(
                 ['et' => $entityData->getEntityTable()],
@@ -95,8 +95,7 @@ class GetOutdatedRelations
             $assets = $connection->fetchAssoc($select);
         } catch (\Exception $exception) {
             $this->logger->critical($exception);
-            $message = __('Could not fetch media content links data');
-            throw new CouldNotDeleteException($message, $exception);
+            throw new CouldNotDeleteException(__('Could not fetch media content links data'), $exception);
         }
 
         foreach ($assets as $asset) {

--- a/MediaContentSynchronization/Model/Synchronize.php
+++ b/MediaContentSynchronization/Model/Synchronize.php
@@ -13,6 +13,7 @@ use Magento\Framework\Stdlib\DateTime\DateTimeFactory;
 use Magento\MediaContentSynchronizationApi\Api\SynchronizeInterface;
 use Magento\MediaContentSynchronizationApi\Model\SynchronizerPool;
 use Psr\Log\LoggerInterface;
+use Magento\MediaContentSynchronization\Model\RemoveObsoleteContentAsset;
 
 /**
  * Synchronize content with assets
@@ -42,17 +43,25 @@ class Synchronize implements SynchronizeInterface
     private $synchronizerPool;
 
     /**
+     * @var RemoveObsoleteContentAsset
+     */
+    private $removeObsoleteContent;
+
+    /**
+     * @param RemoveObsoleteContentAsset $removeObsoleteContent
      * @param DateTimeFactory $dateFactory
      * @param FlagManager $flagManager
      * @param LoggerInterface $log
      * @param SynchronizerPool $synchronizerPool
      */
     public function __construct(
+        RemoveObsoleteContentAsset $removeObsoleteContent,
         DateTimeFactory $dateFactory,
         FlagManager $flagManager,
         LoggerInterface $log,
         SynchronizerPool $synchronizerPool
     ) {
+        $this->removeObsoleteContent = $removeObsoleteContent;
         $this->dateFactory = $dateFactory;
         $this->flagManager = $flagManager;
         $this->log = $log;
@@ -87,6 +96,7 @@ class Synchronize implements SynchronizeInterface
         }
 
         $this->setLastExecutionTime();
+        $this->removeObsoleteContent->execute();
     }
 
     /**

--- a/MediaContentSynchronization/composer.json
+++ b/MediaContentSynchronization/composer.json
@@ -5,7 +5,8 @@
         "php": "~7.3.0||~7.4.0",
         "magento/framework": "*",
         "magento/module-media-content-synchronization-api": "*",
-        "magento/framework-message-queue": "*"
+        "magento/framework-message-queue": "*",
+        "magento/module-media-content-api": "*"
     },
     "suggest": {
         "magento/module-media-gallery-synchronization": "*"

--- a/MediaContentSynchronizationApi/Model/Entities.php
+++ b/MediaContentSynchronizationApi/Model/Entities.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\MediaContentSynchronizationApi\Model;
+
+/**
+ * Configuration of entities used for media content.
+ */
+class Entities implements GetEntitiesInterface
+{
+    /**
+     * @var array
+     */
+    private $entities;
+
+    /**
+     * @param array $entities
+     */
+    public function __construct(
+        array $entities = []
+    ) {
+        $this->entities = $entities;
+    }
+
+    /**
+     * Get all entities configuration  used in media content.
+     *
+     * @return array
+     */
+    public function execute(): array
+    {
+        return $this->entities;
+    }
+}

--- a/MediaContentSynchronizationApi/Model/GetEntitiesInterface.php
+++ b/MediaContentSynchronizationApi/Model/GetEntitiesInterface.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\MediaContentSynchronizationApi\Model;
+
+/**
+ * Get Entites by provided configuration.
+ */
+interface GetEntitiesInterface
+{
+    /**
+     * Get entities that used for media content
+     *
+     * @return array
+     */
+    public function execute(): array;
+}

--- a/MediaContentSynchronizationApi/etc/di.xml
+++ b/MediaContentSynchronizationApi/etc/di.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <preference for="Magento\MediaContentSynchronizationApi\Model\GetEntitiesInterface" type="Magento\MediaContentSynchronizationApi\Model\Entities"/>
+</config>

--- a/MediaContentSynchronizationCatalog/etc/di.xml
+++ b/MediaContentSynchronizationCatalog/etc/di.xml
@@ -14,6 +14,14 @@
             </argument>
         </arguments>
     </type>
+    <type name="Magento\MediaContentSynchronizationApi\Model\GetEntitiesInterface">
+        <arguments>
+            <argument name="entities" xsi:type="array">
+                <item name="catalog_product" xsi:type="string">Magento\Catalog\Api\Data\ProductInterface</item>
+                <item name="catalog_category" xsi:type="string">Magento\Catalog\Api\Data\CategoryInterface</item>
+            </argument>
+        </arguments>
+    </type>
     <type name="Magento\MediaContentSynchronizationCatalog\Model\Synchronizer\Product">
         <arguments>
             <argument name="fields" xsi:type="array">

--- a/MediaContentSynchronizationCms/etc/di.xml
+++ b/MediaContentSynchronizationCms/etc/di.xml
@@ -14,6 +14,14 @@
             </argument>
         </arguments>
     </type>
+    <type name="Magento\MediaContentSynchronizationApi\Model\GetEntitiesInterface">
+        <arguments>
+            <argument name="entities" xsi:type="array">
+                <item name="cms_block" xsi:type="string">Magento\Cms\Api\Data\BlockInterface</item>
+                <item name="cms_page" xsi:type="string">Magento\Cms\Api\Data\PageInterface</item>
+            </argument>
+        </arguments>
+    </type>
     <type name="Magento\MediaContentSynchronizationCms\Model\Synchronizer\Block">
         <arguments>
             <argument name="fields" xsi:type="array">


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/adobe-stock-integration#1474: The "Used in" still displays that the image is used in a Product after the Product has been deleted
2. ...

### Manual testing scenarios (*)
1. Create a Product and add an image from Media Gallery
2. Go to Content - Media Gallery and View the Details of the image that was previously added to the Product
3. Verify that the Details display that the image is **Used In 1 Product**
4. Go to _Catalog - Products_ and **Delete** the previously created Product
5. Perform ``` bin/magento indexer:reindex, bin/magento media-content:sync, bin/magento cache:clean``` 
6. Go to Go to Content - Media Gallery and View the Details of the image that was previously Used

The image is not Used in a product so it should not be displayed in Details
