### PR TITLE
fix DownloadTest.php local failure

### DIFF
--- a/AdobeStockImageAdminUi/Test/Unit/Controller/Adminhtml/Preview/DownloadTest.php
+++ b/AdobeStockImageAdminUi/Test/Unit/Controller/Adminhtml/Preview/DownloadTest.php
@@ -115,7 +115,7 @@ class DownloadTest extends TestCase
         $this->context->expects($this->once())
             ->method('getResultFactory')
             ->willReturn($this->resultFactory);
-        $this->saveImage->expects($this->once())->method('execute')->willReturn(null);
+        $this->saveImage->expects($this->once())->method('execute');
         $this->jsonObject = $this->createMock(Json::class);
         $this->resultFactory->expects($this->once())->method('create')->with('json')->willReturn($this->jsonObject);
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

local run AdobeStockAdminUi/Test/Unit/Controller/Adminhtml/Preview/DownloadTest.php #testExecuteWithException #testExecute causes warnings

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
No issues created

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
No manual testing required
