### PR TITLE
[2.0.0][MFTF] Add search filter to drop defaults filters and have unique images

### DIFF
--- a/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockGridSortTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockGridSortTest.xml
@@ -28,6 +28,9 @@
             <actionGroup ref="ResetAdminDataGridToDefaultViewActionGroup" stepKey="resetAdminDataGridToDefaultView"/>
             <actionGroup ref="AdminLogoutActionGroup" stepKey="logout"/>
         </after>
+        <actionGroup ref="AdminSearchImagesOnModalActionGroup" stepKey="searchForCarsToDropDefaultFilter">
+            <argument name="query" value="cars"/>
+        </actionGroup>
         <actionGroup ref="AdminAdobeStockClickSortActionGroup" stepKey="sortByCreation">
             <argument name="sortName" value="creation"/>
         </actionGroup>

--- a/AdobeStockImageAdminUi/Test/Mftf/Test/AdminMediaGalleryViewAdobeStockDetailsTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/AdminMediaGalleryViewAdobeStockDetailsTest.xml
@@ -11,6 +11,7 @@
         <annotations>
             <features value="AdobeStockMediaGallery"/>
             <useCaseId value="https://github.com/magento/adobe-stock-integration/issues/428"/>
+            <stories value="View adobe stock image details"/>
             <title value="View adobe stock image details"/>
             <testCaseId value="https://studio.cucumber.io/projects/131313/test-plan/folders/1054245/scenarios/4653671"/>
             <description value="User views adobe stock image attributes in Media Gallery"/>

--- a/MediaGalleryUi/Test/Mftf/Test/AdminMediaGalleryUploadCategoryImageTest.xml
+++ b/MediaGalleryUi/Test/Mftf/Test/AdminMediaGalleryUploadCategoryImageTest.xml
@@ -11,6 +11,7 @@
         <annotations>
             <features value="AdminMediaGalleryImagePanel"/>
             <useCaseId value="https://github.com/magento/adobe-stock-integration/issues/1435"/>
+            <stories value="User uploads image outside of the Media Gallery"/>
             <title value="User uploads image outside of the Media Gallery"/>
             <testCaseId value="https://studio.cucumber.io/projects/131313/test-plan/folders/943908/scenarios/4836631"/>
             <description value="User uploads image outside of the Media Gallery"/>


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
 Add search filter to drop defaults filters and have unique images

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/adobe-stock-integration#1563: Fix failed mftf tests

### Manual testing scenarios (*)
MFTF tests all green
