### PR TITLE
ASI should depend on IMS metapackage

### DIFF
--- a/_metapackage/composer.json
+++ b/_metapackage/composer.json
@@ -10,6 +10,7 @@
         "magento/module-adobe-stock-image-api": "*",
         "magento/module-adobe-stock-client": "*",
         "magento/module-adobe-stock-client-api": "*",
-        "magento/module-adobe-stock-admin-ui": "*"
+        "magento/module-adobe-stock-admin-ui": "*",
+        "magento/adobe-ims": "*"
     }
 }


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes https://github.com/magento/adobe-stock-integration/issues/1735: ASI should depend on IMS metapackage

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Perform git installation
