### PR TITLE
#1604: The "See more" is not in correct position on device mode

### DIFF
--- a/AdobeStockImageAdminUi/view/adminhtml/web/css/source/_module.less
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/css/source/_module.less
@@ -367,7 +367,7 @@
                         max-width: 130px;
                     }
                     .see-more-wrapper {
-                        max-width: 130px;
+                        width: auto;
                     }
                 }
             }


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR will fix the position of "See More" on device mode. 
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes https://github.com/magento/adobe-stock-integration/issues/1604: The "See more" is not in correct position on device mode 
2. ...

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->

1. Go to Content - Media Gallery
2. Click Search Adobe Stock
3. Open an image Preview
4. Switch your browser to device mode
5. The "See More" button should now be in the correct position. 

![Screen Shot 2020-07-21 at 7 26 38 PM](https://user-images.githubusercontent.com/23549533/88049898-78267b00-cb88-11ea-9d0f-55e6a4969976.png)
