### PR TITLE
#1561: Grammar mistakes in "Delete image" confirmation message

### DIFF
--- a/MediaGalleryUi/view/adminhtml/web/js/action/deleteImageWithDetailConfirmation.js
+++ b/MediaGalleryUi/view/adminhtml/web/js/action/deleteImageWithDetailConfirmation.js
@@ -53,10 +53,12 @@ define([
          * @return {String}
          */
         getRecordRelatedContentMessage: function (imageDetails) {
-            var usedInMessage = $.mage.__('This image%p is used in %s.'),
+            var usedInMessage = $.mage.__('%n image%p %v used in %s.'),
                 usedIn = {},
                 message = '',
-                prefix = Object.keys(imageDetails).length  > 1 ? 's' : '';
+                pronoun,
+                s,
+                linkingVerb;
 
             $.each(imageDetails, function (key, image) {
                 if (_.isObject(image.details[6]) && !_.isEmpty(image.details[6].value)) {
@@ -73,8 +75,19 @@ define([
                 message +=  count + ' ' +  this.getEntityNameWithPrefix(entityName, count) +  ', ';
             }.bind(this));
 
+            if (Object.keys(imageDetails).length  > 1) {
+                pronoun = 'These';
+                s = 's';
+                linkingVerb = 'are';
+            } else {
+                pronoun = 'This';
+                s = '';
+                linkingVerb = 'is';
+            }
+
             message = message.replace(/,\s*$/, '');
-            message = usedInMessage.replace('%s', message).replace('%p', prefix);
+            message = usedInMessage.replace('%s', message).replace('%n', pronoun).replace('%p', s)
+                .replace('%v', linkingVerb);
 
             return message;
         },


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR will fix the grammar issue found in the "Delete Image" confirmation message.
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/adobe-stock-integration https://github.com/magento/adobe-stock-integration/issues/1561: Grammar mistakes in "Delete image" confirmation message
2. ...

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->

1. Go to Content - Media Gallery
2. Click Delete Images
3. Select the image which is used in one entity and one more image
4. Click Delete Selected
5. Observe the Delete image confirmation message.

### Expected Result (*)
![86589878-24683f00-bf97-11ea-9b10-4331ef0786fb](https://user-images.githubusercontent.com/23549533/86903091-71881480-c141-11ea-9439-9c7baa6a3505.png)

