### PR TITLE
AdminAdobeStockInsertRenditionImageFromGalleryFileSizeTest

### DIFF
--- a/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockInsertRenditionImageFromGalleryFileSizeTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockInsertRenditionImageFromGalleryFileSizeTest.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+    <test name="AdminAdobeStockInsertRenditionImageFromGalleryFileSizeTest">
+        <annotations>
+            <features value="AdminAdobeStockInsertRenditionImageFromGalleryFileSizeTest"/>
+            <useCaseId value="https://github.com/magento/adobe-stock-integration/issues/1806"/>
+            <title value="Admin user should see correct image file size after rendition inserted from gallery"/>
+            <testCaseId value="https://studio.cucumber.io/projects/131313/test-plan/folders/1507933/scenarios/5200023"/>
+            <stories value="User inserts image rendition to the content from media gallery"/>
+            <description value="Admin user should see correct image file size after rendition inserted from gallery"/>
+            <severity value="AVERAGE"/>
+            <group value="adobe_stock_media_gallery"/>
+        </annotations>
+        <before>
+            <createData entity="SimpleSubCategory" stepKey="category"/>
+            <actionGroup ref="AdminLoginActionGroup" stepKey="loginAsAdmin"/>
+            <!-- Prepare configuration -->
+            <magentoCLI command="config:set system/media_gallery_renditions/width 50" stepKey="prepareWidth"/>
+            <magentoCLI command="config:set system/media_gallery_renditions/height 50" stepKey="prepareHeight"/>
+        </before>
+        <after>
+            <!-- Restore configuration -->
+            <magentoCLI command="config:set system/media_gallery_renditions/width 1000" stepKey="restoreWidth"/>
+            <magentoCLI command="config:set system/media_gallery_renditions/height 1000" stepKey="restoreHeight"/>
+            <!-- Delete uploaded image -->
+            <actionGroup ref="AdminOpenMediaGalleryFromCategoryImageUploaderActionGroup" stepKey="openMediaGalleryFromWysiwyg"/>
+            <actionGroup ref="AdminEnhancedMediaGalleryImageDeleteActionGroup" stepKey="removeSavedPreview"/>
+            <actionGroup ref="AdminAdobeStockMediaGalleryClearFiltersActionGroup" stepKey="clearFilters"/>
+            <!-- Delete category -->
+            <deleteData createDataKey="category" stepKey="deleteCategory"/>
+        </after>
+
+        <!-- Open category page -->
+        <actionGroup ref="AdminOpenCategoryGridPageActionGroup" stepKey="openCategoryPage"/>
+        <actionGroup ref="AdminEditCategoryInGridPageActionGroup" stepKey="editCategoryItem">
+            <argument name="categoryName" value="$category.name$"/>
+        </actionGroup>
+
+        <!-- Add image to category from gallery -->
+        <actionGroup ref="AdminOpenMediaGalleryFromCategoryImageUploaderActionGroup" stepKey="openMediaGallery"/>
+        <actionGroup ref="AdminAdobeStockOpenFromEnhancedMediaGalleryActionGroup" stepKey="openAdobeStockPanel"/>
+        <actionGroup ref="AdminSearchImagesOnModalActionGroup" stepKey="searchForUnlicensedImage">
+            <argument name="query" value="{{AdobeStockUnlicensedImage.id}}"/>
+        </actionGroup>
+        <actionGroup ref="AdminAdobeStockExpandImagePreviewActionGroup" stepKey="expandImagePreview"/>
+        <actionGroup ref="AdminAdobeStockSavePreviewActionGroup" stepKey="saveImagePreview"/>
+        <actionGroup ref="AdminSaveAdobeStockImagePreviewActionGroup" stepKey="confirmSaveImagePreview"/>
+        <actionGroup ref="AdminMediaGalleryClickAddSelectedActionGroup" stepKey="addSelectedSavedPreview"/>
+
+        <!-- Assert added image size -->
+        <actionGroup ref="AdminAssertImageUploadFileSizeThanActionGroup" stepKey="assertSize">
+            <argument name="fileSize" value="1 KB"/>
+        </actionGroup>
+    </test>
+</tests>

--- a/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockInsertRenditionImageFromGalleryFileSizeTest.xml
+++ b/AdobeStockImageAdminUi/Test/Mftf/Test/AdminAdobeStockInsertRenditionImageFromGalleryFileSizeTest.xml
@@ -23,13 +23,14 @@
             <createData entity="SimpleSubCategory" stepKey="category"/>
             <actionGroup ref="AdminLoginActionGroup" stepKey="loginAsAdmin"/>
             <!-- Prepare configuration -->
-            <magentoCLI command="config:set system/media_gallery_renditions/width 50" stepKey="prepareWidth"/>
-            <magentoCLI command="config:set system/media_gallery_renditions/height 50" stepKey="prepareHeight"/>
+            <actionGroup ref="AdminRenditionsSetImageSizeActionGroup" stepKey="prepareRenditionsConfig">
+                <argument name="height" value="50"/>
+                <argument name="width" value="50"/>
+            </actionGroup>
         </before>
         <after>
             <!-- Restore configuration -->
-            <magentoCLI command="config:set system/media_gallery_renditions/width 1000" stepKey="restoreWidth"/>
-            <magentoCLI command="config:set system/media_gallery_renditions/height 1000" stepKey="restoreHeight"/>
+            <actionGroup ref="AdminRenditionsSetImageSizeActionGroup" stepKey="restoreRenditionsConfig"/>
             <!-- Delete uploaded image -->
             <actionGroup ref="AdminOpenMediaGalleryFromCategoryImageUploaderActionGroup" stepKey="openMediaGalleryFromWysiwyg"/>
             <actionGroup ref="AdminEnhancedMediaGalleryImageDeleteActionGroup" stepKey="removeSavedPreview"/>


### PR DESCRIPTION
### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
### Related Pull Requests
https://github.com/magento/magento2/pull/30074/files
<!-- related pull request placeholder -->

Cover issue by MFTF test by adding image from adobe stock inventory
### Fixed Issues (if relevant)
https://github.com/magento/adobe-stock-integration/issues/1806
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
#### Preconditions:
Set rendition image size 50x50
#### Steps
1. Open Category page
2. Open Media Gallery
3. Save image preview  from Adobe Stock
4. Add saved preview to category
5. Assert correct file (1) size is shown
