### PR TITLE
#1573 :- Possible to Edit image and save it with empty name

### DIFF
--- a/MediaGalleryUi/view/adminhtml/web/js/image/image-actions.js
+++ b/MediaGalleryUi/view/adminhtml/web/js/image/image-actions.js
@@ -74,6 +74,7 @@ define([
         saveImageDetailsAction: function () {
             var saveDetailsUrl = this.mediaGalleryEditDetails().saveDetailsUrl,
                 modalElement = $(this.modalSelector);
+
             modalElement.find('#image-edit-details-form').validation();
 
             if (modalElement.find('#image-edit-details-form').validation('isValid')) {

--- a/MediaGalleryUi/view/adminhtml/web/js/image/image-actions.js
+++ b/MediaGalleryUi/view/adminhtml/web/js/image/image-actions.js
@@ -9,7 +9,8 @@ define([
     'uiElement',
     'Magento_MediaGalleryUi/js/action/deleteImageWithDetailConfirmation',
     'Magento_MediaGalleryUi/js/grid/columns/image/insertImageAction',
-    'Magento_MediaGalleryUi/js/action/saveDetails'
+    'Magento_MediaGalleryUi/js/action/saveDetails',
+    'mage/validation'
 ], function ($, _, Element, deleteImageWithDetailConfirmation, addSelected, saveDetails) {
     'use strict';
 
@@ -73,15 +74,16 @@ define([
         saveImageDetailsAction: function () {
             var saveDetailsUrl = this.mediaGalleryEditDetails().saveDetailsUrl,
                 modalElement = $(this.modalSelector);
-
-            saveDetails(
-                saveDetailsUrl,
-                modalElement.find('#image-edit-details-form')
-            ).then(function () {
-                this.closeModal();
-                this.imageModel().reloadGrid();
-            }.bind(this));
-
+            modalElement.find('#image-edit-details-form').validation();
+            if (modalElement.find('#image-edit-details-form').validation('isValid')) {
+                saveDetails(
+                    saveDetailsUrl,
+                    modalElement.find('#image-edit-details-form')
+                ).then(function () {
+                    this.closeModal();
+                    this.imageModel().reloadGrid();
+                }.bind(this));
+            }
         },
 
         /**

--- a/MediaGalleryUi/view/adminhtml/web/js/image/image-actions.js
+++ b/MediaGalleryUi/view/adminhtml/web/js/image/image-actions.js
@@ -75,6 +75,7 @@ define([
             var saveDetailsUrl = this.mediaGalleryEditDetails().saveDetailsUrl,
                 modalElement = $(this.modalSelector);
             modalElement.find('#image-edit-details-form').validation();
+
             if (modalElement.find('#image-edit-details-form').validation('isValid')) {
                 saveDetails(
                     saveDetailsUrl,

--- a/MediaGalleryUi/view/adminhtml/web/template/image/image-edit.html
+++ b/MediaGalleryUi/view/adminhtml/web/template/image/image-edit.html
@@ -13,8 +13,8 @@
                     <span>Name</span>
                 </label>
                 <div class="admin__field-control">
-                    <input type="text" id="title" data-ui-id="title" name="title" placeholder="Title"
-                           class="admin__control-text required-entry" data-bind="value: image().title" />
+                    <input type="text" data-validate="{required:true}" id="title" data-ui-id="title" name="title" placeholder="Title"
+                           class="admin__control-text" data-bind="value: image().title" />
                 </div>
             </div>
             <div class="admin__field">


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR will fix the issue with the image title validation issue
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/adobe-stock-integration#1573: Possible to Edit image and save it with empty name

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Go to Content - Media Gallery
2. Select an image from Media Gallery and click "three dots" in the bottom right
3. Select Edit
4. Remove all the text from the Name field
5. Click Save button

### Expected Result 
![image](https://user-images.githubusercontent.com/39480008/86958218-710b7000-c179-11ea-8f71-321941a154ca.png)

