### PR TITLE
Redirect to "Adobe Stock Integration" config path more accurate

### DIFF
--- a/AdobeStockAsset/Model/GetAssetList.php
+++ b/AdobeStockAsset/Model/GetAssetList.php
@@ -76,7 +76,13 @@ class GetAssetList implements GetAssetListInterface
                 __(
                     'Failed to authenticate to Adobe Stock API. <br> Please correct the API credentials in '
                     . '<a href="%1">Configuration → System → Adobe Stock Integration.</a>',
-                    $this->url->getUrl('adminhtml/system_config/edit/section/system')
+                    $this->url->getUrl(
+                        'adminhtml/system_config/edit',
+                        [
+                            'section' => 'system',
+                            '_fragment' => 'system_adobe_stock_integration-link'
+                        ]
+                    )
                 ),
                 $exception
             );


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

Go to Adobe Stock without fill the API Key:

![image](https://user-images.githubusercontent.com/8234209/88808021-8e61b600-d1dc-11ea-9b1a-58167105dd80.png)


Click the link.

Now, it redirect to :

![image](https://user-images.githubusercontent.com/8234209/88807809-607c7180-d1dc-11ea-8b25-65142e3f7487.png)

But we need redirect to "Adobe Stock Integration" config like that:

![image](https://user-images.githubusercontent.com/8234209/88807951-75f19b80-d1dc-11ea-953e-785313aeee1f.png)


### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->

Click the link: Please correct the API credentials in Configuration → System → Adobe Stock Integration.

=> redirect to "Adobe Stock Integration" config like that:

![image](https://user-images.githubusercontent.com/8234209/88807951-75f19b80-d1dc-11ea-953e-785313aeee1f.png)

Instead just "System" section
