### PR TITLE
Changed restrictions for php to "~7.4.0||~8.1.0" into `composer.json` files

### DIFF
--- a/AdobeStockAdminUi/composer.json
+++ b/AdobeStockAdminUi/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-adobe-stock-admin-ui",
     "description": "Magento module responsible for the admin panel UI implementation",
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/framework": "*",
         "magento/module-adobe-ims-api": "*",
         "magento/module-adobe-stock-client-api": "*",

--- a/AdobeStockAsset/composer.json
+++ b/AdobeStockAsset/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-adobe-stock-asset",
     "description": "Magento module responsible for the Adobe Stock assets handling implementation on Magento side",
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/framework": "*",
         "magento/module-adobe-stock-asset-api": "*",
         "magento/module-adobe-stock-client-api": "*",

--- a/AdobeStockAssetApi/composer.json
+++ b/AdobeStockAssetApi/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-adobe-stock-asset-api",
     "description": "Magento module responsible for Adobe Stock assets handling on Magento side",
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/framework": "*"
     },
     "type": "magento2-module",

--- a/AdobeStockClient/composer.json
+++ b/AdobeStockClient/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-adobe-stock-client",
     "description": "Magento module responsible for interaction with Adobe Stock API implementation",
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/framework": "*",
         "magento/module-adobe-ims-api": "*",
         "magento/module-adobe-stock-client-api": "*",

--- a/AdobeStockClientApi/composer.json
+++ b/AdobeStockClientApi/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-adobe-stock-client-api",
     "description": "Magento module responsible for interaction with Adobe Stock API",
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/framework": "*"
     },
     "type": "magento2-module",

--- a/AdobeStockImage/composer.json
+++ b/AdobeStockImage/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-adobe-stock-image",
     "description": "Magento module responsible for the images handling implementation",
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/framework": "*",
         "magento/module-adobe-stock-client-api": "*",
         "magento/module-adobe-stock-asset-api": "*",

--- a/AdobeStockImageAdminUi/composer.json
+++ b/AdobeStockImageAdminUi/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-adobe-stock-image-admin-ui",
     "description": "Magento module responsible for the admin panel images UI implementation",
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/framework": "*",
         "magento/module-adobe-ims": "*",
         "magento/module-adobe-ims-api": "*",

--- a/AdobeStockImageApi/composer.json
+++ b/AdobeStockImageApi/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-adobe-stock-image-api",
     "description": "Magento module responsible for the images handling",
     "require": {
-        "php": "~7.4.0||~8.0.0||~8.1.0",
+        "php": "~7.4.0||~8.1.0",
         "magento/framework": "*"
     },
     "type": "magento2-module",


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This pull request (PR) provides fixes for `composer.json` files

1. remove restriction `"~8.0.0"` for `"php"` requirements

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/partners-magento2b2b#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#34852

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
