### PR TITLE
#1801: User is not scrolled up to the "Login failed. Please check if the Secret Key..." error, and can miss the message

### DIFF
--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/actions.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/actions.js
@@ -39,7 +39,6 @@ define([
             loginProvider: 'name = adobe-login, ns = adobe-login',
             mediaGallerySelector: '.media-gallery-modal:has(#search_adobe_stock)',
             adobeStockModalSelector: '.adobe-search-images-modal',
-            errorMessageSelector: '.modal-slide.magento._show ul.messages',
             downloadImagePreviewUrl: 'adobe_stock/preview/download',
             licenseAndDownloadUrl: 'adobe_stock/license/license',
             saveLicensedAndDownloadUrl: 'adobe_stock/license/saveLicensed',

--- a/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/actions.js
+++ b/AdobeStockImageAdminUi/view/adminhtml/web/js/components/grid/column/preview/actions.js
@@ -39,6 +39,7 @@ define([
             loginProvider: 'name = adobe-login, ns = adobe-login',
             mediaGallerySelector: '.media-gallery-modal:has(#search_adobe_stock)',
             adobeStockModalSelector: '.adobe-search-images-modal',
+            errorMessageSelector: '.modal-slide.magento._show ul.messages',
             downloadImagePreviewUrl: 'adobe_stock/preview/download',
             licenseAndDownloadUrl: 'adobe_stock/license/license',
             saveLicensedAndDownloadUrl: 'adobe_stock/license/saveLicensed',
@@ -438,6 +439,7 @@ define([
          */
         licenseProcess: function (id, title, path, contentType, isDownloaded) {
             var deferred = $.Deferred();
+            var errorMessageSelector = '.modal-slide.magento._show ul.messages';
 
             this.login().login()
                 .then(function () {
@@ -493,6 +495,11 @@ define([
                     });
                 }.bind(this)).fail(function (error) {
                 deferred.reject(error);
+                $(errorMessageSelector).get(0).scrollIntoView({
+                    behavior: 'smooth',
+                    block: 'center',
+                    inline: 'nearest'
+                });
             });
 
             return deferred.promise();


### PR DESCRIPTION
### Description (*)
Added a modification to scroll to the top of the modal to show the error message after unsuccessful licensing from Media Gallery

### Fixed Issues (if relevant)
1. Fixes magento/adobe-stock-integration#1801: User is not scrolled up to the "Login failed. Please check if the Secret Key..." error, and can miss the message

### Manual testing scenarios (*)
**Preconditions**
1. Install Magento with Adobe Stock Integration
2. Configured integration in Stores -> Configuration -> Advanced-> System -> Adobe Stock Integration fieldset
3. Old Media Gallery enabled in Stores -> Configuration -> Advanced-> System -> Media Gallery -> Enable Old Media Gallery - No
4. Provided _API Key (Client ID)_ . **Not** provided _Client Secret_
5. Multiple images saved to Media Gallery, (four rows of images in my case)
6. Unlicensed image preview saved to Media Gallery being at the bottom of images

**Testing Steps**
1. Go to **Content - Media Gallery**, click **Search Adobe Stock**
2. Scroll to the bottom of the page
3. Select the previously saved Unlicensed image
4. Click "three dots" and select **License**