### PR TITLE
#1657: The position of the filters is changed when Directory filter is applied

### DIFF
--- a/MediaGalleryUi/view/adminhtml/ui_component/media_gallery_listing.xml
+++ b/MediaGalleryUi/view/adminhtml/ui_component/media_gallery_listing.xml
@@ -87,7 +87,7 @@
         <bookmark name="bookmarks"/>
         <filterSearch name="fulltext" />
         <filters name="listing_filters">
-            <filterInput name="path" provider="${ $.parentName }" sortOrder="100">
+            <filterInput name="path" provider="${ $.parentName }" sortOrder="2000">
                 <settings>
                     <visible>false</visible>
                     <dataScope>path</dataScope>

--- a/MediaGalleryUi/view/adminhtml/ui_component/standalone_media_gallery_listing.xml
+++ b/MediaGalleryUi/view/adminhtml/ui_component/standalone_media_gallery_listing.xml
@@ -74,7 +74,7 @@
         <bookmark name="bookmarks"/>
         <filterSearch name="fulltext" />
         <filters name="listing_filters">
-            <filterInput name="path" provider="${ $.parentName }" sortOrder="100">
+            <filterInput name="path" provider="${ $.parentName }" sortOrder="2000">
                 <settings>
                     <visible>false</visible>
                     <dataScope>path</dataScope>


### PR DESCRIPTION

<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Depends on the changes made in #1633  (filter sort order)
Fixes issue #1657 


### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/adobe-stock-integration#1657: The position of the filters is changed when Directory filter is applied

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Go to **Content - Media Gallery**,
2. Expand **Filters**
3. Select a directory from the folder try 
4. Position of the filters should have no gaps or changed

![image](https://user-images.githubusercontent.com/20994795/88771595-0b2b6a80-d1b2-11ea-816d-89801815a6dc.png)

