### PR TITLE
[WIP] #1770: Preview is not expanded on applying bookmark if the same rowIndex preview was expanded

### DIFF
--- a/AdobeStockImageAdminUi/view/adminhtml/ui_component/adobe_stock_images_listing.xml
+++ b/AdobeStockImageAdminUi/view/adminhtml/ui_component/adobe_stock_images_listing.xml
@@ -215,6 +215,7 @@
                     <item name="mediaGalleryListingFilters" xsi:type="string">media_gallery_listing.media_gallery_listing.listing_top.listing_filters</item>
                     <item name="listingPaging" xsi:type="string">media_gallery_listing.media_gallery_listing.listing_top.listing_paging</item>
                     <item name="sortByComponentName" xsi:type="string">adobe_stock_images_listing.adobe_stock_images_listing.listing_top.sorting</item>
+                    <item name="bookmarksProvider" xsi:type="string">adobe_stock_images_listing.adobe_stock_images_listing.listing_top.bookmarks</item>
                 </item>
             </argument>
             <settings>

--- a/AdobeStockImageAdminUi/view/adminhtml/ui_component/adobe_stock_images_listing.xml
+++ b/AdobeStockImageAdminUi/view/adminhtml/ui_component/adobe_stock_images_listing.xml
@@ -215,7 +215,6 @@
                     <item name="mediaGalleryListingFilters" xsi:type="string">media_gallery_listing.media_gallery_listing.listing_top.listing_filters</item>
                     <item name="listingPaging" xsi:type="string">media_gallery_listing.media_gallery_listing.listing_top.listing_paging</item>
                     <item name="sortByComponentName" xsi:type="string">adobe_stock_images_listing.adobe_stock_images_listing.listing_top.sorting</item>
-                    <item name="bookmarksProvider" xsi:type="string">adobe_stock_images_listing.adobe_stock_images_listing.listing_top.bookmarks</item>
                 </item>
             </argument>
             <settings>

--- a/AdobeStockImageAdminUi/view/adminhtml/ui_component/standalone_adobe_stock_images_listing.xml
+++ b/AdobeStockImageAdminUi/view/adminhtml/ui_component/standalone_adobe_stock_images_listing.xml
@@ -215,7 +215,6 @@
                     <item name="mediaGalleryListingFilters" xsi:type="string">standalone_media_gallery_listing.standalone_media_gallery_listing.listing_top.listing_filters</item>
                     <item name="listingPaging" xsi:type="string">standalone_media_gallery_listing.standalone_media_gallery_listing.listing_top.listing_paging</item>
                     <item name="sortByComponentName" xsi:type="string">standalone_adobe_stock_images_listing.standalone_adobe_stock_images_listing.listing_top.sorting</item>
-                    <item name="bookmarksProvider" xsi:type="string">standalone_adobe_stock_images_listing.standalone_adobe_stock_images_listing.listing_top.bookmarks</item>
                 </item>
             </argument>
             <settings>

--- a/AdobeStockImageAdminUi/view/adminhtml/ui_component/standalone_adobe_stock_images_listing.xml
+++ b/AdobeStockImageAdminUi/view/adminhtml/ui_component/standalone_adobe_stock_images_listing.xml
@@ -215,6 +215,7 @@
                     <item name="mediaGalleryListingFilters" xsi:type="string">standalone_media_gallery_listing.standalone_media_gallery_listing.listing_top.listing_filters</item>
                     <item name="listingPaging" xsi:type="string">standalone_media_gallery_listing.standalone_media_gallery_listing.listing_top.listing_paging</item>
                     <item name="sortByComponentName" xsi:type="string">standalone_adobe_stock_images_listing.standalone_adobe_stock_images_listing.listing_top.sorting</item>
+                    <item name="bookmarksProvider" xsi:type="string">standalone_adobe_stock_images_listing.standalone_adobe_stock_images_listing.listing_top.bookmarks</item>
                 </item>
             </argument>
             <settings>


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR will introduce the adding of bookmarksProvider configuration to `standalone_adobe_stock_images_listing` and `adobe_stock_images_listing`.
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/adobe-stock-integration https://github.com/magento/adobe-stock-integration/issues/1770: Preview is not expanded on applying bookmark if the same rowIndex preview was expanded 
2. ...

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...
