### PR TITLE
#1619: Change the position of "Show duplicates" checkbox

### DIFF
--- a/MediaGalleryUi/view/adminhtml/ui_component/media_gallery_listing.xml
+++ b/MediaGalleryUi/view/adminhtml/ui_component/media_gallery_listing.xml
@@ -144,7 +144,7 @@
             <filterInput
 		    name="duplicated"
 		    provider="${ $.parentName }"
-		    sortOrder="90"
+		    sortOrder="1000"
                     template="Magento_MediaGalleryUi/grid/filter/checkbox"
                     component="Magento_Ui/js/form/element/single-checkbox">
                 <argument name="data" xsi:type="array">

--- a/MediaGalleryUi/view/adminhtml/ui_component/standalone_media_gallery_listing.xml
+++ b/MediaGalleryUi/view/adminhtml/ui_component/standalone_media_gallery_listing.xml
@@ -131,7 +131,7 @@
             <filterInput
 		    name="duplicated"
 		    provider="${ $.parentName }"
-		    sortOrder="90"
+		    sortOrder="1000"
                     template="Magento_MediaGalleryUi/grid/filter/checkbox"
                     component="Magento_Ui/js/form/element/single-checkbox">
                 <argument name="data" xsi:type="array">


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR will introduce the change to the position of the "Show Duplicates" checkbox filter. The checkbox should be in the last position.
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/adobe-stock-integration https://github.com/magento/adobe-stock-integration/issues/1619: Change the position of "Show duplicates" checkbox
2. ...

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->

1. Go to **Content - Media Gallery**
2. Click **Filters**
3. The checkbox should be in the last position.

**Content - Media Gallery - Filters**
![Screen Shot 2020-07-22 at 5 43 23 PM](https://user-images.githubusercontent.com/23549533/88161833-14ad5380-cc43-11ea-9508-bbd318454b1f.png)

**Categories - Media Gallery - Filters**
![Screen Shot 2020-07-22 at 5 43 37 PM](https://user-images.githubusercontent.com/23549533/88161782-019a8380-cc43-11ea-965e-e5aaa7e5f045.png)

