### PR TITLE
[WIP] #1387: "Uncaught TypeError: Cannot read property 'complete' of undefined" appears in dev console if save Previewed image as a new View and open this View on another page

### DIFF
--- a/AdobeStockImageAdminUi/view/adminhtml/ui_component/adobe_stock_images_listing.xml
+++ b/AdobeStockImageAdminUi/view/adminhtml/ui_component/adobe_stock_images_listing.xml
@@ -215,6 +215,7 @@
                     <item name="mediaGalleryListingFilters" xsi:type="string">media_gallery_listing.media_gallery_listing.listing_top.listing_filters</item>
                     <item name="listingPaging" xsi:type="string">media_gallery_listing.media_gallery_listing.listing_top.listing_paging</item>
                     <item name="sortByComponentName" xsi:type="string">adobe_stock_images_listing.adobe_stock_images_listing.listing_top.sorting</item>
+                    <item name="bookmarksProvider" xsi:type="string">adobe_stock_images_listing.adobe_stock_images_listing.listing_top.bookmarks</item>
                 </item>
             </argument>
             <settings>

--- a/AdobeStockImageAdminUi/view/adminhtml/ui_component/standalone_adobe_stock_images_listing.xml
+++ b/AdobeStockImageAdminUi/view/adminhtml/ui_component/standalone_adobe_stock_images_listing.xml
@@ -215,6 +215,7 @@
                     <item name="mediaGalleryListingFilters" xsi:type="string">standalone_media_gallery_listing.standalone_media_gallery_listing.listing_top.listing_filters</item>
                     <item name="listingPaging" xsi:type="string">standalone_media_gallery_listing.standalone_media_gallery_listing.listing_top.listing_paging</item>
                     <item name="sortByComponentName" xsi:type="string">standalone_adobe_stock_images_listing.standalone_adobe_stock_images_listing.listing_top.sorting</item>
+                    <item name="bookmarksProvider" xsi:type="string">standalone_adobe_stock_images_listing.standalone_adobe_stock_images_listing.listing_top.bookmarks</item>
                 </item>
             </argument>
             <settings>

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/image-preview.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/image-preview.js
@@ -20,10 +20,12 @@ define([
             mediaGallerySelector: '.media-gallery-modal:has(#search_adobe_stock)',
             adobeStockModalSelector: '.adobe-search-images-modal',
             activeMediaGallerySelector: 'aside.modal-slide.adobe-stock-modal._show',
+            bookmarksProvider: 'componentType = bookmark, ns = ${ $.ns }',
             modules: {
                 keywords: '${ $.name }_keywords',
                 related: '${ $.name }_related',
-                actions: '${ $.name }_actions'
+                actions: '${ $.name }_actions',
+                bookmarks: '${ $.bookmarksProvider }'
             },
             viewConfig: [
                 {
@@ -50,8 +52,37 @@ define([
                 }
             ],
             listens: {
-                '${ $.sortByComponentName }:applied': 'hide'
+                '${ $.sortByComponentName }:applied': 'hide',
+                '${ $.bookmarksProvider }:activeIndex': 'onActiveIndexChange'
             }
+        },
+
+        /**
+         * Listener of the activeIndex property.
+         */
+        onActiveIndexChange: function () {
+            var subscription,
+                rowIndex,
+                record;
+
+            if (this.bookmarks().getActiveView().index === 'default') {
+                this.hide();
+
+                return;
+            }
+
+            subscription = this.masonry().rows.subscribe(function () {
+                subscription.dispose();
+                rowIndex = this.lastOpenedImage();
+
+                if (rowIndex === false) {
+                    return;
+                }
+
+                record = this.masonry().rows()[rowIndex];
+                this.hide();
+                this.show(record);
+            }.bind(this));
         },
 
         /**

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/image-preview.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/image-preview.js
@@ -53,7 +53,8 @@ define([
             ],
             listens: {
                 '${ $.sortByComponentName }:applied': 'hide',
-                '${ $.bookmarksProvider }:activeIndex': 'onActiveIndexChange'
+                '${ $.bookmarksProvider }:activeIndex': 'onActiveIndexChange',
+                '${ $.bookmarksProvider }:current': 'onStateChange'
             }
         },
 
@@ -61,15 +62,32 @@ define([
          * Listener of the activeIndex property.
          */
         onActiveIndexChange: function () {
-            var subscription,
-                rowIndex,
-                record;
-
             if (this.bookmarks().getActiveView().index === 'default') {
                 this.hide();
 
                 return;
             }
+            this.subscribeImagePreview();
+        },
+
+        /**
+         * Listener of the activeIndex property.
+         * To open image preview with the correct image when switching to a saved view
+         * from another page without reverting back to default view.
+         */
+        onStateChange: function () {
+            if (this.bookmarks().getActiveView().index !== 'default') {
+                this.subscribeImagePreview();
+            }
+        },
+
+        /**
+         * Subscribe image preview
+         */
+        subscribeImagePreview: function () {
+            var subscription,
+                rowIndex,
+                record;
 
             subscription = this.masonry().rows.subscribe(function () {
                 subscription.dispose();


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR will introduce the modifications on image-preview.js to fix the issue of a wrong image showing in image preview section when switching views.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/adobe-stock-integration https://github.com/magento/adobe-stock-integration/issues/1387: "Uncaught TypeError: Cannot read property 'complete' of undefined" appears in dev console if save Previewed image as a new View and open this View on another page
2. ...

### Related PR (*)
1. https://github.com/magento/magento2/pull/29639
### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->

1. Go to Content - Media Gallery
2. Click Search Adobe Stock
3. Go to the first page from the grid, and select any image to open its Preview
4. Click on Default View (bookmarks view)
5. Click Save View As...,
6. Click Save all Changes ➡️
7. Switch to the Default View
8. Go to the second page in Adobe Stock grid
9. Switch to the previously created New View
