### PR TITLE
#1684: Login failed error contains HTML tags

### DIFF
--- a/MediaGalleryUi/view/adminhtml/web/js/grid/messages.js
+++ b/MediaGalleryUi/view/adminhtml/web/js/grid/messages.js
@@ -4,15 +4,17 @@
  */
 
 define([
-    'uiElement'
-], function (Element) {
+    'uiElement',
+    'escaper'
+], function (Element, escaper) {
     'use strict';
 
     return Element.extend({
         defaults: {
             template: 'Magento_MediaGalleryUi/grid/messages',
             messageDelay: 5,
-            messages: []
+            messages: [],
+            allowedTags: ['div', 'span', 'b', 'strong', 'i', 'em', 'u', 'a']
         },
 
         /**
@@ -72,6 +74,16 @@ define([
                 clearTimeout(timerId);
                 this.clear();
             }.bind(this), Number(delay) * 1000);
+        },
+
+        /**
+         * Prepare the given message to be rendered as HTML
+         *
+         * @param {String} message
+         * @return {String}
+         */
+        prepareMessageForHtml: function (message) {
+            return escaper.escapeHtml(message, this.allowedTags);
         }
     });
 });

--- a/MediaGalleryUi/view/adminhtml/web/template/grid/messages.html
+++ b/MediaGalleryUi/view/adminhtml/web/template/grid/messages.html
@@ -8,7 +8,7 @@
     <div class="messages" outereach="messages">
         <div attr="class: 'message message-'+code">
             <div data-ui-id="messages-message-error">
-                <span text="message"></span>
+                <span data-bind="html: $parent.prepareMessageForHtml(message)"></span>
             </div>
         </div>
     </div>


### PR DESCRIPTION
### Need to verify (*)
- if error messages no longer contain HTML tags
- error messages are rendered as HTML

### Description (*)
- added a function to format and render error/success messages as HTML

### Fixed Issues (if relevant)
1. Fixes magento/adobe-stock-integration#1684: Login failed error contains HTML tags

### Manual testing scenarios (*)
1. Go to Content - Media Gallery, click Search Adobe Stock
2. Save an Unlicensed image Preview
3. (the image appeared in Media Gallery)
4. Select the previously saved Unlicensed image
5. Click "three dots" and select License
