### PR TITLE
Fix error when saving image from stock that does not have Category

### DIFF
--- a/AdobeStockAsset/Model/Asset.php
+++ b/AdobeStockAsset/Model/Asset.php
@@ -56,9 +56,11 @@ class Asset extends AbstractExtensibleModel implements AssetInterface
     /**
      * @inheritdoc
      */
-    public function getCategoryId(): int
+    public function getCategoryId(): ?int
     {
-        return (int) $this->getData(self::CATEGORY_ID);
+        $categoryId = $this->getData(self::CATEGORY_ID);
+
+        return $categoryId !== null ? (int) $categoryId : null;
     }
 
     /**

--- a/AdobeStockAsset/Model/SaveAsset.php
+++ b/AdobeStockAsset/Model/SaveAsset.php
@@ -79,12 +79,13 @@ class SaveAsset implements SaveAssetInterface
         $data = $this->objectProcessor->buildOutputDataArray($asset, AssetInterface::class);
 
         $category = $asset->getCategory();
-        if ($category->getId() !== null) {
-            $category = $this->categoryRepository->save($category);
+        if ($category !== null) {
+            if ($category->getId() !== null) {
+                $category = $this->categoryRepository->save($category);
+            }
+            $data[self::CATEGORY_ID] = $category->getId();
+            $data[self::CATEGORY] = $category;
         }
-        $data[self::CATEGORY_ID] = $category->getId();
-        $data[self::CATEGORY] = $category;
-
         $creator = $asset->getCreator();
         if ($creator !== null) {
             $creator = $this->creatorRepository->save($creator);

--- a/AdobeStockAsset/Model/SaveAsset.php
+++ b/AdobeStockAsset/Model/SaveAsset.php
@@ -80,10 +80,11 @@ class SaveAsset implements SaveAssetInterface
 
         $category = $asset->getCategory();
         if ($category !== null) {
-            if ($category->getId() !== null) {
+            $categoryId = $category->getId();
+            if ($categoryId !== null) {
                 $category = $this->categoryRepository->save($category);
             }
-            $data[self::CATEGORY_ID] = $category->getId();
+            $data[self::CATEGORY_ID] = $categoryId;
             $data[self::CATEGORY] = $category;
         }
         $creator = $asset->getCreator();

--- a/AdobeStockAsset/Model/SaveAsset.php
+++ b/AdobeStockAsset/Model/SaveAsset.php
@@ -79,7 +79,7 @@ class SaveAsset implements SaveAssetInterface
         $data = $this->objectProcessor->buildOutputDataArray($asset, AssetInterface::class);
 
         $category = $asset->getCategory();
-        if ($category !== null) {
+        if ($category->getId() !== null) {
             $category = $this->categoryRepository->save($category);
         }
         $data[self::CATEGORY_ID] = $category->getId();

--- a/AdobeStockAsset/Test/Integration/Model/SaveAssetTest.php
+++ b/AdobeStockAsset/Test/Integration/Model/SaveAssetTest.php
@@ -13,6 +13,7 @@ use Magento\AdobeStockAssetApi\Api\CategoryRepositoryInterface;
 use Magento\AdobeStockAssetApi\Api\CreatorRepositoryInterface;
 use Magento\AdobeStockAssetApi\Api\Data\AssetInterface;
 use Magento\AdobeStockAssetApi\Api\Data\AssetInterfaceFactory;
+use Magento\AdobeStockAssetApi\Api\Data\CategoryInterfaceFactory;
 use Magento\AdobeStockAssetApi\Api\SaveAssetInterface;
 use Magento\MediaGalleryApi\Api\GetAssetsByPathsInterface;
 use Magento\MediaGalleryApi\Api\SaveAssetsInterface;
@@ -36,6 +37,29 @@ class SaveAssetTest extends TestCase
     private $saveAsset;
 
     /**
+     * @return array
+     */
+    public function getAssetData(): array
+    {
+        return [
+            'asset_save' => [
+                'data' => [
+                    'media_gallery_path' => ['some/path.jpg'],
+                    'category_id' => 42,
+                    'creator_id' => 42,
+                ]
+            ],
+            'without_category' => [
+                'data' => [
+                    'media_gallery_path' => ['some/path.jpg'],
+                    'category_id' => null,
+                    'creator_id' => 42,
+                ]
+            ]
+        ];
+    }
+
+    /**
      * @inheritdoc
      */
     protected function setUp(): void
@@ -46,13 +70,16 @@ class SaveAssetTest extends TestCase
 
     /**
      * Test save an Adobe Stock asset.
+     * @param array $caseData
+     *
+     * @dataProvider getAssetData
      * @magentoDataFixture ../../../../app/code/Magento/AdobeStockAsset/Test/_files/media_asset.php
      * @magentoDataFixture ../../../../app/code/Magento/AdobeStockAsset/Test/_files/category.php
      * @magentoDataFixture ../../../../app/code/Magento/AdobeStockAsset/Test/_files/creator.php
      */
-    public function testExecute(): void
+    public function testExecute(array $caseData): void
     {
-        $asset = $this->prepareAsset();
+        $asset = $this->prepareAsset($caseData);
         $this->saveAsset->execute($asset);
         $expectedAsset = $this->assetRepository->getById($asset->getId());
 
@@ -66,35 +93,24 @@ class SaveAssetTest extends TestCase
 
     /**
      * Prepare an Adobe Stock asset test object.
+     *
+     * @param array $caseData
+     * @return AssetInterface
+     * @throws \Magento\Framework\Exception\LocalizedException
      */
-    public function prepareAsset(): AssetInterface
+    public function prepareAsset(array $caseData): AssetInterface
     {
-        /** @var GetAssetsByPathsInterface $mediaGetByPath */
-        $mediaGetByPath = Bootstrap::getObjectManager()->get(GetAssetsByPathsInterface::class);
-        $mediaAssetId = $mediaGetByPath->execute(['some/path.jpg'])[0]->getId();
-
-        /** @var CategoryRepositoryInterface $categoryRepository */
-        $categoryRepository = Bootstrap::getObjectManager()->get(CategoryRepositoryInterface::class);
-        $category= $categoryRepository->getById(42);
-
-        /** @var CreatorRepositoryInterface $creatorRepository */
-        $creatorRepository = Bootstrap::getObjectManager()->get(CreatorRepositoryInterface::class);
-        $creator = $creatorRepository->getById(42);
-
+        $assetData['data'] = [
+            'id' => 1,
+            'is_licensed' => 1,
+        ];
+        $assetData['data']['media_gallery_id'] = $this->getMediaAssetId($caseData['media_gallery_path']);
+        $assetData['data']['category'] = $this->getCategory($caseData['category_id']);
+        $assetData['data']['creator'] = $this->getCreator($caseData['creator_id']);
         /** @var AssetInterfaceFactory $assetFactory */
         $assetFactory = Bootstrap::getObjectManager()->get(AssetInterfaceFactory::class);
         /** @var AssetInterface $asset */
-        $asset = $assetFactory->create(
-            [
-                'data' => [
-                    'id' => 1,
-                    'is_licensed' => 1,
-                    'media_gallery_id' => $mediaAssetId,
-                    'category' => $category,
-                    'creator' => $creator
-                ]
-            ]
-        );
+        $asset = $assetFactory->create($assetData);
 
         return $asset;
     }
@@ -108,5 +124,48 @@ class SaveAssetTest extends TestCase
     private function cleanUpEntries(AssetInterface $asset): void
     {
         $this->assetRepository->deleteById($asset->getId());
+    }
+
+    /**
+     * @param $paths
+     * @return int|null
+     * @throws \Magento\Framework\Exception\LocalizedException
+     */
+    protected function getMediaAssetId($paths): int
+    {
+        /** @var GetAssetsByPathsInterface $mediaGetByPath */
+        $mediaGetByPath = Bootstrap::getObjectManager()->get(GetAssetsByPathsInterface::class);
+        $mediaAssetId = $mediaGetByPath->execute($paths)[0]->getId();
+
+        return $mediaAssetId;
+    }
+
+    /**
+     * @param int|null $categoryId
+     * @return \Magento\AdobeStockAssetApi\Api\Data\CategoryInterface|null
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
+     */
+    protected function getCategory(?int $categoryId): ?\Magento\AdobeStockAssetApi\Api\Data\CategoryInterface
+    {
+        /** @var CategoryRepositoryInterface $categoryRepository */
+        $categoryRepository = Bootstrap::getObjectManager()->get(CategoryRepositoryInterface::class);
+        /** @var CategoryInterfaceFactory $categoryRepository */
+        $categoryFactory = Bootstrap::getObjectManager()->get(CategoryInterfaceFactory::class);
+
+        return $categoryId !== null ? $categoryRepository->getById($categoryId) : $categoryFactory->create();
+    }
+
+    /**
+     * @param int $creatorId
+     * @return \Magento\AdobeStockAssetApi\Api\Data\CreatorInterface
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
+     */
+    protected function getCreator(int $creatorId): \Magento\AdobeStockAssetApi\Api\Data\CreatorInterface
+    {
+        /** @var CreatorRepositoryInterface $creatorRepository */
+        $creatorRepository = Bootstrap::getObjectManager()->get(CreatorRepositoryInterface::class);
+        $creator = $creatorRepository->getById($creatorId);
+
+        return $creator;
     }
 }

--- a/AdobeStockAsset/Test/Integration/Model/SaveAssetTest.php
+++ b/AdobeStockAsset/Test/Integration/Model/SaveAssetTest.php
@@ -70,6 +70,7 @@ class SaveAssetTest extends TestCase
 
     /**
      * Test save an Adobe Stock asset.
+     *
      * @param array $caseData
      *
      * @dataProvider getAssetData

--- a/AdobeStockImageAdminUi/Plugin/AddAdobeStockImageDetailsPlugin.php
+++ b/AdobeStockImageAdminUi/Plugin/AddAdobeStockImageDetailsPlugin.php
@@ -128,7 +128,8 @@ class AddAdobeStockImageDetailsPlugin
      */
     private function loadAssetsInfo(AssetInterface $asset): array
     {
-        $assetCategory = $this->categoryRepository->getById($asset->getCategoryId());
+        $hasCategory = $asset->getCategoryId() !== null;
+        $assetCategory = $hasCategory ? $this->categoryRepository->getById($asset->getCategoryId()) : null;
         $assetCreator = $this->creatorRepository->getById($asset->getCreatorId());
 
         return [
@@ -142,7 +143,7 @@ class AddAdobeStockImageDetailsPlugin
             ],
             [
                 'title' => __('Category'),
-                'value' => $assetCategory->getName(),
+                'value' => $assetCategory !== null ? $assetCategory->getName() : __('None'),
             ],
             [
                 'title' => __('Author'),


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Fixes error that is thrown on saving asset with no category (category_id=0)
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/adobe-stock-integration#1846: Error when saving image from stock that does not have Category
2. If there was no category - empty value was saved in database table adobe_stock_category

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->

1. Open Adobe Stock Panel from Media Gallery
2. Search for "Distant deer in a misty forest"
3. In the search results find an image with category "None"
4. Save Preview
5. Check saved image details (Adobe Stock section should be displayed correctly, pay attention to Category)

#### Expected result (*)
Image is saved successfully, no errors appear
#### Actual result (*)
Image is saved but an error appears "An error occurred during adobe stock asset save."