### PR TITLE
#1582 & #1583 Improvements

### DIFF
--- a/MediaGalleryUi/Test/Mftf/ActionGroup/AdminEnhancedMediaGalleryVerifyImageFilenameActionGroup.xml
+++ b/MediaGalleryUi/Test/Mftf/ActionGroup/AdminEnhancedMediaGalleryVerifyImageFilenameActionGroup.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="AdminEnhancedMediaGalleryVerifyImageFilenameActionGroup">
+        <annotations>
+            <description>Verifies image filename on the View Details panel</description>
+        </annotations>
+        <arguments>
+            <argument name="filename" type="string"/>
+        </arguments>
+
+        <grabTextFrom selector="{{AdminEnhancedMediaGalleryViewDetailsSection.filename}}" stepKey="grabFilename"/>
+        <assertStringContainsString stepKey="verifyFilename">
+            <actualResult type="variable">grabFilename</actualResult>
+            <expectedResult type="string">{{filename}}</expectedResult>
+        </assertStringContainsString>
+    </actionGroup>
+</actionGroups>

--- a/MediaGalleryUi/Test/Mftf/Section/AdminEnhancedMediaGalleryViewDetailsSection.xml
+++ b/MediaGalleryUi/Test/Mftf/Section/AdminEnhancedMediaGalleryViewDetailsSection.xml
@@ -13,6 +13,7 @@
         <element name="type" type="text" selector="//div[@class='attribute']/span[contains(text(), 'Type')]/following-sibling::div"/>
         <element name="height" type="text" selector="//div[@class='attribute']/span[contains(text(), 'Height')]/following-sibling::div"/>
         <element name="description" type="text" selector=".image-details-section.description p"/>
+        <element name="filename" type="text" selector=".image-details-section.filename p"/>
         <element name="delete" type="button" selector="//div[@class='media-gallery-image-details-modal']//button[contains(@class, 'delete')]"/>
         <element name="confirmDelete" type="button" selector=".action-accept"/>
         <element name="addImage" type="button" selector=".add-image-action"/>

--- a/MediaGalleryUi/Test/Mftf/Test/AdminMediaGalleryViewDetailsTest.xml
+++ b/MediaGalleryUi/Test/Mftf/Test/AdminMediaGalleryViewDetailsTest.xml
@@ -33,5 +33,8 @@
         <actionGroup ref="AdminEnhancedMediaGalleryVerifyImageDetailsActionGroup" stepKey="verifyImageDetails">
             <argument name="image" value="ImageUpload"/>
         </actionGroup>
+        <actionGroup ref="AdminEnhancedMediaGalleryVerifyImageFilenameActionGroup" stepKey="verifyFilename">
+            <argument name="filename" value="{{ImageUpload.file}}"/>
+        </actionGroup>
     </test>
 </tests>

--- a/MediaGalleryUi/Test/Mftf/Test/AdminStandaloneMediaGalleryViewDetailsTest.xml
+++ b/MediaGalleryUi/Test/Mftf/Test/AdminStandaloneMediaGalleryViewDetailsTest.xml
@@ -33,5 +33,8 @@
         <actionGroup ref="AdminEnhancedMediaGalleryVerifyImageDetailsActionGroup" stepKey="verifyImageDetails">
             <argument name="image" value="ImageUpload"/>
         </actionGroup>
+        <actionGroup ref="AdminEnhancedMediaGalleryVerifyImageFilenameActionGroup" stepKey="verifyFilename">
+            <argument name="filename" value="{{ImageUpload.file}}"/>
+        </actionGroup>
     </test>
 </tests>

--- a/MediaGalleryUi/view/adminhtml/web/template/image/image-details.html
+++ b/MediaGalleryUi/view/adminhtml/web/template/image/image-details.html
@@ -16,6 +16,10 @@
                 <span class="type" data-ui-id="content-type" data-bind="text: image().content_type"></span>
             </div>
         </div>
+        <div class="filename image-details-section">
+            <h3 data-bind="i18n: 'Filename'"></h3>
+            <p data-bind="text: image().path"></p>
+        </div>
         <div class="general-details image-details-section" if="image().details">
             <h3 data-bind="i18n: 'Details'"></h3>
             <div class="attributes">

--- a/MediaGalleryUi/view/adminhtml/web/template/image/image-edit.html
+++ b/MediaGalleryUi/view/adminhtml/web/template/image/image-edit.html
@@ -10,7 +10,7 @@
             <input type="hidden" data-bind="value: image().id" data-ui-id="id" name="id"/>
             <div class="admin__field _required">
                 <label for="title" class="admin__field-label">
-                    <span>Name</span>
+                    <span>Title</span>
                 </label>
                 <div class="admin__field-control">
                     <input type="text" data-validate="{required:true}" id="title" data-ui-id="title" name="title" placeholder="Title"

--- a/MediaGalleryUi/view/adminhtml/web/template/image/image-edit.html
+++ b/MediaGalleryUi/view/adminhtml/web/template/image/image-edit.html
@@ -10,7 +10,7 @@
             <input type="hidden" data-bind="value: image().id" data-ui-id="id" name="id"/>
             <div class="admin__field _required">
                 <label for="title" class="admin__field-label">
-                    <span>Title</span>
+                    <span data-bind="i18n: 'Title'"></span>
                 </label>
                 <div class="admin__field-control">
                     <input type="text" data-validate="{required:true}" id="title" data-ui-id="title" name="title" placeholder="Title"
@@ -19,7 +19,7 @@
             </div>
             <div class="admin__field">
                 <label for="path" class="admin__field-label">
-                    <span>Filename</span>
+                    <span data-bind="i18n: 'Filename'"></span>
                 </label>
                 <div class="admin__field-control path-display">
                     <span data-ui-id="path" id="path" data-bind="text: image().path"></span>
@@ -27,7 +27,7 @@
             </div>
             <div class="admin__field">
                 <label for="description" class="admin__field-label">
-                    <span>Description</span>
+                    <span data-bind="i18n: 'Description'"></span>
                 </label>
                 <div class="admin__field-control">
                     <textarea id="description"


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR will add the filename in image detail and also renamed the image name label
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/adobe-stock-integration#1582: Add "filename" information to Image Details page [Improvement]
2. Fixes magento/adobe-stock-integration#1583: Rename the field "Name" into "Title" on Edit Image page [Improvement]

### Expected result
**Renamed label**
![image](https://user-images.githubusercontent.com/39480008/87074261-38809a80-c23c-11ea-8c0a-9ee37c297c4b.png)
**Filename added**
![image](https://user-images.githubusercontent.com/39480008/87074296-47674d00-c23c-11ea-97c8-9f61095a4e0a.png)

