### PR TITLE
Fix Delete Images... on click event binding after cloning element

### DIFF
--- a/MediaGalleryUi/Test/Mftf/ActionGroup/AdminEnhancedMediaGalleryDisableMassactionModeActionGroup.xml
+++ b/MediaGalleryUi/Test/Mftf/ActionGroup/AdminEnhancedMediaGalleryDisableMassactionModeActionGroup.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="AdminEnhancedMediaGalleryDisableMassactionModeActionGroup">
+        <annotations>
+            <description>Disable massaction mode by clicking on cancel button</description>
+        </annotations>
+
+
+        <click selector="{{AdminEnhancedMediaGalleryMassActionSection.cancelMassActionMode}}" stepKey="cancelMassAction"/>
+        <dontSeeElement selector="{{AdminEnhancedMediaGalleryMassActionSection.totalSelected}}" stepKey="verifyTeminateMAssAction"/>
+    </actionGroup>
+</actionGroups>

--- a/MediaGalleryUi/Test/Mftf/Test/AdminEnhancedMediaGalleryDeleteImagesInBulkTest.xml
+++ b/MediaGalleryUi/Test/Mftf/Test/AdminEnhancedMediaGalleryDeleteImagesInBulkTest.xml
@@ -33,6 +33,9 @@
         <actionGroup ref="AdminEnhancedMediaGalleryAssertMassActionModeDetailsActionGroup" stepKey="assertMassActionModeAvailable">
             <argument name="imageName" value="{{ImageUpload.fileName}}"/>
         </actionGroup>
+        <actionGroup ref="AdminEnhancedMediaGalleryDisableMassactionModeActionGroup" stepKey="disableMassActionMode"/>
+        
+        <actionGroup ref="AdminEnhancedMediaGalleryEnableMassActionModeActionGroup" stepKey="enableMassActionToDeleteImages"/>
         <actionGroup ref="AdminEnhancedMediaGallerySelectImageForMassActionActionGroup" stepKey="selectFirstImageToDelete">
             <argument name="imageName" value="{{ImageUpload.fileName}}"/>
          </actionGroup>

--- a/MediaGalleryUi/view/adminhtml/web/js/grid/massaction/massactionView.js
+++ b/MediaGalleryUi/view/adminhtml/web/js/grid/massaction/massactionView.js
@@ -95,8 +95,11 @@ define([
           * Activate mass action buttons view
           */
         activateMassactionButtonView: function () {
-            this.originDeleteSelector = $(this.deleteButtonSelector).clone(true, true);
-            this.originCancelEvent = $('#cancel').clone(true);
+            this.originDeleteSelector = $(this.deleteButtonSelector).clone();
+            $(this.originDeleteSelector).click(function () {
+                $(window).trigger('massAction.MediaGallery');
+            });
+            this.originCancelEvent = $('#cancel').clone(true, true);
 
             $.each(this.buttonsIds, function (key, value) {
                 $(value).addClass('no-display');


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
The clone() method of jquery no longer clone events from element that defined in UI components

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/adobe-stock-integration#1680: Bulk image delete is not working after the first attempt was canceled 
2. ...

### Manual testing scenarios (*)
