### PR TITLE
Introduce Duplicated images filter

### DIFF
--- a/MediaGalleryUi/Model/SearchCriteria/CollectionProcessor/FilterProcessor/Duplicated.php
+++ b/MediaGalleryUi/Model/SearchCriteria/CollectionProcessor/FilterProcessor/Duplicated.php
@@ -40,7 +40,7 @@ class Duplicated implements CustomFilterInterface
         $value = $filter->getValue();
         if ($value) {
             $collection->getSelect()
-                ->where('main_table.hash IN ('. $this->getDubplicatedSqlPart() . ' HAVING count(*) > 1)');
+                ->where('main_table.hash IN ('. $this->getDuplicatedSqlPart() . ' HAVING count(*) > 1)');
         }
         return true;
     }
@@ -48,7 +48,7 @@ class Duplicated implements CustomFilterInterface
     /**
      * Return sql part of duplicated values.
      */
-    private function getDubplicatedSqlPart(): Select
+    private function getDuplicatedSqlPart(): Select
     {
         return $this->connection->getConnection()
                        ->select()

--- a/MediaGalleryUi/Model/SearchCriteria/CollectionProcessor/FilterProcessor/Duplicated.php
+++ b/MediaGalleryUi/Model/SearchCriteria/CollectionProcessor/FilterProcessor/Duplicated.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\MediaGalleryUi\Model\SearchCriteria\CollectionProcessor\FilterProcessor;
+
+use Magento\Framework\Api\Filter;
+use Magento\Framework\Api\SearchCriteria\CollectionProcessor\FilterProcessor\CustomFilterInterface;
+use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\Data\Collection\AbstractDb;
+use Magento\Framework\DB\Select;
+
+/**
+ * Custom filter to filter collection by duplicated hash values
+ */
+class Duplicated implements CustomFilterInterface
+{
+
+    /**
+     * @var ResourceConnection
+     */
+    private $connection;
+
+    /**
+     * @param ResourceConnection $resource
+     */
+    public function __construct(ResourceConnection $resource)
+    {
+        $this->connection = $resource;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function apply(Filter $filter, AbstractDb $collection): bool
+    {
+        $value = $filter->getValue();
+        if ($value) {
+            $collection->getSelect()
+                ->where('main_table.hash IN ('. $this->getDubplicatedSqlPart() . ' HAVING count(*) > 1)');
+        }
+        return true;
+    }
+
+    /**
+     * Return sql part of duplicated values.
+     */
+    private function getDubplicatedSqlPart(): Select
+    {
+        return $this->connection->getConnection()
+                       ->select()
+                       ->from($this->connection->getTableName('media_gallery_asset'), ['hash'])
+                       ->group(['hash']);
+    }
+}

--- a/MediaGalleryUi/Test/Mftf/ActionGroup/AdminEnhancedMediaGalleryApplyDuplicatedFilterActionGroup.xml
+++ b/MediaGalleryUi/Test/Mftf/ActionGroup/AdminEnhancedMediaGalleryApplyDuplicatedFilterActionGroup.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="AdminEnhancedMediaGalleryApplyDuplicatedFilterActionGroup">
+        <annotations>
+            <description>Applies duplicated images filter to the media gallery grid</description>
+        </annotations>
+
+        <click selector="{{AdminEnhancedMediaGalleryFiltersSection.duplicatedFilterCheckbox}}" stepKey="clickShowDuplicates"/>
+     </actionGroup>
+</actionGroups>

--- a/MediaGalleryUi/Test/Mftf/Section/AdminEnhancedMediaGalleryFiltersSection.xml
+++ b/MediaGalleryUi/Test/Mftf/Section/AdminEnhancedMediaGalleryFiltersSection.xml
@@ -16,5 +16,7 @@
         <element name="usedInSelectDropdown" type="text" selector="//label[@class='admin__form-field-label']/span[text()='Show Images Used In']/parent::*/parent::div/div//div[@class='admin__action-multiselect-text' and text()='Select...']"/>
         <element name="usedInEntityType" type="text" selector="//label[@class='admin__action-multiselect-label']/span[text()='{{entityType}}']" parameterized="true"/>
         <element name="usedInDoneButton" type="button" selector="//div[@class='admin__action-multiselect-actions-wrap']/button/span[text()='Done']"/>
+         <element name="duplicatedFilterCheckbox" type="button" selector="//input[@name='duplicated']"/>
+
     </section>
 </sections>

--- a/MediaGalleryUi/Test/Mftf/Test/AdminEnhancedMediaGalleryDuplicatedImagesTest.xml
+++ b/MediaGalleryUi/Test/Mftf/Test/AdminEnhancedMediaGalleryDuplicatedImagesTest.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+    <test name="AdminEnhancedMediaGalleryDuplicatedImagesTest">
+        <annotations>
+            <features value="MediaGallery"/>
+            <useCaseId value="https://github.com/magento/adobe-stock-integration/issues/1500"/>
+            <title value="User can filter duplicated images"/>
+            <stories value="[Story 59] User finds image duplicates"/>
+            <testCaseId value="https://studio.cucumber.io/projects/131313/test-plan/folders/1054245/scenarios/4753539"/>
+            <description value="User can filter duplicated images"/>
+            <severity value="CRITICAL"/>
+            <group value="media_gallery_ui"/>
+        </annotations>
+        <before>
+            <actionGroup ref="AdminLoginActionGroup" stepKey="loginAsAdmin"/>
+            <actionGroup ref="AdminOpenMediaGalleryForPageNoEditorActionGroup" stepKey="openMediaGalleryForPage"/>
+        </before>
+        <after>
+        <actionGroup ref="AdminEnhancedMediaGalleryEnableMassActionModeActionGroup" stepKey="enableMassActionToDeleteImages"/>
+        <actionGroup ref="AdminEnhancedMediaGallerySelectImageForMassActionActionGroup" stepKey="selectFirstImageToDelete">
+            <argument name="imageName" value="{{ImageUpload.fileName}}"/>
+         </actionGroup>
+        <actionGroup ref="AdminEnhancedMediaGallerySelectImageForMassActionActionGroup" stepKey="selectSecondImageToDelete">
+            <argument name="imageName" value="{{ImageUpload_1.fileName}}"/>
+        </actionGroup>
+        <actionGroup ref="AdminEnhancedMediaGalleryClickDeleteImagesButtonActionGroup" stepKey="clikDeleteSelectedButton"/>
+        <actionGroup ref="AdminEnhancedMediaGalleryConfirmDeleteImagesActionGroup" stepKey="deleteImages"/>       
+        </after>
+
+        <actionGroup ref="AdminEnhancedMediaGalleryUploadImageActionGroup" stepKey="uploadImage">
+            <argument name="image" value="ImageUpload"/>
+        </actionGroup>
+        <actionGroup ref="AdminEnhancedMediaGalleryUploadImageActionGroup" stepKey="uploadSecondImage">
+            <argument name="image" value="ImageUpload_1"/>
+        </actionGroup>
+
+        <actionGroup ref="AdminEnhancedMediaGalleryExpandFilterActionGroup" stepKey="expandFilters"/>
+        <actionGroup ref="AdminEnhancedMediaGalleryApplyDuplicatedFilterActionGroup" stepKey="SelectDuplicatedFilter"/>
+        <actionGroup ref="AdminEnhancedMediaGalleryApplyFiltersActionGroup" stepKey="applyFilters"/>
+        
+        <actionGroup ref="AdminMediaGalleryAssertImageInGridActionGroup" stepKey="assertFirstImageInGrid">
+            <argument name="image" value="ImageUpload"/>
+        </actionGroup>
+        <actionGroup ref="AdminMediaGalleryAssertImageInGridActionGroup" stepKey="assertSecondImageInGrid">
+            <argument name="image" value="ImageUpload_1"/>
+        </actionGroup>
+       </test>
+</tests>

--- a/MediaGalleryUi/etc/adminhtml/di.xml
+++ b/MediaGalleryUi/etc/adminhtml/di.xml
@@ -12,6 +12,7 @@
                 <item name="path" xsi:type="object">Magento\MediaGalleryUi\Model\SearchCriteria\CollectionProcessor\FilterProcessor\Directory</item>
                 <item name="fulltext" xsi:type="object">Magento\MediaGalleryUi\Model\SearchCriteria\CollectionProcessor\FilterProcessor\Keyword</item>
                 <item name="entity_type" xsi:type="object">Magento\MediaGalleryUi\Model\SearchCriteria\CollectionProcessor\FilterProcessor\EntityType</item>
+                <item name="duplicated" xsi:type="object">Magento\MediaGalleryUi\Model\SearchCriteria\CollectionProcessor\FilterProcessor\Duplicated</item>
             </argument>
         </arguments>
     </virtualType>

--- a/MediaGalleryUi/view/adminhtml/ui_component/media_gallery_listing.xml
+++ b/MediaGalleryUi/view/adminhtml/ui_component/media_gallery_listing.xml
@@ -127,7 +127,7 @@
 		    provider="${ $.parentName }"
 		    sortOrder="90"
                     template="Magento_MediaGalleryUi/grid/filter/checkbox"
-		    component="Magento_Ui/js/form/element/single-checkbox">
+                    component="Magento_Ui/js/form/element/single-checkbox">
                 <argument name="data" xsi:type="array">
                     <item name="config" xsi:type="array">
                         <item name="description" xsi:type="string" translate="true">Show duplicates</item>

--- a/MediaGalleryUi/view/adminhtml/ui_component/media_gallery_listing.xml
+++ b/MediaGalleryUi/view/adminhtml/ui_component/media_gallery_listing.xml
@@ -122,6 +122,25 @@
                     <dataScope>entity_type</dataScope>
                 </settings>
             </filterSelect>
+            <filterInput
+		    name="duplicated"
+		    provider="${ $.parentName }"
+		    sortOrder="90"
+                    template="Magento_MediaGalleryUi/grid/filter/checkbox"
+		    component="Magento_Ui/js/form/element/single-checkbox">
+                <argument name="data" xsi:type="array">
+                    <item name="config" xsi:type="array">
+                        <item name="description" xsi:type="string" translate="true">Show duplicates</item>
+                        <item name="valueMap" xsi:type="array">
+                            <item name="true" xsi:type="string">Yes</item>
+                        </item>
+                    </item>
+                </argument>
+                <settings>
+                    <dataScope>duplicated</dataScope>
+                    <label translate="true">Show duplicates</label>
+                </settings>
+            </filterInput>
         </filters>
         <paging name="listing_paging">
             <settings>

--- a/MediaGalleryUi/view/adminhtml/ui_component/standalone_media_gallery_listing.xml
+++ b/MediaGalleryUi/view/adminhtml/ui_component/standalone_media_gallery_listing.xml
@@ -114,7 +114,7 @@
 		    provider="${ $.parentName }"
 		    sortOrder="90"
                     template="Magento_MediaGalleryUi/grid/filter/checkbox"
-		    component="Magento_Ui/js/form/element/single-checkbox">
+                    component="Magento_Ui/js/form/element/single-checkbox">
                 <argument name="data" xsi:type="array">
                     <item name="config" xsi:type="array">
                         <item name="description" xsi:type="string" translate="true">Show duplicates</item>

--- a/MediaGalleryUi/view/adminhtml/ui_component/standalone_media_gallery_listing.xml
+++ b/MediaGalleryUi/view/adminhtml/ui_component/standalone_media_gallery_listing.xml
@@ -109,6 +109,25 @@
                     <dataScope>entity_type</dataScope>
                 </settings>
             </filterSelect>
+            <filterInput
+		    name="duplicated"
+		    provider="${ $.parentName }"
+		    sortOrder="90"
+                    template="Magento_MediaGalleryUi/grid/filter/checkbox"
+		    component="Magento_Ui/js/form/element/single-checkbox">
+                <argument name="data" xsi:type="array">
+                    <item name="config" xsi:type="array">
+                        <item name="description" xsi:type="string" translate="true">Show duplicates</item>
+                        <item name="valueMap" xsi:type="array">
+                            <item name="true" xsi:type="string">Yes</item>
+                        </item>
+                    </item>
+                </argument>
+                <settings>
+                    <dataScope>duplicated</dataScope>
+                    <label translate="true">Show duplicates</label>
+                </settings>
+            </filterInput>
         </filters>
         <paging name="listing_paging">
             <settings>

--- a/MediaGalleryUi/view/adminhtml/web/template/grid/filter/checkbox.html
+++ b/MediaGalleryUi/view/adminhtml/web/template/grid/filter/checkbox.html
@@ -1,0 +1,26 @@
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<div class="admin__field admin__adobe-stock-image-checkbox" visible="visible" css="$data.additionalClasses">
+    <div class="admin__field-control"
+         css="'_with-tooltip': $data.tooltip">
+        <label class="admin__form-field-label" if="$data.label" attr="for: uid">
+            <span translate="label" attr="'data-config-scope': $data.scopeLabel" />
+        </label>
+        <render args="tooltipTpl" if="$data.tooltip"/>
+    </div>
+    <div class="admin__field admin__field-option">
+        <input type="checkbox"
+               class="admin__control-checkbox"
+               ko-checked="$data.checked"
+               disable="disabled"
+               ko-value="value"
+               hasFocus="focused"
+               attr="id: uid, name: inputName"/>
+
+        <label class="admin__field-label" text="description" attr="for: uid"/>
+    </div>
+</div>

--- a/MediaGalleryUi/view/adminhtml/web/template/grid/filter/checkbox.html
+++ b/MediaGalleryUi/view/adminhtml/web/template/grid/filter/checkbox.html
@@ -4,13 +4,11 @@
  * See COPYING.txt for license details.
  */
 -->
-<div class="admin__field admin__adobe-stock-image-checkbox" visible="visible" css="$data.additionalClasses">
-    <div class="admin__field-control"
-         css="'_with-tooltip': $data.tooltip">
+<div class="admin__field admin__media-gallery-image-checkbox" visible="visible" css="$data.additionalClasses">
+    <div class="admin__field-control">
         <label class="admin__form-field-label" if="$data.label" attr="for: uid">
             <span translate="label" attr="'data-config-scope': $data.scopeLabel" />
         </label>
-        <render args="tooltipTpl" if="$data.tooltip"/>
     </div>
     <div class="admin__field admin__field-option">
         <input type="checkbox"


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/adobe-stock-integration#1500: Add duplicated images filter
2. ...

### Manual testing scenarios (*)
1. Login to admin panel
2. Open the media gallery (Content -> Media Gallery)
3. Expand the filters section

Checkbox filter "Show duplicates" is present in the filter section
Only the images that have the duplicated hashes should be displayed when selecting the checkbox and applying the filters

