### PR TITLE
#1600: Improvements to mass delete message

### DIFF
--- a/MediaGalleryUi/Controller/Adminhtml/Image/Delete.php
+++ b/MediaGalleryUi/Controller/Adminhtml/Image/Delete.php
@@ -102,13 +102,13 @@ class Delete extends Action implements HttpPostActionInterface
             $this->deleteImage->execute($assets);
             $responseCode = self::HTTP_OK;
             if (count($imageIds) === 1) {
-                $message = sprintf('The asset "%s" has been successfully deleted.', current($assets)->getTitle());
+                $message = __('The asset "%title" has been successfully deleted.', ['title' => current($assets)->getTitle()]);
             } else {
-                $message = sprintf('%s assets have been successfully deleted.', count($imageIds));
+                $message = __('%count assets have been successfully deleted.', ['count' => count($imageIds)]);
             }
             $responseContent = [
                 'success' => true,
-                'message' => __($message),
+                'message' => $message,
             ];
         } catch (LocalizedException $exception) {
             $responseCode = self::HTTP_BAD_REQUEST;

--- a/MediaGalleryUi/Controller/Adminhtml/Image/Delete.php
+++ b/MediaGalleryUi/Controller/Adminhtml/Image/Delete.php
@@ -102,9 +102,9 @@ class Delete extends Action implements HttpPostActionInterface
             $this->deleteImage->execute($assets);
             $responseCode = self::HTTP_OK;
             if (count($imageIds) === 1) {
-                $message = sprintf('The asset "%s" has been successfully deleted', current($assets)->getTitle());
+                $message = sprintf('The asset "%s" has been successfully deleted.', current($assets)->getTitle());
             } else {
-                $message = 'Assets have been successfully deleted';
+                $message = sprintf('%s assets have been successfully deleted.', count($imageIds));
             }
             $responseContent = [
                 'success' => true,

--- a/MediaGalleryUi/Controller/Adminhtml/Image/Delete.php
+++ b/MediaGalleryUi/Controller/Adminhtml/Image/Delete.php
@@ -102,9 +102,19 @@ class Delete extends Action implements HttpPostActionInterface
             $this->deleteImage->execute($assets);
             $responseCode = self::HTTP_OK;
             if (count($imageIds) === 1) {
-                $message = __('The asset "%title" has been successfully deleted.', ['title' => current($assets)->getTitle()]);
+                $message = __(
+                    'The asset "%title" has been successfully deleted.',
+                    [
+                        'title' => current($assets)->getTitle()
+                    ]
+                );
             } else {
-                $message = __('%count assets have been successfully deleted.', ['count' => count($imageIds)]);
+                $message = __(
+                    '%count assets have been successfully deleted.',
+                    [
+                        'count' => count($imageIds)
+                    ]
+                );
             }
             $responseContent = [
                 'success' => true,


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR will add the specific number of assets selected to be deleted during mass delete.
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/adobe-stock-integration https://github.com/magento/adobe-stock-integration/issues/1600: Improvements to mass delete message


### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->

1. Go to **Content - Media Gallery**
2. Click on **Delete Images** button
3. Select 3 images to delete
4. Click on **delete selected** button
5. Check the popup message in which number of images is present
6. Click on delete image button in the popup
7. The success message should show the specific number of images deleted.
