### PR TITLE
[2.1.0-master] Unskipped AdminMediaGalleryPageSavedPreviewAddSelectedTest

### DIFF
--- a/AdobeStockImageAdminUi/Test/Mftf/Test/AdminMediaGalleryPageSavedPreviewAddSelectedTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/AdminMediaGalleryPageSavedPreviewAddSelectedTest.xml
@@ -9,9 +9,6 @@
 <tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
     <test name="AdminMediaGalleryPageSavedPreviewAddSelectedTest">
         <annotations>
-            <skip>
-                <issueId value="https://github.com/magento/adobe-stock-integration/issues/1817"/>
-            </skip>
             <features value="AdobeStockImagePanel"/>
             <stories value="[Story #4] User selects saved image preview in Page"/>
             <useCaseId value="https://github.com/magento/adobe-stock-integration/issues/1688"/>


### PR DESCRIPTION
### Description (*)

Unskipped AdminMediaGalleryPageSavedPreviewAddSelectedTest

### Fixed Issues (if relevant)
Fixes https://github.com/magento/adobe-stock-integration/issues/1817

### Manual testing scenarios (*)

No manual testing required