### PR TITLE
#1589: Hitting Enter key on Edit Image page redirects the user to Magento Dashboard instead of Saving the image

### DIFF
--- a/MediaGalleryUi/view/adminhtml/web/js/image/image-edit.js
+++ b/MediaGalleryUi/view/adminhtml/web/js/image/image-edit.js
@@ -100,6 +100,25 @@ define([
         addMediaGridMessage: function (code, message) {
             this.mediaGridMessages().add(code, message);
             this.mediaGridMessages().scheduleCleanup();
+        },
+
+        /**
+         * Handle Enter key event to save image details
+         *
+         * @param {Object} data
+         * @param {jQuery.Event} event
+         */
+        handleEnterKey: function (data, event) {
+            var modalElement = $(this.modalSelector),
+                result = true;
+
+            if (event.keyCode === 13) {
+                event.preventDefault();
+                result = false;
+                modalElement.find('.page-action-buttons button.save').click();
+            }
+
+            return result;
         }
     });
 });

--- a/MediaGalleryUi/view/adminhtml/web/js/image/image-edit.js
+++ b/MediaGalleryUi/view/adminhtml/web/js/image/image-edit.js
@@ -108,7 +108,7 @@ define([
          *
          * @param {Object} data
          * @param {jQuery.Event} event
-         * @returns {boolean}
+         * @returns {Boolean}
          */
         handleEnterKey: function (data, event) {
             var modalElement = $(this.modalSelector),

--- a/MediaGalleryUi/view/adminhtml/web/js/image/image-edit.js
+++ b/MediaGalleryUi/view/adminhtml/web/js/image/image-edit.js
@@ -7,8 +7,9 @@ define([
     'jquery',
     'underscore',
     'uiComponent',
+    'Magento_Ui/js/lib/key-codes',
     'Magento_MediaGalleryUi/js/action/getDetails'
-], function ($, _, Component, getDetails) {
+], function ($, _, Component, keyCodes, getDetails) {
     'use strict';
 
     return Component.extend({
@@ -107,18 +108,18 @@ define([
          *
          * @param {Object} data
          * @param {jQuery.Event} event
+         * @returns {boolean}
          */
         handleEnterKey: function (data, event) {
             var modalElement = $(this.modalSelector),
-                result = true;
+                key = keyCodes[event.keyCode];
 
-            if (event.keyCode === 13) {
+            if (key === 'enterKey') {
                 event.preventDefault();
-                result = false;
                 modalElement.find('.page-action-buttons button.save').click();
             }
 
-            return result;
+            return true;
         }
     });
 });

--- a/MediaGalleryUi/view/adminhtml/web/template/image/image-edit.html
+++ b/MediaGalleryUi/view/adminhtml/web/template/image/image-edit.html
@@ -14,7 +14,8 @@
                 </label>
                 <div class="admin__field-control">
                     <input type="text" id="title" data-ui-id="title" name="title" placeholder="Title"
-                           class="admin__control-text required-entry minimum-length-1 maximum-length-120" data-bind="value: image().title"
+                           class="admin__control-text required-entry minimum-length-1 maximum-length-120"
+                           data-bind="value: image().title, event: {keypress: handleEnterKey}"
                            data-validate="{'required':true,'validate-alphanum-with-spaces':true, 'validate-length':true}"/>
                 </div>
             </div>
@@ -36,7 +37,7 @@
                               name="description"
                               class="admin__control-textarea minimum-length-0 maximum-length-500"
                               rows="7" cols="80"
-                              data-bind="value: image().description"
+                              data-bind="value: image().description, event: {keypress: handleEnterKey}"
                               data-validate="{'validate-alphanum-with-spaces':true, 'validate-length':true}"></textarea>
                 </div>
             </div>


### PR DESCRIPTION
### Need to verify (*)
- If pressing Enter key closes edit image modal and saves the image details

### Description (*)
- Added event on data-bind attribute and created a function for Enter event key to prevent the page from reloading and to save image details

### Fixed Issues (if relevant)
1. Fixes magento/adobe-stock-integration#1589: Hitting Enter key on Edit Image page redirects the user to Magento Dashboard instead of Saving the image

### Manual testing scenarios (*)
1. Go to **Content - Media Gallery**
2. Select an image saved from Adobe Stock and click "three dots" in the bottom right
3. Select Edit
4. Place the cursor into Name or Description field
5. Type any text
6. Hit Enter key from your keyboard
