### PR TITLE
Depend "Delete Images" button visibility on images records count

### DIFF
--- a/MediaGalleryUi/view/adminhtml/ui_component/media_gallery_listing.xml
+++ b/MediaGalleryUi/view/adminhtml/ui_component/media_gallery_listing.xml
@@ -158,7 +158,8 @@
               <argument name="data" xsi:type="array">
                   <item name="config" xsi:type="array">
                       <item name="checkboxComponentName" xsi:type="string">media_gallery_listing.media_gallery_listing.media_gallery_columns.massaction_checkbox</item>
-                       <item name="imageModelName" xsi:type="string">media_gallery_listing.media_gallery_listing.media_gallery_columns.thumbnail_url</item>
+                      <item name="imageModelName" xsi:type="string">media_gallery_listing.media_gallery_listing.media_gallery_columns.thumbnail_url</item>
+                      <item name="mediaGalleryProvider" xsi:type="string">media_gallery_listing.media_gallery_listing_data_source</item>
                   </item>
             </argument>
         </container>

--- a/MediaGalleryUi/view/adminhtml/ui_component/standalone_media_gallery_listing.xml
+++ b/MediaGalleryUi/view/adminhtml/ui_component/standalone_media_gallery_listing.xml
@@ -145,7 +145,8 @@
               <argument name="data" xsi:type="array">
                   <item name="config" xsi:type="array">
                       <item name="checkboxComponentName" xsi:type="string">standalone_media_gallery_listing.standalone_media_gallery_listing.media_gallery_columns.massaction_checkbox</item>
-                       <item name="imageModelName" xsi:type="string">standalone_media_gallery_listing.standalone_media_gallery_listing.media_gallery_columns.thumbnail_url</item>
+                      <item name="imageModelName" xsi:type="string">standalone_media_gallery_listing.standalone_media_gallery_listing.media_gallery_columns.thumbnail_url</item>
+                      <item name="mediaGalleryProvider" xsi:type="string">standalone_media_gallery_listing.media_gallery_listing_data_source</item>
                   </item>
             </argument>
         </container>

--- a/MediaGalleryUi/view/adminhtml/web/js/grid/massaction/massactions.js
+++ b/MediaGalleryUi/view/adminhtml/web/js/grid/massaction/massactions.js
@@ -15,6 +15,7 @@ define([
 
     return Component.extend({
         defaults: {
+            deleteImagesSelector: '#delete_massaction',
             mediaGalleryImageDetailsName: 'mediaGalleryImageDetails',
             modules: {
                 massactionView: '${ $.name }_view',
@@ -27,6 +28,12 @@ define([
                     name: '${ $.name }_view'
                 }
             ],
+            imports: {
+                imageItems: '${ $.mediaGalleryProvider }:data.items'
+            },
+            listens: {
+                imageItems: 'checkButtonVisibility'
+            },
             exports: {
                 massActionMode: '${ $.name }_view:massActionMode'
             }
@@ -90,6 +97,17 @@ define([
             }
 
             return 0;
+        },
+
+        /**
+         * If images record less then one disable delete images button
+         */
+        checkButtonVisibility: function () {
+            if (this.imageItems.length < 1) {
+                $(this.deleteImagesSelector).addClass('disabled');
+            } else {
+                $(this.deleteImagesSelector).removeClass('disabled');
+            }
         },
 
         /**

--- a/MediaGalleryUi/view/adminhtml/web/js/grid/massaction/massactions.js
+++ b/MediaGalleryUi/view/adminhtml/web/js/grid/massaction/massactions.js
@@ -100,7 +100,7 @@ define([
         },
 
         /**
-         * If images record less then one disable delete images button
+         * If images records less than one, disable "delete images" button
          */
         checkButtonVisibility: function () {
             if (this.imageItems.length < 1) {

--- a/MediaGalleryUi/view/adminhtml/web/template/grid/massactions/count.html
+++ b/MediaGalleryUi/view/adminhtml/web/template/grid/massactions/count.html
@@ -5,5 +5,5 @@
  */
 -->
 <div data-bind="visible: massActionMode()" class="mediagallery-massaction-items-count">
-  <div class="selected_count_text">(<!--ko text: getSelectedCount()--><!--/ko--> Selected) </div>
+  <div class="selected_count_text">(<b><!--ko text: getSelectedCount()--><!--/ko--> Selected</b>) </div>
 </div>


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/adobe-stock-integration#1557: The 'Delete Images...' button is active when there are no images in Media Gallery [Improvement]
2. Fixes magento/adobe-stock-integration#1559: Make the 'number_of_images selected' counter more noticeable 

### Manual testing scenarios (*)
1. Go to **Content - Media Gallery**
2. Verify that there are no images in Media Gallery
3. Verify if the **Delete Images** button is active

### Expected result (*)
Since there are no images in Media Gallery, the **Delete images...** button should not be active
