### PR TITLE
#1809: Long image name doesn't fit into License "Adobe Stock Images...?" message

### DIFF
--- a/AdobeStockImageAdminUi/view/adminhtml/web/css/source/_module.less
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/css/source/_module.less
@@ -317,6 +317,10 @@
                 .prompt-message {
                     font-weight: normal;
                     margin-bottom: 15px;
+
+                    p {
+                        word-break: break-all;
+                    }
                 }
 
                 .admin__field-wide {


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR will fix the issue of the long image name that doesn't fit into License "Adobe Stock Images...?" message.
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/adobe-stock-integration https://github.com/magento/adobe-stock-integration/issues/1809: Long image name doesn't fit into License "Adobe Stock Images...?" message
2. ...

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
_Precondition:_ Unlicensed image Preview saved into Media Gallery

1. Go to Content - Media Gallery, select the previously used image
2. Click "three dots" and select Edit
3. Type the maximum number of symbols into the Title field (128 symbols) without spaces. Click Save
4. Select the previously edited image, and click "three dots"
5. Click License
6. Image name must fit into the message modal. 

