### PR TITLE
The newly added Description will appear in Image Details only after the web page is refreshed

### DIFF
--- a/MediaGalleryUi/view/adminhtml/web/js/image/image-actions.js
+++ b/MediaGalleryUi/view/adminhtml/web/js/image/image-actions.js
@@ -74,14 +74,15 @@ define([
         saveImageDetailsAction: function () {
             var saveDetailsUrl = this.mediaGalleryEditDetails().saveDetailsUrl,
                 modalElement = $(this.modalSelector),
+                dataForm = modalElement.find('#image-edit-details-form'),
                 imageId = this.imageModel().getSelected().id;
 
             modalElement.find('#image-edit-details-form').validation();
 
-            if (modalElement.find('#image-edit-details-form').validation('isValid')) {
+            if (dataForm.validation('isValid')) {
                 saveDetails(
                     saveDetailsUrl,
-                    modalElement.find('#image-edit-details-form')
+                    dataForm
                 ).then(function () {
                     this.closeModal();
                     this.imageModel().reloadGrid();

--- a/MediaGalleryUi/view/adminhtml/web/js/image/image-actions.js
+++ b/MediaGalleryUi/view/adminhtml/web/js/image/image-actions.js
@@ -77,8 +77,6 @@ define([
                 dataForm = modalElement.find('#image-edit-details-form'),
                 imageId = this.imageModel().getSelected().id;
 
-            modalElement.find('#image-edit-details-form').validation();
-
             if (dataForm.validation('isValid')) {
                 saveDetails(
                     saveDetailsUrl,

--- a/MediaGalleryUi/view/adminhtml/web/js/image/image-actions.js
+++ b/MediaGalleryUi/view/adminhtml/web/js/image/image-actions.js
@@ -73,7 +73,10 @@ define([
          */
         saveImageDetailsAction: function () {
             var saveDetailsUrl = this.mediaGalleryEditDetails().saveDetailsUrl,
-                modalElement = $(this.modalSelector);
+                modalElement = $(this.modalSelector),
+                localStorageKey = this.mediaGalleryImageDetails().storageConfig.namespace,
+                imageId = this.imageModel().getSelected().id,
+                newImageDetails = this.mediaGalleryEditDetails().images[imageId];
 
             modalElement.find('#image-edit-details-form').validation();
 
@@ -84,6 +87,7 @@ define([
                 ).then(function () {
                     this.closeModal();
                     this.imageModel().reloadGrid();
+                    localStorage.setItem(localStorageKey, JSON.stringify(newImageDetails));
                 }.bind(this));
             }
         },

--- a/MediaGalleryUi/view/adminhtml/web/js/image/image-actions.js
+++ b/MediaGalleryUi/view/adminhtml/web/js/image/image-actions.js
@@ -74,9 +74,7 @@ define([
         saveImageDetailsAction: function () {
             var saveDetailsUrl = this.mediaGalleryEditDetails().saveDetailsUrl,
                 modalElement = $(this.modalSelector),
-                localStorageKey = this.mediaGalleryImageDetails().storageConfig.namespace,
-                imageId = this.imageModel().getSelected().id,
-                newImageDetails = this.mediaGalleryEditDetails().images[imageId];
+                imageId = this.imageModel().getSelected().id;
 
             modalElement.find('#image-edit-details-form').validation();
 
@@ -87,7 +85,7 @@ define([
                 ).then(function () {
                     this.closeModal();
                     this.imageModel().reloadGrid();
-                    localStorage.setItem(localStorageKey, JSON.stringify(newImageDetails));
+                    this.mediaGalleryImageDetails().removeCached(imageId);
                 }.bind(this));
             }
         },

--- a/MediaGalleryUi/view/adminhtml/web/js/image/image-details.js
+++ b/MediaGalleryUi/view/adminhtml/web/js/image/image-details.js
@@ -47,9 +47,6 @@ define([
          * @param {String} imageId
          */
         showImageDetailsById: function (imageId) {
-            var localStorageKey = this.storageConfig.namespace,
-                newImageDetails = JSON.parse(localStorage.getItem(localStorageKey));
-
             if (_.isUndefined(this.images[imageId])) {
                 getDetails(this.imageDetailsUrl, [imageId]).then(function (imageDetails) {
                     this.images[imageId] = imageDetails[imageId];
@@ -68,12 +65,7 @@ define([
                 return;
             }
 
-            if (newImageDetails) {
-                this.image(newImageDetails)
-            } else {
-                this.image(this.images[imageId]);
-            }
-
+            this.image(this.images[imageId]);
             this.openImageDetailsModal();
         },
 
@@ -175,6 +167,15 @@ define([
             }
 
             return entityName;
+        },
+
+        /**
+         * Remove image details
+         *
+         * @param id
+         */
+        removeCached: function (id) {
+            delete this.images[id];
         }
     });
 });

--- a/MediaGalleryUi/view/adminhtml/web/js/image/image-details.js
+++ b/MediaGalleryUi/view/adminhtml/web/js/image/image-details.js
@@ -47,7 +47,7 @@ define([
          * @param {String} imageId
          */
         showImageDetailsById: function (imageId) {
-            if (_.isUndefined(this.images[imageId])) {
+            if (_.isUndefined(this.images[imageId]) || this.images[imageId]) {
                 getDetails(this.imageDetailsUrl, [imageId]).then(function (imageDetails) {
                     this.images[imageId] = imageDetails[imageId];
                     this.image(this.images[imageId]);

--- a/MediaGalleryUi/view/adminhtml/web/js/image/image-details.js
+++ b/MediaGalleryUi/view/adminhtml/web/js/image/image-details.js
@@ -47,7 +47,10 @@ define([
          * @param {String} imageId
          */
         showImageDetailsById: function (imageId) {
-            if (_.isUndefined(this.images[imageId]) || this.images[imageId]) {
+            var localStorageKey = this.storageConfig.namespace,
+                newImageDetails = JSON.parse(localStorage.getItem(localStorageKey));
+
+            if (_.isUndefined(this.images[imageId])) {
                 getDetails(this.imageDetailsUrl, [imageId]).then(function (imageDetails) {
                     this.images[imageId] = imageDetails[imageId];
                     this.image(this.images[imageId]);
@@ -65,7 +68,12 @@ define([
                 return;
             }
 
-            this.image(this.images[imageId]);
+            if (newImageDetails) {
+                this.image(newImageDetails)
+            } else {
+                this.image(this.images[imageId]);
+            }
+
             this.openImageDetailsModal();
         },
 

--- a/MediaGalleryUi/view/adminhtml/web/js/image/image-details.js
+++ b/MediaGalleryUi/view/adminhtml/web/js/image/image-details.js
@@ -172,7 +172,7 @@ define([
         /**
          * Remove image details
          *
-         * @param id
+         * @param {String} id
          */
         removeCached: function (id) {
             delete this.images[id];

--- a/MediaGalleryUi/view/adminhtml/web/template/image/image-edit.html
+++ b/MediaGalleryUi/view/adminhtml/web/template/image/image-edit.html
@@ -5,7 +5,7 @@
  */
 -->
 <div class="edit-image-details" if="image">
-    <form id="image-edit-details-form" method="post" enctype="multipart/form-data">
+    <form data-bind="mageInit:{'validation':{}}" id="image-edit-details-form" method="post" enctype="multipart/form-data">
         <fieldset class="admin__fieldset">
             <input type="hidden" data-bind="value: image().id" data-ui-id="id" name="id"/>
             <div class="admin__field _required">
@@ -33,7 +33,7 @@
                     <textarea id="description"
                               data-ui-id="description"
                               name="description"
-                              class="admin__control-textarea"
+                              class="admin__control-textarea minimum-length-0 maximum-length-500"
                               rows="7" cols="80"
                               data-bind="value: image().description"></textarea>
                 </div>

--- a/MediaGalleryUi/view/adminhtml/web/template/image/image-edit.html
+++ b/MediaGalleryUi/view/adminhtml/web/template/image/image-edit.html
@@ -13,8 +13,9 @@
                     <span data-bind="i18n: 'Title'"></span>
                 </label>
                 <div class="admin__field-control">
-                    <input type="text" data-validate="{required:true}" id="title" data-ui-id="title" name="title" placeholder="Title"
-                           class="admin__control-text" data-bind="value: image().title" />
+                    <input type="text" id="title" data-ui-id="title" name="title" placeholder="Title"
+                           class="admin__control-text required-entry minimum-length-1 maximum-length-120" data-bind="value: image().title"
+                           data-validate="{'required':true,'validate-alphanum-with-spaces':true, 'validate-length':true}"/>
                 </div>
             </div>
             <div class="admin__field">
@@ -35,7 +36,8 @@
                               name="description"
                               class="admin__control-textarea minimum-length-0 maximum-length-500"
                               rows="7" cols="80"
-                              data-bind="value: image().description"></textarea>
+                              data-bind="value: image().description"
+                              data-validate="{'validate-alphanum-with-spaces':true, 'validate-length':true}"></textarea>
                 </div>
             </div>
         </fieldset>


### PR DESCRIPTION
### Description (*)
- Added a condition if image id is set then retrieval of image details will be triggered as well and not only when image id is undefined. Trigger of image details retrieval will update the image details with newly updated data when viewing image details.

### Fixed Issues (if relevant)
1. Fixes magento/adobe-stock-integration#1575: The newly added Description will appear in Image Details only after the web page is refreshed

### Manual testing scenarios (*)
1. Go to **Content > Media Gallery**
2. Select an image saved from Adobe Stock and click "**three dots**" in the bottom right
3. Select View Details. The Description field will not be available yet.
4. Close Image Details window
5. Select the same image and click "three dots" in the bottom right then select **Edit**
6. Type anything into the Description field and click Save
7. Select the same image and click "three dots" in the bottom right
8. Select View Details
9. Verify if the Description appeared/updated
