### PR TITLE
Update license action visibility based on overlay as is_lecensed column not exist anymore

### DIFF
--- a/AdobeStockImageAdminUi/Test/Mftf/ActionGroup/AdminAdobeStockImageAssertLicenseButtonNotAvailableInMediaGalleryActionGroup.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/ActionGroup/AdminAdobeStockImageAssertLicenseButtonNotAvailableInMediaGalleryActionGroup.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="AdminAdobeStockImageAssertLicenseButtonNotAvailableInMediaGalleryActionGroup">
+        <annotations>
+            <description>Opens View Details panel for the image asserts that license button not exists</description>
+        </annotations>
+
+        <click selector="{{AdminEnhancedMediaGalleryImageActionsSection.openContextMenu}}" stepKey="openContextMenu"/>
+        <dontSeeElement selector="{{AdminEnhancedMediaGalleryImageActionsSection.license}}" stepKey="assertLicenseButtonAvailable"/>
+        <click selector="{{AdminEnhancedMediaGalleryImageActionsSection.openContextMenu}}" stepKey="closeContextMenu"/>
+    </actionGroup>
+</actionGroups>

--- a/AdobeStockImageAdminUi/Test/Mftf/ActionGroup/AssertAdminAdobeStockImageAssertLicenseButtonMediaGalleryActionGroup.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/ActionGroup/AssertAdminAdobeStockImageAssertLicenseButtonMediaGalleryActionGroup.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="AssertAdminAdobeStockImageAssertLicenseButtonMediaGalleryActionGroup">
+        <annotations>
+            <description>Opens View Details panel for the unlicensed images asserts that license button exists</description>
+        </annotations>
+
+        <click selector="{{AdminEnhancedMediaGalleryImageActionsSection.openContextMenu}}" stepKey="openContextMenu"/>
+        <seeElement selector="{{AdminEnhancedMediaGalleryImageActionsSection.license}}" stepKey="assertLicenseButtonAvailable"/>
+        <click selector="{{AdminEnhancedMediaGalleryImageActionsSection.openContextMenu}}" stepKey="closeContextMenu"/>
+    </actionGroup>
+</actionGroups>
+

--- a/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockImageVerifyLicenseActionOnMediaGallery.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockImageVerifyLicenseActionOnMediaGallery.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+    <test name="AdminAdobeStockImageVerifyLicenseActionOnMediaGallery">
+        <annotations>
+            <features value="AdobeStockImagePanel"/>
+            <stories value="[Story #39] User license the preview image in Media Gallery"/>
+            <useCaseId value="https://github.com/magento/adobe-stock-integration/issues/1519"/>
+            <testCaseId value="https://studio.cucumber.io/projects/131313/test-plan/folders/1054245/scenarios/3586886"/>
+            <title value="Admin should be able to see license action on enhanced media gallery"/>
+            <description value="Admin should be able to see license action on enhanced media gallery"/>
+            <severity value="BLOCKER"/>
+            <group value="adobe_stock_media_gallery"/>
+        </annotations>
+        <before>
+            <actionGroup ref="AdminLoginActionGroup" stepKey="loginAsAdmin"/>
+            <actionGroup ref="AdminOpenMediaGalleryForPageNoEditorActionGroup" stepKey="openMediaGalleryForPage"/>
+            <actionGroup ref="AdminAdobeStockOpenFromEnhancedMediaGalleryActionGroup" stepKey="openAdobeStockPanel"/>
+        </before>
+        <after>
+            <actionGroup ref="ResetAdminDataGridToDefaultViewActionGroup" stepKey="resetAdminDataGridToDefaultView"/>
+            <actionGroup ref="AdminLogoutActionGroup" stepKey="logout"/>
+        </after>
+        <actionGroup ref="AdminSearchImagesOnModalActionGroup" stepKey="searchForUnlicensedImage">
+            <argument name="query" value="{{AdobeStockUnlicensedImage.id}}"/>
+        </actionGroup>
+        <actionGroup ref="AdminAdobeStockExpandImagePreviewActionGroup" stepKey="expandImagePreview"/>
+        <actionGroup ref="AdminAdobeStockSavePreviewActionGroup" stepKey="saveImagePreview"/>
+        <actionGroup ref="AdminSaveAdobeStockImagePreviewActionGroup" stepKey="confirmSaveImagePreview"/>
+        <actionGroup ref="AssertAdminAdobeStockImageUnlicensedLabelActionGroup" stepKey="assertUnlicensedLabel"/>
+        <actionGroup ref="AssertAdminAdobeStockImageAssertLicenseButtonMediaGalleryActionGroup" stepKey="assertLicenseButton"/>
+        <actionGroup ref="AdminEnhancedMediaGalleryImageDeleteActionGroup" stepKey="removeSavedPreview"/>
+        
+        <actionGroup ref="AdminEnhancedMediaGalleryUploadImageActionGroup" stepKey="uploadImage">
+            <argument name="image" value="ImageUpload3"/>
+        </actionGroup>
+        <actionGroup ref="AdminAdobeStockImageAssertLicenseButtonNotAvailableInMediaGalleryActionGroup" stepKey="assertLicenseButtonNotAvailable"/>
+        <actionGroup ref="AdminEnhancedMediaGalleryViewImageDetails" stepKey="viewImageDetails"/>
+        <actionGroup ref="AdminEnhancedMediaGalleryImageDetailsDeleteActionGroup" stepKey="deleteImage"/>
+    </test>
+</tests>

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/mediaGallery/grid/columns/image/licenseActions.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/mediaGallery/grid/columns/image/licenseActions.js
@@ -67,11 +67,11 @@ define([
          */
         isVisible: function (record, name) {
             if (name === this.licenseAction.name) {
-                if (_.isNull(record['is_licensed'])) {
+                if (_.isUndefined(record.overlay) || record.overlay === '') {
                     return false;
                 }
 
-                return !parseInt(record['is_licensed'], 16);
+                return true;
             }
 
             return true;


### PR DESCRIPTION


<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/adobe-stock-integration#1517: "License" button is available for already Licensed and locally Uploaded images 
2. ...

### Manual testing scenarios (*)
1. Go to **Content - Media Gallery**, click **Search Adobe Stock**
2. **Sign in** Adobe Stock
3. Save a Licensed image
4. Select the previously saved licensed image from Media Gallery
5. Click on "three dots" and verify is the **License** button is available

The License button should not be available for already licensed images
