### PR TITLE
#1518: The main actions buttons are not stretched to the end of the Image Details Page[Device View]

### DIFF
--- a/MediaGalleryUi/view/adminhtml/web/css/source/_module.less
+++ b/MediaGalleryUi/view/adminhtml/web/css/source/_module.less
@@ -286,23 +286,23 @@
         }
 
         .image-details {
-            display: block;
+            .lib-vendor-prefix-display();
 
             .image-details-image {
-                max-width: 500px;
-
                 img {
-                    max-height: 450px;
+                    max-height: 650px;
                 }
             }
 
             .image-details-sidebar {
-                margin-top: 20px;
+                .lib-vendor-prefix-flex-grow(1);
+                margin-top: 0;
+                padding-left: 40px;
 
                 .image-details-section {
+                    margin-bottom: 40px;
                     max-width: 400px;
                     min-width: 290px;
-                    margin-bottom: 40px;
                     word-wrap: anywhere;
                     .lib-clearfix();
                 }
@@ -369,19 +369,18 @@
     }
 }
 
-.media-width(@extremum, @break) when (@extremum = 'min') and (@break = @screen__m) {
+.media-width(@extremum, @break) when (@extremum = 'max') and (@break = @screen__m) {
     .media-gallery-image-details-modal {
         .image-details {
-            .lib-vendor-prefix-display();
+            display: block;
 
             .image-details-sidebar {
-                .lib-vendor-prefix-flex-grow(1);
-                margin-top: 0;
-                padding-left: 40px;
+                margin-top: 20px;
+                padding-left: 0;
             }
 
             .image-details-image img {
-                max-height: 650px;
+                max-height: 450px;
             }
         }
     }

--- a/MediaGalleryUi/view/adminhtml/web/css/source/_module.less
+++ b/MediaGalleryUi/view/adminhtml/web/css/source/_module.less
@@ -286,30 +286,30 @@
         }
 
         .image-details {
+            display: block;
+
             .image-details-image {
-                float: left;
-                max-width: 70%;
-                width: auto;
+                max-width: 500px;
 
                 img {
-                    max-height: 650px;
+                    max-height: 450px;
                 }
             }
 
             .image-details-sidebar {
-                float: left;
-                max-width: 30%;
-                padding-left: 40px;
+                margin-top: 20px;
 
                 .image-details-section {
+                    max-width: 400px;
+                    min-width: 290px;
                     margin-bottom: 40px;
-                    min-width: 350px;
                     word-wrap: anywhere;
                     .lib-clearfix();
                 }
 
                 h3.image-title {
                     font-weight: bold;
+                    line-height: 1.5;
                 }
 
                 .attributes {
@@ -366,5 +366,23 @@
     .masonry-results-number {
         display: inline-block;
         margin-right: 1.4rem;
+    }
+}
+
+.media-width(@extremum, @break) when (@extremum = 'min') and (@break = @screen__m) {
+    .media-gallery-image-details-modal {
+        .image-details {
+            .lib-vendor-prefix-display();
+
+            .image-details-sidebar {
+                .lib-vendor-prefix-flex-grow(1);
+                margin-top: 0;
+                padding-left: 40px;
+            }
+
+            .image-details-image img {
+                max-height: 650px;
+            }
+        }
     }
 }


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
This PR includes adjustments to the current RWD styling of image details page. Image and details will now stack together when reaching tablet screen size 767px and below.
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/adobe-stock-integration#1518: The main action buttons are not stretched to the end of the Image Details page [Device View]

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Login to Admin panel
2. Go to Content > Media > Media Gallery
3. Select an image, click the "three dots" icon, then click **View Details**
4. Resize your browser by either manually resizing the window or use the Responsive Web View of your browser.
![image](https://user-images.githubusercontent.com/47961795/85605190-8ade8a80-b684-11ea-971c-b4f0046f0085.png)
