### PR TITLE
#1398: A small truncation of the "note symbol" in Adobe Stock filters

### DIFF
--- a/AdobeStockImageAdminUi/view/adminhtml/web/css/source/_module.less
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/css/source/_module.less
@@ -360,6 +360,13 @@
 
             .admin__field-tooltip {
                 margin: -5px 0 0 5px;
+
+                .admin__field-tooltip-action {
+                    &:before {
+                        line-height: initial;
+                        overflow: visible;
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
A small truncation at the top of the symbol
![truncation](https://user-images.githubusercontent.com/45624059/83264604-fbe76b00-a1c8-11ea-8b02-9d790dc7a2ed.png)

<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR fixes issue#1398, was able to replicate this on Chrome with 67% or less zoom.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/adobe-stock-integration#1398: A small truncation of the "note symbol" in Adobe Stock filters

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Go to **Content - Media Gallery** click **Search Adobe Stock**
2. Click **Filters**
3. Observe the :grey_question: symbol for _Isolated Assets_ checkbox
