### PR TITLE
#1630: [Refactoring] Backend type check during uploading an image

### DIFF
--- a/MediaGalleryUi/Controller/Adminhtml/Image/Upload.php
+++ b/MediaGalleryUi/Controller/Adminhtml/Image/Upload.php
@@ -63,6 +63,7 @@ class Upload extends Action implements HttpPostActionInterface
         /** @var Json $resultJson */
         $resultJson = $this->resultFactory->create(ResultFactory::TYPE_JSON);
         $targetFolder = $this->getRequest()->getParam('target_folder');
+        $type = $this->getRequest()->getParam('type');
 
         if (!$targetFolder) {
             $responseContent = [
@@ -76,7 +77,7 @@ class Upload extends Action implements HttpPostActionInterface
         }
 
         try {
-            $this->uploadImage->execute($targetFolder);
+            $this->uploadImage->execute($targetFolder, $type);
 
             $responseCode = self::HTTP_OK;
             $responseContent = [

--- a/MediaGalleryUi/Model/UploadImage.php
+++ b/MediaGalleryUi/Model/UploadImage.php
@@ -61,10 +61,10 @@ class UploadImage
      * Uploads the image and returns file object
      *
      * @param string $targetFolder
-     * @param string|null $type
+     * @param string $type
      * @throws LocalizedException
      */
-    public function execute(string $targetFolder, string $type = null): void
+    public function execute(string $targetFolder, string $type): void
     {
         $mediaDirectory = $this->filesystem->getDirectoryRead(DirectoryList::MEDIA);
         if (!$mediaDirectory->isDirectory($targetFolder)) {

--- a/MediaGalleryUi/Test/Unit/Model/UploadImageTest.php
+++ b/MediaGalleryUi/Test/Unit/Model/UploadImageTest.php
@@ -123,6 +123,7 @@ class UploadImageTest extends TestCase
     public function testExecuteWithException(): void
     {
         $targetFolder = 'not-a-folder';
+        $type = 'image';
         $this->fileSystemMock->expects($this->once())
             ->method('getDirectoryRead')
             ->with(DirectoryList::MEDIA)
@@ -136,7 +137,7 @@ class UploadImageTest extends TestCase
         $this->expectException(LocalizedException::class);
         $this->expectExceptionMessage('Directory not-a-folder does not exist in media directory.');
 
-        $this->uploadImage->execute($targetFolder, null);
+        $this->uploadImage->execute($targetFolder, $type);
     }
 
     /**
@@ -149,7 +150,7 @@ class UploadImageTest extends TestCase
         return [
             [
                 'targetFolder' => 'media/catalog',
-                'type' => null,
+                'type' => 'image',
                 'absolutePath' => 'root/pub/media/catalog/test-image.jpeg'
             ]
         ];


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
`\Magento\MediaGalleryUi\Model\UploadImage::execute` - the $type parameter should be required
`\Magento\MediaGalleryUi\Controller\Adminhtml\Image\Upload::execute` - the `image` $type should be passed to the `UploadImage:execute` method call


### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/adobe-stock-integration#1630: [Refactoring] Backend type check during uploading an image

### Testing (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Go to Content - Media Gallery
2. Upload of a different image and file types should be tested
