### PR TITLE
fix composer dependencies for version 2.1.1

### DIFF
--- a/_metapackage/composer.json
+++ b/_metapackage/composer.json
@@ -3,14 +3,14 @@
     "description": "Adobe Stock integration",
     "type": "metapackage",
     "require": {
-        "magento/module-adobe-stock-asset": "*",
-        "magento/module-adobe-stock-asset-api": "*",
-        "magento/module-adobe-stock-image": "*",
-        "magento/module-adobe-stock-image-admin-ui": "*",
-        "magento/module-adobe-stock-image-api": "*",
-        "magento/module-adobe-stock-client": "*",
-        "magento/module-adobe-stock-client-api": "*",
-        "magento/module-adobe-stock-admin-ui": "*",
+        "magento/module-adobe-stock-asset": "1.3.0",
+        "magento/module-adobe-stock-asset-api": "2.0.0",
+        "magento/module-adobe-stock-image": "1.3.0",
+        "magento/module-adobe-stock-image-admin-ui": "1.3.0",
+        "magento/module-adobe-stock-image-api": "1.3.0",
+        "magento/module-adobe-stock-client": "1.3.0",
+        "magento/module-adobe-stock-client-api": "2.1.0",
+        "magento/module-adobe-stock-admin-ui": "1.3.0",
         "magento/adobe-ims": "*"
     }
 }


### PR DESCRIPTION
### Description (*)

The dependencies in `2.1.1-develop` branch as well as in the tag `2.1.1` do not correspond with those on `repo.magento.com`:

```
$ composer show magento/adobe-stock-integration
name     : magento/adobe-stock-integration
descrip. : Adobe Stock integration
keywords : 
versions : * 2.1.1
type     : metapackage
homepage : 
source   : []  
dist     : [zip] https://repo.magento.com/archives/magento/adobe-stock-integration/magento-adobe-stock-integration-2.1.1.0.zip 
path     : /tmp/magento
names    : magento/adobe-stock-integration

requires
magento/adobe-ims *
magento/module-adobe-stock-admin-ui 1.3.0
magento/module-adobe-stock-asset 1.3.0
magento/module-adobe-stock-asset-api 2.0.0
magento/module-adobe-stock-client 1.3.0
magento/module-adobe-stock-client-api 2.1.0
magento/module-adobe-stock-image 1.3.0
magento/module-adobe-stock-image-admin-ui 1.3.0
magento/module-adobe-stock-image-api 1.3.0
```

If you will consider this PR, please also update the 2.1.1 tag after merging.


### Manual testing scenarios (*)

1. Install Magento 2.4.2-p2
2. Run command `composer show magento/adobe-stock-integration`.
3. Observe that magento/adobe-stock-integration:2.1.1 but the requirements do not match this repository.