### PR TITLE
#1802: The "three dots" context menu is not closed after unsuccessful licensing from Media Gallery 

### DIFF
--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/mediaGallery/grid/columns/image/licenseActions.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/mediaGallery/grid/columns/image/licenseActions.js
@@ -98,6 +98,7 @@ define([
                     this.imageModel().addMessage('success', $.mage.__('The image has been licensed.'));
                 }.bind(this)).fail(function (error) {
                     if (error) {
+                        $('ul.action-menu').removeClass('_active');
                         this.imageModel().addMessage('error', error);
                     }
                 }.bind(this));


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR will introduce the modification that will hide the context menu after unsuccessful licensing from Media Gallery.
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/adobe-stock-integration https://github.com/magento/adobe-stock-integration/issues/1802: The "three dots" context menu is not closed after unsuccessful licensing from Media Gallery 
2. ...

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
**Preconditions**

1. Install Magento with Adobe Stock Integration
2. Configured integration in Stores -> Configuration -> Advanced-> System -> Adobe Stock Integration fieldset
3. Old Media Gallery disabled in Stores -> Configuration -> Advanced-> System -> Media Gallery -> Enable Old Media Gallery -> No
4. Provide API Key (Client ID). Do not provide Client Secret.
5. Unlicensed image preview saved to Media Gallery being at the bottom of images

**Testing steps**

1. Go to Content - Media Gallery, click Search Adobe Stock
2. Select the previously saved Unlicensed image
3. Click "three dots" and select License
4. Do not click anywhere. 
5. The context menu is closed after _Login failed_... message appears