### PR TITLE
Handling jpeg image that is corrupted at the end

### DIFF
--- a/MediaGalleryMetadata/Model/Jpeg/FileReader.php
+++ b/MediaGalleryMetadata/Model/Jpeg/FileReader.php
@@ -137,7 +137,10 @@ class FileReader implements FileReaderInterface
         } while (!$this->driver->endOfFile($resource));
 
         $endOfImageMarkerPosition = strpos($compressedImage, self::MARKER_PREFIX . self::MARKER_IMAGE_END);
-        $compressedImage = substr($compressedImage, 0, $endOfImageMarkerPosition);
+
+        if ($endOfImageMarkerPosition !== false) {
+            $compressedImage = substr($compressedImage, 0, $endOfImageMarkerPosition);
+        }
 
         return $compressedImage;
     }


### PR DESCRIPTION
### Description (*)
The image that is corrupted at the end (does not have the full compressed image and does not have the image end marker) is still read by common applications. This fix is making media gallery able to process (and fix) such images as well

### Manual testing scenarios (*)
1. Get a jpeg image
2. Apply the following script to corrupt the image:

```
$originalImage = 'no-end-marker.jpg';
$updatedImage = 'no-end-marker1.jpg';

$filesize = filesize($originalImage);
$originalFile = fopen($originalImage, 'rb');
$originalBinary = fread($originalFile, $filesize);
fclose($originalFile);

$corruptedEnd = substr($originalBinary, 0, -2);

$updatedFile = fopen($updatedImage, 'wb');
fwrite($updatedFile, $corruptedEnd);
fclose($updatedFile);
```
3. Upload the resulting image to the media gallery

### Expected result
The image should be uploaded and displayed successfully