### PR TITLE
#1620: Not possible to enter multi-line image Description

### DIFF
--- a/MediaGalleryUi/view/adminhtml/web/template/image/image-edit.html
+++ b/MediaGalleryUi/view/adminhtml/web/template/image/image-edit.html
@@ -37,7 +37,7 @@
                               name="description"
                               class="admin__control-textarea minimum-length-0 maximum-length-500"
                               rows="7" cols="80"
-                              data-bind="value: image().description, event: {keypress: handleEnterKey}"
+                              data-bind="value: image().description"
                               data-validate="{'validate-alphanum-with-spaces':true, 'validate-length':true}"></textarea>
                 </div>
             </div>


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR will fix the issue wherein it is not possible to enter multi-line image description by clicking Enter.
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/adobe-stock-integration https://github.com/magento/adobe-stock-integration/issues/1620: Not possible to enter multi-line image Description 
2. ...

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->

1. Go to **Content - Media Gallery**
2. Select an image from Media Gallery, click on "three dots"
3. Select **Edit**
4. Place the cursor to the **Description** field
5. Type any text, and hit Enter key
6. The cursor should go to the next line.