### PR TITLE
#1667: Add a column with an edit link to the Category grid

### DIFF
--- a/MediaGalleryCatalogUi/Ui/Component/Listing/Columns/CategoryActions.php
+++ b/MediaGalleryCatalogUi/Ui/Component/Listing/Columns/CategoryActions.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\MediaGalleryCatalogUi\Ui\Component\Listing\Columns;
+
+use Magento\Framework\View\Element\UiComponent\ContextInterface;
+use Magento\Framework\View\Element\UiComponentFactory;
+use Magento\Ui\Component\Listing\Columns\Column;
+use Magento\Framework\UrlInterface;
+
+/**
+ * Class CategoryActions for Category grid
+ */
+class CategoryActions extends Column
+{
+    /**
+     * @var UrlInterface
+     */
+    protected $urlBuilder;
+
+    /**
+     * @param ContextInterface $context
+     * @param UiComponentFactory $uiComponentFactory
+     * @param UrlInterface $urlBuilder
+     * @param array $components
+     * @param array $data
+     */
+    public function __construct(
+        ContextInterface $context,
+        UiComponentFactory $uiComponentFactory,
+        UrlInterface $urlBuilder,
+        array $components = [],
+        array $data = []
+    ) {
+        $this->urlBuilder = $urlBuilder;
+        parent::__construct($context, $uiComponentFactory, $components, $data);
+    }
+
+    /**
+     * Prepare Data Source
+     *
+     * @param array $dataSource
+     * @return array
+     */
+    public function prepareDataSource(array $dataSource)
+    {
+        if (isset($dataSource['data']['items'])) {
+            $storeId = $this->context->getFilterParam('store_id');
+
+            foreach ($dataSource['data']['items'] as &$item) {
+                $item[$this->getData('name')]['edit'] = [
+                    'href' => $this->urlBuilder->getUrl(
+                        'catalog/category/edit',
+                        ['id' => $item['entity_id'], 'store' => $storeId]
+                    ),
+                    'label' => __('Edit'),
+                    'hidden' => false,
+                ];
+            }
+        }
+
+        return $dataSource;
+    }
+}

--- a/MediaGalleryCatalogUi/Ui/Component/Listing/Columns/CategoryActions.php
+++ b/MediaGalleryCatalogUi/Ui/Component/Listing/Columns/CategoryActions.php
@@ -47,13 +47,13 @@ class CategoryActions extends Column
     public function prepareDataSource(array $dataSource)
     {
         if (isset($dataSource['data']['items'])) {
-            $storeId = $this->context->getFilterParam('store_id');
-
             foreach ($dataSource['data']['items'] as &$item) {
                 $item[$this->getData('name')]['edit'] = [
                     'href' => $this->urlBuilder->getUrl(
                         'catalog/category/edit',
-                        ['id' => $item['entity_id'], 'store' => $storeId]
+                        [
+                            'id' => $item['entity_id']
+                        ]
                     ),
                     'label' => __('Edit'),
                     'hidden' => false,

--- a/MediaGalleryCatalogUi/Ui/Component/Listing/Columns/CategoryActions.php
+++ b/MediaGalleryCatalogUi/Ui/Component/Listing/Columns/CategoryActions.php
@@ -18,7 +18,7 @@ class CategoryActions extends Column
     /**
      * @var UrlInterface
      */
-    protected $urlBuilder;
+    private $urlBuilder;
 
     /**
      * @param ContextInterface $context

--- a/MediaGalleryCatalogUi/view/adminhtml/ui_component/media_gallery_category_listing.xml
+++ b/MediaGalleryCatalogUi/view/adminhtml/ui_component/media_gallery_category_listing.xml
@@ -169,5 +169,10 @@
                 <label translate="true">Enabled</label>
             </settings>
         </column>
+        <actionsColumn name="actions" class="Magento\MediaGalleryCatalogUi\Ui\Component\Listing\Columns\CategoryActions" sortOrder="1000">
+            <settings>
+                <indexField>entity_id</indexField>
+            </settings>
+        </actionsColumn>
     </columns>
 </listing>


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR Add's a column(Action) with an edit link in the media gallery Category grid.
#1667

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Go to `magento.host/admin/media_gallery_catalog/category/index` page
2. Click `Edit` link in `Actions` column for a category

### Expected result:
1. Actions column is present on Category grid
2. Edit page is opened for a corresponding category (`admin/catalog/category/edit/id/<category_id>/`)

