### PR TITLE
#1703: The deleted tags are not removed from Tags drop-down until the web page is refreshed

### DIFF
--- a/MediaGalleryUi/view/adminhtml/web/js/image/image-actions.js
+++ b/MediaGalleryUi/view/adminhtml/web/js/image/image-actions.js
@@ -86,7 +86,8 @@ define([
                 form = modalElement.find('#image-edit-details-form'),
                 imageId = this.imageModel().getSelected().id,
                 keywords = this.mediaGalleryEditDetails().selectedKeywords(),
-                imageDetails = this.mediaGalleryImageDetails();
+                imageDetails = this.mediaGalleryImageDetails(),
+                imageEditDetails = this.mediaGalleryEditDetails();
 
             if (form.validation('isValid')) {
                 saveDetails(
@@ -98,6 +99,7 @@ define([
                     this.closeModal();
                     this.imageModel().reloadGrid();
                     imageDetails.removeCached(imageId);
+                    imageEditDetails.removeCached(imageId, keywords);
 
                     if (imageDetails.isActive()) {
                         imageDetails.showImageDetailsById(imageId);

--- a/MediaGalleryUi/view/adminhtml/web/js/image/image-edit.js
+++ b/MediaGalleryUi/view/adminhtml/web/js/image/image-edit.js
@@ -223,6 +223,16 @@ define([
             }
 
             return true;
+        },
+
+        /**
+         * Remove cached image details in edit form
+         *
+         * @param {String} id
+         * @param {String} tags
+         */
+        removeCached: function (id, tags) {
+            this.images[id].tags = tags;
         }
     });
 });


### PR DESCRIPTION
### Need to verify (*)
- deleted tags have been removed after clicking save

### Description (*)
Replaced the outdated keywords after new image details have been saved

### Fixed Issues (if relevant)
1. Fixes magento/adobe-stock-integration#1703: The deleted tags are not removed from Tags drop-down until the web page is refreshed

### Manual testing scenarios (*)
1. Select the uploaded image by clicking on it
2. Click "three dots", select Edit
3. Add three new Tags, for example. Click Save
4. Click "three dots" again, and select Edit
5. Remove the previously added Tags by clicking on the cross (x) near them
6. Click Save
7. Click "three dots" again, and select Edit