### PR TITLE
Use getMaxFileSize instead of a constant

### DIFF
--- a/MediaGalleryUi/Ui/Component/ImageUploader.php
+++ b/MediaGalleryUi/Ui/Component/ImageUploader.php
@@ -20,7 +20,6 @@ class ImageUploader extends Container
     private const ACCEPT_FILE_TYPES = '/(\.|\/)(gif|jpe?g|png)$/i';
     private const ALLOWED_EXTENSIONS = 'jpg jpeg png gif';
 
-
     /**
      * @var UrlInterface
      */

--- a/MediaGalleryUi/Ui/Component/ImageUploader.php
+++ b/MediaGalleryUi/Ui/Component/ImageUploader.php
@@ -10,6 +10,7 @@ namespace Magento\MediaGalleryUi\Ui\Component;
 use Magento\Framework\UrlInterface;
 use Magento\Framework\View\Element\UiComponent\ContextInterface;
 use Magento\Ui\Component\Container;
+use Magento\Framework\File\Size;
 
 /**
  * Image Uploader component
@@ -18,7 +19,7 @@ class ImageUploader extends Container
 {
     private const ACCEPT_FILE_TYPES = '/(\.|\/)(gif|jpe?g|png)$/i';
     private const ALLOWED_EXTENSIONS = 'jpg jpeg png gif';
-    private const MAX_FILE_SIZE = '2097152';
+
 
     /**
      * @var UrlInterface
@@ -26,20 +27,26 @@ class ImageUploader extends Container
     private $url;
 
     /**
-     * Constructor
-     *
+     * @var Size
+     */
+    private $size;
+    
+    /**
+     * @param Size $size
      * @param ContextInterface $context
      * @param UrlInterface $url
      * @param array $components
      * @param array $data
      */
     public function __construct(
+        Size $size,
         ContextInterface $context,
         UrlInterface $url,
         array $components = [],
         array $data = []
     ) {
         parent::__construct($context, $components, $data);
+        $this->size = $size;
         $this->url = $url;
     }
 
@@ -57,7 +64,7 @@ class ImageUploader extends Container
                     'imageUploadUrl' => $this->url->getUrl('media_gallery/image/upload', ['type' => 'image']),
                     'acceptFileTypes' => self::ACCEPT_FILE_TYPES,
                     'allowedExtensions' => self::ALLOWED_EXTENSIONS,
-                    'maxFileSize' => self::MAX_FILE_SIZE
+                    'maxFileSize' => $this->size->getMaxFileSize()
                 ]
             )
         );


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/adobe-stock-integration#1524: The max file size for Media Gallery Uploader is not dependent on settings in "php.ini" file
2. ...

### Manual testing scenarios (*)
Change the max file size value for Media Gallery uploader is depend on the size set in the _php.ini_ file

