### PR TITLE
ASI-1543: represent an error message text into the console

### DIFF
--- a/AdobeIms/view/adminhtml/web/js/action/authorization.js
+++ b/AdobeIms/view/adminhtml/web/js/action/authorization.js
@@ -113,6 +113,11 @@ define([
                 if (authWindow.closed) {
                     clearTimeout(stopWatcherId);
                     clearInterval(watcherId);
+
+                    // eslint-disable-next-line max-depth
+                    if (window.adobeIMSAuthWindow && window.adobeIMSAuthWindow.closed) {
+                        deferred.reject();
+                    }
                 }
             }
         }

--- a/AdobeIms/view/adminhtml/web/js/action/authorization.js
+++ b/AdobeIms/view/adminhtml/web/js/action/authorization.js
@@ -113,11 +113,6 @@ define([
                 if (authWindow.closed) {
                     clearTimeout(stopWatcherId);
                     clearInterval(watcherId);
-
-                    // eslint-disable-next-line max-depth
-                    if (window.adobeIMSAuthWindow && window.adobeIMSAuthWindow.closed) {
-                        deferred.reject(new Error('Authentication window was closed.'));
-                    }
                 }
             }
         }

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/mediaGallery/grid/columns/image/licenseActions.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/mediaGallery/grid/columns/image/licenseActions.js
@@ -98,13 +98,11 @@ define([
                     this.imageModel().addMessage('success', $.mage.__('The image has been licensed.'));
                 }.bind(this)).fail(function (error) {
                     if (error) {
-                        console.log(error.message);
+                        this.imageModel().addMessage('error', error);
                     }
                 });
             }.bind(this)).fail(function (message) {
-                if (message) {
-                    console.log(message);
-                }
+                this.imageModel().addMessage('error', message);
             });
         }
     });

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/mediaGallery/grid/columns/image/licenseActions.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/mediaGallery/grid/columns/image/licenseActions.js
@@ -98,11 +98,13 @@ define([
                     this.imageModel().addMessage('success', $.mage.__('The image has been licensed.'));
                 }.bind(this)).fail(function (error) {
                     if (error) {
-                        this.imageModel().addMessage('error', error);
+                        console.log(error.message);
                     }
                 });
             }.bind(this)).fail(function (message) {
-                this.imageModel().addMessage('error', message);
+                if (message) {
+                    console.log(message);
+                }
             });
         }
     });


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
This PR provides changes related to the #1543 
As a suggestion, I just represent the error message text received from the Adobe auth service directly into the console.

Error from the service
![image](https://user-images.githubusercontent.com/5318512/86008742-dfd22600-ba21-11ea-93b1-d2f48a23569d.png)

Console representation
![image](https://user-images.githubusercontent.com/5318512/86008471-8538ca00-ba21-11ea-9c99-42c345f88a85.png)

@chalov-anton please, validate this approach.

### Fixed Issues (if relevant)
#1543 

### Manual testing scenarios (*)
#1543 