### PR TITLE
Fix iptc file segment replacement

### DIFF
--- a/MediaGalleryMetadata/Model/AddIptcMetadata.php
+++ b/MediaGalleryMetadata/Model/AddIptcMetadata.php
@@ -112,7 +112,11 @@ class AddIptcMetadata
 
         foreach ($segments as $key => $segment) {
             if ($segment->getName() === 'APP13') {
-                $originFileSegments[$key] = $segments[$key];
+                foreach ($originFileSegments as $originKey => $segment) {
+                    if ($segment->getName() === 'APP13') {
+                        $originFileSegments[$originKey] = $segments[$key];
+                    }
+                }
                 return $originFileSegments;
             }
         }


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/adobe-stock-integration#1663: Media Gallery synchronization fails on newly Saved and Edited image
2. ...

### Manual testing scenarios (*)
1. Save a new image Preview from Adobe Stock.
2. Edit the image Description.
3. Perform `php bin/magento media-gallery:sync`

### Expected result (*)
Synchronization pass successfully 
