### PR TITLE
fix long names UI issue in Media Gallery 

### DIFF
--- a/MediaGalleryUi/view/adminhtml/web/css/source/_module.less
+++ b/MediaGalleryUi/view/adminhtml/web/css/source/_module.less
@@ -148,7 +148,7 @@
                 display: -webkit-box;
                 font-size: 15px;
                 font-weight: bold;
-                line-height: 18px;
+                line-height: 20px;
                 max-height: 50px;
                 overflow: hidden;
                 padding-bottom: 2px;


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
The PR provides a fix for image names 

### Fixed Issues (if relevant)
Before the PR 
![front1](https://user-images.githubusercontent.com/45624059/85406403-6f7f5c80-b56a-11ea-8b87-dab1de7bdfc5.png)

After the PR 
![front2](https://user-images.githubusercontent.com/45624059/85406421-76a66a80-b56a-11ea-9cb1-5f249c71f772.png)

### Manual testing scenarios (*)
Save Several images with long file name to the Media Gallery
Observe the image names