### PR TITLE
Adjust getIMageDetails to the bulk parameters

### DIFF
--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/mediaGallery/grid/columns/image/licenseActions.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/mediaGallery/grid/columns/image/licenseActions.js
@@ -83,8 +83,8 @@ define([
          * @param {Number} imageId
          */
         getImageRecord: function (imageId) {
-            getDetails(this.imageDetailsUrl, imageId).then(function (imageDetails) {
-                var id = imageDetails['adobe_stock'][0].value;
+            getDetails(this.imageDetailsUrl, [imageId]).then(function (imageDetails) {
+                var id = imageDetails[imageId]['adobe_stock'][0].value;
 
                 this.image().actions().licenseProcess(
                     id,

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/mediaGallery/grid/columns/image/licenseActions.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/mediaGallery/grid/columns/image/licenseActions.js
@@ -88,9 +88,9 @@ define([
 
                 this.image().actions().licenseProcess(
                     id,
-                    imageDetails.title,
-                    imageDetails.path,
-                    imageDetails['content_type'],
+                    imageDetails[imageId].title,
+                    imageDetails[imageId].path,
+                    imageDetails[imageId]['content_type'],
                     true
                 ).then(function () {
                     this.image().actions().login().getUserQuota();


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/adobe-stock-integration#1565: Spinner hangs and errors appear in dev console if try to license an image form Media Gallery using an account with zero licenses
2. ...

### Manual testing scenarios (*)
1. Go to **Content - Media Gallery**
2. Click **Search Adobe Stock**
3. Sign In with an account that has Zero licenses
4. Select an image and click **Save Preview**
5. Select the previously saved image from Media Gallery
6. Click on "three dots" at the bottom right of the image and select **License**

### Expected result (*)
A message which informs that there are no available licenses
