### PR TITLE
Update is_downloaded for displayed record that was applied from related or series tab

### DIFF
--- a/AdobeStockImageAdminUi/Controller/Adminhtml/Asset/GetMediaGalleryAsset.php
+++ b/AdobeStockImageAdminUi/Controller/Adminhtml/Asset/GetMediaGalleryAsset.php
@@ -13,6 +13,7 @@ use Magento\Framework\App\Action\HttpPostActionInterface;
 use Magento\Framework\Controller\ResultFactory;
 use Psr\Log\LoggerInterface;
 use Magento\AdobeStockImageAdminUi\Model\Asset\GetMediaGalleryAssetByAdobeId;
+use Magento\Framework\Exception\NoSuchEntityException;
 
 /**
  * Backend controller for retrieving asset information by adobeId
@@ -61,7 +62,6 @@ class GetMediaGalleryAsset extends Action implements HttpPostActionInterface
     {
         $resultJson = $this->resultFactory->create(ResultFactory::TYPE_JSON);
         try {
-
             $params = $this->getRequest()->getParams();
             $adobeId = isset($params['adobe_id']) ? $params['adobe_id'] : null;
 
@@ -78,6 +78,9 @@ class GetMediaGalleryAsset extends Action implements HttpPostActionInterface
 
             $responseCode = self::HTTP_OK;
             $responseContent = $this->getAssetByAdobeId->execute((int) $adobeId);
+        } catch (NoSuchEntityException $execption) {
+            $responseCode = self::HTTP_OK;
+            $responseContent = [];
         } catch (\Exception $exception) {
             $responseCode = self::HTTP_INTERNAL_ERROR;
             $this->logger->critical($exception);

--- a/AdobeStockImageAdminUi/Model/Asset/GetMediaGalleryAssetByAdobeId.php
+++ b/AdobeStockImageAdminUi/Model/Asset/GetMediaGalleryAssetByAdobeId.php
@@ -58,7 +58,13 @@ class GetMediaGalleryAssetByAdobeId
      */
     public function execute(int $adobeId): array
     {
-        $mediaGalleryId = $this->getAssetByAdobeId->execute([$adobeId])[$adobeId]->getMediaGalleryId();
+        $mediaGalleryAsset = $this->getAssetByAdobeId->execute([$adobeId]);
+
+        if (!isset($mediaGalleryAsset[$adobeId])) {
+            return [];
+        }
+
+        $mediaGalleryId = $mediaGalleryAsset[$adobeId]->getMediaGalleryId();
         $asset = $this->getMediaGalleryAssetsById->execute([$mediaGalleryId]);
 
         return $this->objectProcessor->buildOutputDataArray(current($asset), AssetInterface::class);

--- a/AdobeStockImageAdminUi/Model/Asset/GetMediaGalleryAssetByAdobeId.php
+++ b/AdobeStockImageAdminUi/Model/Asset/GetMediaGalleryAssetByAdobeId.php
@@ -12,6 +12,7 @@ use Magento\AdobeStockAssetApi\Model\Asset\Command\LoadByIdsInterface;
 use Magento\MediaGalleryApi\Api\GetAssetsByIdsInterface;
 use Magento\MediaGalleryApi\Api\Data\AssetInterface;
 use Magento\Framework\Reflection\DataObjectProcessor;
+use Magento\Framework\Exception\NoSuchEntityException;
 
 /**
  * Return media gallery asset by adobe id
@@ -55,13 +56,19 @@ class GetMediaGalleryAssetByAdobeId
      *
      * @param int $adobeId
      * @return array
+     * @throws NoSuchEntityException
      */
     public function execute(int $adobeId): array
     {
         $mediaGalleryAsset = $this->getAssetByAdobeId->execute([$adobeId]);
 
         if (!isset($mediaGalleryAsset[$adobeId])) {
-            return [];
+            throw new NoSuchEntityException(
+                __(
+                    'Media Gallery asset with adobe id %id does not exist.',
+                    ['id' => $adobeId]
+                )
+            );
         }
 
         $mediaGalleryId = $mediaGalleryAsset[$adobeId]->getMediaGalleryId();

--- a/AdobeStockImageAdminUi/view/adminhtml/web/css/source/_module.less
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/css/source/_module.less
@@ -45,7 +45,7 @@
 
             &-preview {
                 position: fixed;
-                z-index: 299;
+                z-index: 289;
 
                 .container {
                     padding-top: 0;

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/image-preview.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/image-preview.js
@@ -61,28 +61,10 @@ define([
          */
         initialize: function () {
             this._super().initView();
-            $(window).on('fileDeleted.enhancedMediaGallery', function () {
-                this.reloadAdobeGrid();
-            }.bind(this));
-            $(window).on('folderDeleted.enhancedMediaGallery', function () {
-                this.reloadAdobeGrid();
-            }.bind(this));
+            $(window).on('fileDeleted.enhancedMediaGallery', this.reloadAdobeGrid.bind(this));
+            $(window).on('folderDeleted.enhancedMediaGallery', this.reloadAdobeGrid.bind(this));
 
             return this;
-        },
-
-        /**
-         * Update is_downloaded filed for displayed record
-         */
-        updateIsDownloadedField: function () {
-            var record = this.displayedRecord();
-
-            this.actions().getAssetDetails(this.displayedRecord().id).then(function (assetDetails) {
-                if (assetDetails.length === 0) {
-                    record['is_downloaded'] = 0;
-                    this.displayedRecord(record);
-                }
-            }.bind(this));
         },
 
         /**
@@ -207,7 +189,6 @@ define([
          * Reload Adobe grid after deleting image
          */
         reloadAdobeGrid: function () {
-            this.updateIsDownloadedField();
             this.actions().source().reload({
                 refresh: true
             });

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/image-preview.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/image-preview.js
@@ -62,11 +62,9 @@ define([
         initialize: function () {
             this._super().initView();
             $(window).on('fileDeleted.enhancedMediaGallery', function () {
-                this.updateIsDownloadedField();
                 this.reloadAdobeGrid();
             }.bind(this));
             $(window).on('folderDeleted.enhancedMediaGallery', function () {
-                this.updateIsDownloadedField();
                 this.reloadAdobeGrid();
             }.bind(this));
 
@@ -209,6 +207,7 @@ define([
          * Reload Adobe grid after deleting image
          */
         reloadAdobeGrid: function () {
+            this.updateIsDownloadedField();
             this.actions().source().reload({
                 refresh: true
             });

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/image-preview.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/image-preview.js
@@ -63,11 +63,18 @@ define([
             this._super().initView();
             $(window).on('fileDeleted.enhancedMediaGallery', function () {
                 this.reloadAdobeGrid();
-                this.hide();
             }.bind(this));
             $(window).on('folderDeleted.enhancedMediaGallery', function () {
+                this.actions().getAssetDetails(this.displayedRecord().id).then(function (assetDetails) {
+                    var record = this.displayedRecord();
+
+                    if (assetDetails.length === 0) {
+                        record['is_downloaded'] = 0;
+                        this.displayedRecord(record);
+                    }
+                }.bind(this));
+
                 this.reloadAdobeGrid();
-                this.hide();
             }.bind(this));
 
             return this;

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/image-preview.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/image-preview.js
@@ -61,8 +61,14 @@ define([
          */
         initialize: function () {
             this._super().initView();
-            $(window).on('fileDeleted.enhancedMediaGallery', this.reloadAdobeGrid.bind(this));
-            $(window).on('folderDeleted.enhancedMediaGallery', this.reloadAdobeGrid.bind(this));
+            $(window).on('fileDeleted.enhancedMediaGallery', function () {
+                this.reloadAdobeGrid();
+                this.hide();
+            }.bind(this));
+            $(window).on('folderDeleted.enhancedMediaGallery', function () {
+                this.reloadAdobeGrid();
+                this.hide();
+            }.bind(this));
 
             return this;
         },

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/image-preview.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/image-preview.js
@@ -62,22 +62,29 @@ define([
         initialize: function () {
             this._super().initView();
             $(window).on('fileDeleted.enhancedMediaGallery', function () {
+                this.updateIsDownloadedField();
                 this.reloadAdobeGrid();
             }.bind(this));
             $(window).on('folderDeleted.enhancedMediaGallery', function () {
-                this.actions().getAssetDetails(this.displayedRecord().id).then(function (assetDetails) {
-                    var record = this.displayedRecord();
-
-                    if (assetDetails.length === 0) {
-                        record['is_downloaded'] = 0;
-                        this.displayedRecord(record);
-                    }
-                }.bind(this));
-
+                this.updateIsDownloadedField();
                 this.reloadAdobeGrid();
             }.bind(this));
 
             return this;
+        },
+
+        /**
+         * Update is_downloaded filed for displayed record
+         */
+        updateIsDownloadedField: function () {
+            var record = this.displayedRecord();
+
+            this.actions().getAssetDetails(this.displayedRecord().id).then(function (assetDetails) {
+                if (assetDetails.length === 0) {
+                    record['is_downloaded'] = 0;
+                    this.displayedRecord(record);
+                }
+            }.bind(this));
         },
 
         /**

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/actions.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/actions.js
@@ -170,6 +170,9 @@ define([
 
             this.mediaGalleryListingFilters().clear();
             this.getAssetDetails(imageId).then(function (assetDetails) {
+                if (assetDetails.length === 0) {
+                    return;
+                }
                 this.mediaGallerySearchInput().apply(assetDetails.title);
                 path = assetDetails.path;
                 path = path.substring(0, path.lastIndexOf('/'));


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

There is a bug with action buttons on preview, if we expand any preview then click on any related tab image
we applied displayed Record from related images and when we delete the folder or image, buttons cannot be updated because the image doesn't exists in source provider even if we successfully reloaded the grid there is no this image as a result we cannot update the button because status of this image not updated. 
 
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/adobe-stock-integration#1766: Error is shown on the Media Gallery page after deleting folder with licensed image #1766
2. Fixes magento/adobe-stock-integration#1779: Long view name overlapped by image on Adobe Stock

### Manual testing scenarios (*)
1. Create directory 123
2. Open Adobe Stock grid
3. Expand any image
4. Click on any image in related tab
5. Save preview
6. Open adobe stock verify that open in media gallery button present
7. Close adobe stock
8. Delee folder with this image
9. Open adobe stock

Button is changed fron Open In Media Gallery To Save Preview