### PR TITLE
#1562: A line appears on tabs [UI]

### DIFF
--- a/AdobeStockImageAdminUi/view/adminhtml/web/css/source/_module.less
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/css/source/_module.less
@@ -208,6 +208,7 @@
                 .ui-state-default {
                     border-bottom: none;
                 }
+
                 .ui-state-active {
                     border-bottom: 0;
                     font-weight: unset;

--- a/AdobeStockImageAdminUi/view/adminhtml/web/css/source/_module.less
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/css/source/_module.less
@@ -208,6 +208,12 @@
                 .ui-state-default {
                     border-bottom: none;
                 }
+                .ui-state-active {
+                    border-bottom: 0;
+                    font-weight: unset;
+                    letter-spacing: normal;
+                    margin-bottom: -1.1rem;
+                }
             }
 
             .related-loader {


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Added a css fix for the issue indicated in: #1562 

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/adobe-stock-integration#1562:A line appears on tabs [UI]

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Go to **Content - Media Gallery**
2. Click **Search Adobe Stock**
3. Open an image Preview 
4. Start to Zoom In and Zoom Out your web browser window
5. Observe the _More from this series_ tab
