### PR TITLE
MFTF tests coverage for Used In links && fix bug with category grid urlFIlterApplier

### DIFF
--- a/MediaGalleryCatalogUi/Test/Mftf/Test/AdminMediaGalleryCatalogUiVerifyUsedInLinkCategoryGridTest.xml
+++ b/MediaGalleryCatalogUi/Test/Mftf/Test/AdminMediaGalleryCatalogUiVerifyUsedInLinkCategoryGridTest.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+    <test name="AdminMediaGalleryCatalogUiVerifyUsedInLinkCategoryGridTest">
+        <annotations>
+            <features value="AdminMediaGalleryCategoryGrid"/>
+            <useCaseId value="https://github.com/magento/adobe-stock-integration/issues/1503"/>
+            <title value="User can open each entity the asset is associated with in a separate tab to manage association"/>
+            <stories value="Story 58: User sees entities where asset is used in" />
+            <testCaseId value="https://studio.cucumber.io/projects/131313/test-plan/folders/943908/scenarios/4523889"/>
+            <description value="User can open each entity the asset is associated with in a separate tab to manage association"/>
+            <severity value="CRITICAL"/>
+            <group value="media_gallery_ui"/>
+        </annotations>
+        <before>
+            <createData entity="SimpleSubCategory" stepKey="category"/>
+            <actionGroup ref="AdminLoginActionGroup" stepKey="loginAsAdmin"/>
+        </before>
+        <after>
+        <actionGroup ref="AdminOpenStandaloneMediaGalleryActionGroup" stepKey="openMediaGallery"/>
+        <actionGroup ref="AdminEnhancedMediaGalleryEnableMassActionModeActionGroup" stepKey="enableMassActionToDeleteImages"/>
+        <actionGroup ref="AdminEnhancedMediaGallerySelectImageForMassActionActionGroup" stepKey="selectSecondImageToDelete">
+            <argument name="imageName" value="{{UpdatedImageDetails.title}}"/>
+        </actionGroup>
+        <actionGroup ref="AdminEnhancedMediaGalleryClickDeleteImagesButtonActionGroup" stepKey="clikDeleteSelectedButton"/>
+        <actionGroup ref="AdminEnhancedMediaGalleryConfirmDeleteImagesActionGroup" stepKey="deleteImages"/>
+            <deleteData createDataKey="category" stepKey="deleteCategory"/>
+        </after>
+
+        <actionGroup ref="AdminOpenCategoryPageActionGroup" stepKey="openCategoryPage"/>
+        <actionGroup ref="AdminCategoriesOpenCategoryActionGroup" stepKey="openCategory">
+            <argument name="category" value="$$category$$"/>
+        </actionGroup>
+        <actionGroup ref="AdminOpenMediaGalleryFromCategoryImageUploaderActionGroup" stepKey="openMediaGalleryFromImageUploader"/>
+        <actionGroup ref="AdminEnhancedMediaGalleryUploadImageActionGroup" stepKey="uploadImage">
+            <argument name="image" value="ImageUpload"/>
+        </actionGroup>
+        <actionGroup ref="AdminEnhancedMediaGalleryViewImageDetails" stepKey="viewImageDetails"/>
+        <actionGroup ref="AdminEnhancedMediaGalleryImageDetailsEditActionGroup" stepKey="editImage"/>
+        <actionGroup ref="AdminEnhancedMediaGalleryImageDetailsSaveActionGroup" stepKey="saveImage">
+            <argument name="image" value="UpdatedImageDetails"/>
+        </actionGroup>
+        <actionGroup ref="AdminEnhancedMediaGalleryCloseViewDetailsActionGroup" stepKey="closeViewDetails"/>
+        <actionGroup ref="AdminMediaGalleryClickAddSelectedActionGroup" stepKey="clickAddSelectedCategoryImage"/>
+        <actionGroup ref="AdminSaveCategoryActionGroup" stepKey="saveCategory"/>
+        <actionGroup ref="AdminOpenMediaGalleryFromCategoryImageUploaderActionGroup" stepKey="openMediaGalleryFromImageUploaderToVerifyLink"/>
+        <actionGroup ref="AdminEnhancedMediaGalleryViewImageDetails" stepKey="openViewImageDetails"/>
+        <actionGroup ref="AdminEnhancedMediaGalleryClickEntityUsedInActionGroup" stepKey="clickUsedInCategories">
+            <argument name="entityName" value="Categories"/>
+        </actionGroup>
+        <actionGroup ref="AdminMediaGalleryAssertCategoryNameInCategoryGridActionGroup" stepKey="assertCategoryInGrid">
+            <argument name="categoryName" value="$$category.name$$"/>
+        </actionGroup>
+   </test>
+</tests>

--- a/MediaGalleryCatalogUi/view/adminhtml/layout/media_gallery_catalog_category_index.xml
+++ b/MediaGalleryCatalogUi/view/adminhtml/layout/media_gallery_catalog_category_index.xml
@@ -10,6 +10,11 @@
     <body>
         <referenceContainer htmlTag="div" htmlClass="media-gallery-category-container" name="content">
             <uiComponent name="media_gallery_category_listing"/>
+            <block class="Magento\Backend\Block\Template" template="Magento_Cms::url_filter_applier.phtml" name="category_list_url_filter_applier">
+                <arguments>
+                    <argument name="listing_namespace" xsi:type="string">media_gallery_category_listing</argument>
+                </arguments>
+            </block>
         </referenceContainer>
     </body>
 </page>

--- a/MediaGalleryUi/Test/Mftf/ActionGroup/AdminEnhancedMediaGalleryClickEntityUsedInActionGroup.xml
+++ b/MediaGalleryUi/Test/Mftf/ActionGroup/AdminEnhancedMediaGalleryClickEntityUsedInActionGroup.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="AdminEnhancedMediaGalleryClickEntityUsedInActionGroup">
+        <annotations>
+            <description>Clicks one Used In section entity</description>
+        </annotations>
+         <arguments>
+            <argument name="entityName" type="string"/>
+        </arguments>
+
+        <click selector="{{AdminEnhancedMediaGalleryViewDetailsSection.usedInLink(entityName)}}" stepKey="openContextMenu"/>
+        <waitForPageLoad stepKey="waitForPageLoad"/>
+    </actionGroup>
+</actionGroups>

--- a/MediaGalleryUi/Test/Mftf/Section/AdminEnhancedMediaGalleryViewDetailsSection.xml
+++ b/MediaGalleryUi/Test/Mftf/Section/AdminEnhancedMediaGalleryViewDetailsSection.xml
@@ -20,5 +20,6 @@
         <element name="confirmDelete" type="button" selector=".action-accept"/>
         <element name="addImage" type="button" selector=".add-image-action"/>
         <element name="cancel" type="button" selector="#image-details-action-cancel"/>
+        <element name="usedInLink" type="button" parameterized="true" selector="//div[@class='attribute']/span[contains(text(), 'Used In')]/following-sibling::div/a[contains(text(), '{{entityName}}')]"/>
     </section>
 </sections>

--- a/MediaGalleryUi/Test/Mftf/Test/AdminEnhancedMediaGalleryVerifyAssetFilterTest.xml
+++ b/MediaGalleryUi/Test/Mftf/Test/AdminEnhancedMediaGalleryVerifyAssetFilterTest.xml
@@ -42,7 +42,7 @@
             </actionGroup>
             <actionGroup ref="AdminEnhancedMediaGalleryClickDeleteImagesButtonActionGroup" stepKey="clikDeleteSelectedButton"/>
             <actionGroup ref="AdminEnhancedMediaGalleryConfirmDeleteImagesActionGroup" stepKey="deleteImage"/>
-            <deleteData createDataKey="category" stepKey="deleteCategory"/>            
+            <deleteData createDataKey="category" stepKey="deleteCategory"/>
             <magentoCLI command="config:set cms/wysiwyg/enabled disabled" stepKey="disableWYSIWYG"/>
         </after>
 
@@ -64,14 +64,14 @@
         <actionGroup ref="AdminMediaGalleryClickOkButtonTinyMce4ActionGroup" stepKey="clickOkButton"/>
         <actionGroup ref="AdminSaveCategoryActionGroup" stepKey="saveCategory"/>
         <actionGroup ref="AdminOpenCategoryGridPageActionGroup" stepKey="openCategoryGridPage"/>
-        
+
         <actionGroup ref="AdminEnhancedMediaGalleryCategoryGridExpandFilterActionGroup" stepKey="expandFilters"/>
         <actionGroup ref="AdminEnhancedMediaGallerySelectUsedInFilterActionGroup" stepKey="setUsedInFilter">
             <argument name="filterName" value="Asset"/>
             <argument name="optionName" value="{{ImageMetadata.title}}"/>
         </actionGroup>
         <actionGroup ref="AdminEnhancedMediaGalleryCategoryGridApplyFiltersActionGroup" stepKey="applyFilters"/>
-        
+
         <actionGroup ref="AdminMediaGalleryAssertCategoryNameInCategoryGridActionGroup" stepKey="assertCategoryInGrid">
             <argument name="categoryName" value="$$category.name$$"/>
         </actionGroup>

--- a/MediaGalleryUi/view/adminhtml/web/js/image/image-edit.js
+++ b/MediaGalleryUi/view/adminhtml/web/js/image/image-edit.js
@@ -36,7 +36,7 @@ define([
                     component: 'Magento_Ui/js/form/element/ui-select',
                     name: '${ $.name }_keywords',
                     template: 'ui/grid/filters/elements/ui-select',
-                    index: 'keywords'
+                    disableLabel: true
                 }
             ],
             exports: {
@@ -112,6 +112,7 @@ define([
          */
         getOptionForKeyword: function (keyword) {
             return {
+                'is_active': 1,
                 level: 1,
                 value: keyword,
                 label: keyword

--- a/MediaGalleryUi/view/adminhtml/web/js/image/image-edit.js
+++ b/MediaGalleryUi/view/adminhtml/web/js/image/image-edit.js
@@ -10,7 +10,8 @@ define([
     'uiLayout',
     'Magento_Ui/js/lib/key-codes',
     'Magento_MediaGalleryUi/js/action/getDetails',
-    'mage/validation'
+    'mage/validation',
+    'Magento_Ui/js/lib/view/utils/async'
 ], function ($, _, Component, layout, keyCodes, getDetails) {
     'use strict';
 
@@ -35,7 +36,7 @@ define([
                     component: 'Magento_Ui/js/form/element/ui-select',
                     name: '${ $.name }_keywords',
                     template: 'ui/grid/filters/elements/ui-select',
-                    disableLabel: true
+                    index: 'keywords'
                 }
             ],
             exports: {
@@ -54,7 +55,32 @@ define([
         initialize: function () {
             this._super().initView();
 
+            this.removeMouseOverEvent();
+
             return this;
+        },
+
+        /**
+         * Remove mousemove event from ui-select as it deprecated
+         */
+        removeMouseOverEvent: function () {
+
+            if (_.isUndefined(this.keywordsSelect())) {
+                setTimeout(function () {
+                    this.removeMouseOverEvent();
+                }.bind(this), 100);
+
+                return;
+            }
+
+            $.async(
+                this.keywordsSelect().rootListSelector,
+                this,
+                function () {
+                    $(this.keywordsSelect().rootListSelector).off('mousemove');
+                }.bind(this)
+            );
+
         },
 
         /**
@@ -87,7 +113,6 @@ define([
          */
         getOptionForKeyword: function (keyword) {
             return {
-                'is_active': 1,
                 level: 1,
                 value: keyword,
                 label: keyword

--- a/MediaGalleryUi/view/adminhtml/web/js/image/image-edit.js
+++ b/MediaGalleryUi/view/adminhtml/web/js/image/image-edit.js
@@ -75,7 +75,6 @@ define([
 
             $.async(
                 this.keywordsSelect().rootListSelector,
-                this,
                 function () {
                     $(this.keywordsSelect().rootListSelector).off('mousemove');
                 }.bind(this)


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/adobe-stock-integration#1693: MFTF tests coverage for Used In links
2. Fixes magento/adobe-stock-integration#1694: Used In Link: Asset title is not displayed in the applied filters section. Asset filter does not have the selected value
3. Fixes magento/adobe-stock-integration#1700: "Uncaught ReferenceError" appears in dev console if add a new tag and place the mouse cursor over it #1700

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...
