### PR TITLE
Typo fix on Uploading long image name. Changed "chracters" to "characters"

### DIFF
--- a/MediaGalleryUi/view/adminhtml/web/js/image-uploader.js
+++ b/MediaGalleryUi/view/adminhtml/web/js/image-uploader.js
@@ -91,7 +91,7 @@ define([
                         return;
                     } else if (!this.isFileNameLengthExceeded(data.files[0]).passed) {
                         this.addValidationErrorMessage('Cannot upload "' + data.files[0].name +
-                                                       '". Filename is too long, must be 90 chracters or less.');
+                                                       '". Filename is too long, must be 90 characters or less.');
 
                         return;
                     }


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
This PR provides a typo fix in an upload error message

### Fixed Issues (if relevant)
![Selection_051](https://user-images.githubusercontent.com/45624059/88548006-2ddd4800-d027-11ea-8ebc-e1f3043afa2e.png)


### Manual testing scenarios (*)
Open Media Gallery
Try to Upload an image with long name, more than 90 symbols
Observe the error message 
